### PR TITLE
golang: add error handling in simple consumer

### DIFF
--- a/golang/simple_consumer.go
+++ b/golang/simple_consumer.go
@@ -146,11 +146,6 @@ func (sc *defaultSimpleConsumer) Subscribe(topic string, filterExpression *Filte
 }
 
 func (sc *defaultSimpleConsumer) Unsubscribe(topic string) error {
-	_, err := sc.cli.getMessageQueues(context.Background(), topic)
-	if err != nil {
-		sc.cli.log.Errorf("unsubscribe error=%v with topic %s for simpleConsumer", err, topic)
-		return err
-	}
 	sc.subscriptionExpressionsLock.Lock()
 	defer sc.subscriptionExpressionsLock.Unlock()
 

--- a/golang/simple_consumer.go
+++ b/golang/simple_consumer.go
@@ -133,7 +133,11 @@ func (sc *defaultSimpleConsumer) ChangeInvisibleDurationAsync(messageView *Messa
 }
 
 func (sc *defaultSimpleConsumer) Subscribe(topic string, filterExpression *FilterExpression) error {
-	sc.cli.getMessageQueues(context.Background(), topic)
+	_, err := sc.cli.getMessageQueues(context.Background(), topic)
+	if err != nil {
+		sc.cli.log.Errorf("subscribe error with topic %s for simpleConsumer", topic)
+		return err
+	}
 	sc.subscriptionExpressionsLock.Lock()
 	defer sc.subscriptionExpressionsLock.Unlock()
 
@@ -142,7 +146,11 @@ func (sc *defaultSimpleConsumer) Subscribe(topic string, filterExpression *Filte
 }
 
 func (sc *defaultSimpleConsumer) Unsubscribe(topic string) error {
-	sc.cli.getMessageQueues(context.Background(), topic)
+	_, err := sc.cli.getMessageQueues(context.Background(), topic)
+	if err != nil {
+		sc.cli.log.Errorf("unsubscribe error with topic %s for simpleConsumer", topic)
+		return err
+	}
 	sc.subscriptionExpressionsLock.Lock()
 	defer sc.subscriptionExpressionsLock.Unlock()
 

--- a/golang/simple_consumer.go
+++ b/golang/simple_consumer.go
@@ -135,7 +135,7 @@ func (sc *defaultSimpleConsumer) ChangeInvisibleDurationAsync(messageView *Messa
 func (sc *defaultSimpleConsumer) Subscribe(topic string, filterExpression *FilterExpression) error {
 	_, err := sc.cli.getMessageQueues(context.Background(), topic)
 	if err != nil {
-		sc.cli.log.Errorf("subscribe error with topic %s for simpleConsumer", topic)
+		sc.cli.log.Errorf("subscribe error=%v with topic %s for simpleConsumer", err, topic)
 		return err
 	}
 	sc.subscriptionExpressionsLock.Lock()
@@ -148,7 +148,7 @@ func (sc *defaultSimpleConsumer) Subscribe(topic string, filterExpression *Filte
 func (sc *defaultSimpleConsumer) Unsubscribe(topic string) error {
 	_, err := sc.cli.getMessageQueues(context.Background(), topic)
 	if err != nil {
-		sc.cli.log.Errorf("unsubscribe error with topic %s for simpleConsumer", topic)
+		sc.cli.log.Errorf("unsubscribe error=%v with topic %s for simpleConsumer", err, topic)
 		return err
 	}
 	sc.subscriptionExpressionsLock.Lock()


### PR DESCRIPTION
Add error handling in simple consumer in golang for Subscribe and Unsubscribe when getting available message queue from server