### PR TITLE
Fix send message error when MessageType unspecified.

### DIFF
--- a/java/client/src/main/java/org/apache/rocketmq/client/java/message/MessageType.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/message/MessageType.java
@@ -21,7 +21,8 @@ public enum MessageType {
     NORMAL,
     FIFO,
     DELAY,
-    TRANSACTION;
+    TRANSACTION,
+    MESSAGE_TYPE_UNSPECIFIED;
 
     public static MessageType fromProtobuf(apache.rocketmq.v2.MessageType messageType) {
         switch (messageType) {
@@ -33,9 +34,8 @@ public enum MessageType {
                 return MessageType.DELAY;
             case TRANSACTION:
                 return MessageType.TRANSACTION;
-            case MESSAGE_TYPE_UNSPECIFIED:
             default:
-                throw new IllegalArgumentException("Message type is not specified");
+                return MessageType.MESSAGE_TYPE_UNSPECIFIED;
         }
     }
 

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/route/MessageQueueImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/route/MessageQueueImpl.java
@@ -40,7 +40,10 @@ public class MessageQueueImpl {
         this.acceptMessageTypes = new ArrayList<>();
         final List<apache.rocketmq.v2.MessageType> types = messageQueue.getAcceptMessageTypesList();
         for (apache.rocketmq.v2.MessageType type : types) {
-            acceptMessageTypes.add(MessageType.fromProtobuf(type));
+            MessageType messageType = MessageType.fromProtobuf(type);
+            if (messageType != MessageType.MESSAGE_TYPE_UNSPECIFIED) {
+                acceptMessageTypes.add(messageType);
+            }
         }
         this.broker = new Broker(messageQueue.getBroker());
     }


### PR DESCRIPTION
Even if the proxy config set  `enableTopicMessageTypeCheck` false, sending a message always throw an error.