### PR TITLE
Add API of PullConsumer

### DIFF
--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/PullConsumer.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/PullConsumer.java
@@ -57,6 +57,8 @@ public interface PullConsumer extends Closeable {
     /**
      * Fetch messages from assigned message queues specified by {@link #assign(Collection)}.
      *
+     * <p>The messages polled from remote are across the message queue.
+     *
      * @param timeout the maximum time to block.
      * @return list of fetched messages.
      */

--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/PullConsumer.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/PullConsumer.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.apis.consumer;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.apache.rocketmq.client.apis.ClientException;
+import org.apache.rocketmq.client.apis.message.MessageQueue;
+import org.apache.rocketmq.client.apis.message.MessageView;
+
+public interface PullConsumer extends Closeable {
+    /**
+     * Get the consumer group of the consumer.
+     */
+    String getConsumerGroup();
+
+    /**
+     * @param topic    the topic that needs to be monitored.
+     * @param listener the callback to detect the message queue changes.
+     */
+    void registerMessageQueueChangeListenerByTopic(String topic, TopicMessageQueueChangeListener listener);
+
+    /**
+     * Fetch message queues of the topic.
+     */
+    Collection<MessageQueue> fetchMessageQueues(String topic) throws ClientException;
+
+    /**
+     * Manually assign a list of message queues to this consumer.
+     *
+     * <p>This interface does not allow for incremental assignment and will replace the previous assignment (if
+     * previous assignment existed).
+     *
+     * @param messageQueues the list of message queues that are to be assigned to this consumer.
+     */
+    void assign(Collection<MessageQueue> messageQueues);
+
+    /**
+     * Fetch messages from assigned message queues specified by {@link #assign(Collection)}.
+     *
+     * @param timeout the maximum time to block.
+     * @return list of fetched messages.
+     */
+    List<MessageView> poll(Duration timeout);
+
+    /**
+     * Overrides the fetch offsets that the consumer will use on the next poll. If this method is invoked for the same
+     * message queue more than once, the latest offset will be used on the next {@link #poll(Duration)}.
+     *
+     * @param messageQueue the message queue to override the fetch offset.
+     * @param offset       message offset.
+     */
+    void seek(MessageQueue messageQueue, long offset);
+
+    /**
+     * Suspending message pulling from the message queues.
+     *
+     * @param messageQueues message queues that need to be suspended.
+     */
+    void pause(Collection<MessageQueue> messageQueues);
+
+    /**
+     * Resuming message pulling from the message queues.
+     *
+     * @param messageQueues message queues that need to be resumed.
+     */
+    void resume(Collection<MessageQueue> messageQueues);
+
+    /**
+     * Look up the offsets for the given message queue by timestamp. The returned offset for each message queue is the
+     * earliest offset whose timestamp is greater than or equal to the given timestamp in the corresponding message
+     * queue.
+     *
+     * @param messageQueue message queue that needs to be looked up.
+     * @param timestamp    the timestamp for which to search.
+     * @return the offset of the message queue, or {@link Optional#empty()} if there is no message.
+     */
+    Optional<Long> offsetForTimestamp(MessageQueue messageQueue, Long timestamp);
+
+    /**
+     * Get the latest committed offset for the given message queue.
+     *
+     * @return the latest committed offset, or {@link Optional#empty()} if there was no prior commit.
+     */
+    Optional<Long> committed(MessageQueue messageQueue);
+
+    /**
+     * Commit offset manually.
+     */
+    void commit() throws ClientException;
+
+    /**
+     * Overrides the fetch offsets with the beginning offset that the consumer will use on the next poll. If this
+     * method is invoked for the same message queue more than once, the latest offset will be used on the next
+     * {@link #poll(Duration)}.
+     *
+     * @param messageQueue the message queue to seek.
+     */
+    void seekToBegin(MessageQueue messageQueue) throws ClientException;
+
+    /**
+     * Overrides the fetch offsets with the end offset that the consumer will use on the next poll. If this method is
+     * invoked for the same message queue more than once, the latest offset will be used on the next
+     * {@link #poll(Duration)}.
+     *
+     * @param messageQueue the message queue to seek.
+     */
+    void seekToEnd(MessageQueue messageQueue) throws ClientException;
+
+    /**
+     * Close the pull consumer and release all related resources.
+     */
+    @Override
+    void close() throws IOException;
+}

--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/PullConsumerBuilder.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/PullConsumerBuilder.java
@@ -17,21 +17,18 @@
 
 package org.apache.rocketmq.client.apis.consumer;
 
-import java.util.Map;
+import java.time.Duration;
 import org.apache.rocketmq.client.apis.ClientConfiguration;
 import org.apache.rocketmq.client.apis.ClientException;
 
-/**
- * Builder to config and start {@link PushConsumer}.
- */
-public interface PushConsumerBuilder {
+public interface PullConsumerBuilder {
     /**
      * Set the client configuration for the consumer.
      *
      * @param clientConfiguration client's configuration.
      * @return the consumer builder instance.
      */
-    PushConsumerBuilder setClientConfiguration(ClientConfiguration clientConfiguration);
+    PullConsumerBuilder setClientConfiguration(ClientConfiguration clientConfiguration);
 
     /**
      * Set the load balancing group for the consumer.
@@ -39,23 +36,22 @@ public interface PushConsumerBuilder {
      * @param consumerGroup consumer load balancing group.
      * @return the consumer builder instance.
      */
-    PushConsumerBuilder setConsumerGroup(String consumerGroup);
+    PullConsumerBuilder setConsumerGroup(String consumerGroup);
 
     /**
-     * Add {@link FilterExpression} for consumer.
+     * Automate the consumer's offset commit.
      *
-     * @param subscriptionExpressions subscriptions to add.
      * @return the consumer builder instance.
      */
-    PushConsumerBuilder setSubscriptionExpressions(Map<String, FilterExpression> subscriptionExpressions);
+    PullConsumerBuilder enableAutoCommit(boolean enable);
 
     /**
-     * Register message listener, all messages meet the subscription expression would across listener here.
+     * Set the consumer's offset commit interval if auto commit is enabled.
      *
-     * @param listener message listener.
+     * @param duration offset commit interval
      * @return the consumer builder instance.
      */
-    PushConsumerBuilder setMessageListener(MessageListener listener);
+    PullConsumerBuilder setAutoCommitInterval(Duration duration);
 
     /**
      * Set the maximum number of messages cached locally.
@@ -63,7 +59,7 @@ public interface PushConsumerBuilder {
      * @param count message count.
      * @return the consumer builder instance.
      */
-    PushConsumerBuilder setMaxCacheMessageCount(int count);
+    PullConsumerBuilder setMaxCacheMessageCountEachQueue(int count);
 
     /**
      * Set the maximum bytes of messages cached locally.
@@ -71,24 +67,16 @@ public interface PushConsumerBuilder {
      * @param bytes message size.
      * @return the consumer builder instance.
      */
-    PushConsumerBuilder setMaxCacheMessageSizeInBytes(int bytes);
+    PullConsumerBuilder setMaxCacheMessageSizeInBytesEachQueue(int bytes);
 
     /**
-     * Set the consumption thread count in parallel.
+     * Finalize the build of {@link PullConsumer} and start.
      *
-     * @param count thread count.
-     * @return the consumer builder instance.
+     * <p>This method will block until the pull consumer starts successfully.
+     *
+     * <p>Especially, if this method is invoked more than once, different pull consumer will be created and started.
+     *
+     * @return the pull consumer instance.
      */
-    PushConsumerBuilder setConsumptionThreadCount(int count);
-
-    /**
-     * Finalize the build of {@link PushConsumer} and start.
-     *
-     * <p>This method will block until the push consumer starts successfully.
-     *
-     * <p>Especially, if this method is invoked more than once, different push consumer will be created and started.
-     *
-     * @return the push consumer instance.
-     */
-    PushConsumer build() throws ClientException;
+    PullConsumer build() throws ClientException;
 }

--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/PushConsumer.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/PushConsumer.java
@@ -93,7 +93,7 @@ public interface PushConsumer extends Closeable {
      *
      * <p>Nothing occurs if the specified topic does not exist in subscription expressions of the push consumer.
      *
-     * @param topic the topic to remove the subscription.
+     * @param topic the topic to remove from the subscription.
      * @return push consumer instance.
      */
     PushConsumer unsubscribe(String topic) throws ClientException;

--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/TopicMessageQueueChangeListener.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/TopicMessageQueueChangeListener.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.apis.consumer;
+
+import java.util.Set;
+import org.apache.rocketmq.client.apis.message.MessageQueue;
+
+public interface TopicMessageQueueChangeListener {
+    /**
+     * This method will be invoked in the condition of queue numbers changed, These scenarios occur when the topic is
+     * expanded or shrunk.
+     *
+     * @param topic         the topic to listen.
+     * @param messageQueues latest message queues of the topic.
+     */
+    void onChanged(String topic, Set<MessageQueue> messageQueues);
+}

--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/message/MessageQueue.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/message/MessageQueue.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.apis.message;
+
+public interface MessageQueue {
+    /**
+     * Topic of the current message queue.
+     */
+    String getTopic();
+
+    /**
+     * Get the identifier of the current message queue.
+     */
+    String getId();
+}


### PR DESCRIPTION
Similar to the `LitePullConsumer` provided in RocketMQ 4.0, RocketMQ 5.0 will also provide a brand-new API that can achieve the same functionality, providing higher controllability and flexibility to meet more diverse requirements for message processing.

Fixes #341 