### PR TITLE
golang: fix ErrRpcStatus.GetCode() stack overflow

### DIFF
--- a/golang/error.go
+++ b/golang/error.go
@@ -30,7 +30,7 @@ type ErrRpcStatus struct {
 }
 
 func (err *ErrRpcStatus) GetCode() int32 {
-	return err.GetCode()
+	return err.Code
 }
 
 func (err *ErrRpcStatus) GetMessage() string {


### PR DESCRIPTION
#349 

fix ErrRpcStatus.GetCode() stack overflow