### PR TITLE
golang: fix options bug

### DIFF
--- a/golang/producer.go
+++ b/golang/producer.go
@@ -114,7 +114,8 @@ func (p *defaultProducer) wrapSendMessageRequest(pMsgs []*PublishingMessage) (*v
 }
 
 var NewProducer = func(config *Config, opts ...ProducerOption) (Producer, error) {
-	po := &defaultProducerOptions
+	copyOpt := defaultProducerOptions
+	po := &copyOpt
 	for _, opt := range opts {
 		opt.apply(po)
 	}

--- a/golang/simple_consumer.go
+++ b/golang/simple_consumer.go
@@ -316,7 +316,8 @@ func (sc *defaultSimpleConsumer) wrapHeartbeatRequest() *v2.HeartbeatRequest {
 }
 
 var NewSimpleConsumer = func(config *Config, opts ...SimpleConsumerOption) (SimpleConsumer, error) {
-	scOpts := &defaultSimpleConsumerOptions
+	copyOpt := defaultSimpleConsumerOptions
+	scOpts := &copyOpt
 	for _, opt := range opts {
 		opt.apply(scOpts)
 	}


### PR DESCRIPTION
The original option is not isolated, so the producer and consumer instances can only be initialized in sequence on the main thread