### PR TITLE
try to recover on server TelemetryCommand transmission error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ rust/src/pb/*.rs
 composer.phar
 composer.lock
 vendor/
+
+# Go
+*.tests

--- a/golang/.gitignore
+++ b/golang/.gitignore
@@ -1,0 +1,2 @@
+# Go test binaries
+*.test

--- a/golang/.gitignore
+++ b/golang/.gitignore
@@ -1,2 +1,0 @@
-# Go test binaries
-*.test

--- a/golang/client.go
+++ b/golang/client.go
@@ -107,32 +107,33 @@ func (cs *defaultClientSession) startUp() {
 
 			response, err := observer.Recv()
 			if err != nil {
-				// we are recovering because we encountered a transmission error
+				// we are recovering
 				if !cs.recovering {
-					cs.recovering = true
 					cs.cli.log.Info("Encountered error while receiving TelemetryCommand, trying to recover")
 					// we wait five seconds to give time for the transmission error to be resolved externally before we attempt to read the message again.
 					time.Sleep(5 * time.Second)
+					cs.recovering = true
 				} else {
 					// we are recovering but we failed to read the message again, resetting observer
 					cs.cli.log.Info("Failed to recover, err=%w")
 					cs.release()
+					cs.recovering = false
 				}
 				continue
 			}
 			// at this point we received the message and must confirm that the sender is healthy
 			if cs.recovering {
-				// we don't know which server sent the request so we must check that each of the servers is on line.
+				// we don't know which server sent the request so we must check that each of the servers is healthy.
 				// we assume that the list of the servers hasn't changed, so the server that sent the message is still present.
 				hearbeat_response, err := cs.cli.clientManager.HeartBeat(context.TODO(), cs.endpoints, &v2.HeartbeatRequest{}, 10*time.Second)
 				if err == nil && hearbeat_response.Status.Code == v2.Code_OK {
 					cs.cli.log.Info("Managed to recover, executing message")
 					cs._execute_server_telemetry_command(response)
 				} else {
-					// we managed to read the message after a transmission error but one of the servers is unhealthy
 					cs.cli.log.Errorf("Failed to recover, Some of the servers are unhealthy, Heartbeat err=%w", err)
 					cs.release()
 				}
+				cs.recovering = false
 			}
 			cs._execute_server_telemetry_command(response)
 		}

--- a/golang/client_manager.go
+++ b/golang/client_manager.go
@@ -137,7 +137,6 @@ func (cm *defaultClientManager) deleteRpcClient(rpcClient RpcClient) {
 }
 
 func (cm *defaultClientManager) clearIdleRpcClients() {
-	sugarBaseLogger.Info("clientManager start clearIdleRpcClients")
 	cm.rpcClientTableLock.Lock()
 	defer cm.rpcClientTableLock.Unlock()
 	for target, rpcClient := range cm.rpcClientTable {

--- a/golang/client_manager_test.go
+++ b/golang/client_manager_test.go
@@ -38,7 +38,9 @@ var MOCK_CLIENT *MockClient
 var MOCK_RPC_CLIENT *MockRpcClient
 
 type MOCK_MessagingService_TelemetryClient struct {
-	trace []string
+	trace            []string
+	recv_error_count int            `default:"0"`
+	cli              *defaultClient `default:"nil"`
 }
 
 // CloseSend implements v2.MessagingService_TelemetryClient
@@ -80,7 +82,18 @@ func (mt *MOCK_MessagingService_TelemetryClient) Trailer() metadata.MD {
 // Recv implements v2.MessagingService_TelemetryClient
 func (mt *MOCK_MessagingService_TelemetryClient) Recv() (*v2.TelemetryCommand, error) {
 	mt.trace = append(mt.trace, "recv")
-	return nil, io.EOF
+	if mt.recv_error_count >= 1 {
+		mt.recv_error_count -= 1
+		return nil, io.EOF
+	} else {
+		if mt.cli == nil {
+			return nil, io.EOF
+		} else {
+			time.Sleep(time.Second)
+			command := mt.cli.getSettingsCommand()
+			return command, nil
+		}
+	}
 }
 
 // Send implements v2.MessagingService_TelemetryClient

--- a/golang/client_test.go
+++ b/golang/client_test.go
@@ -18,14 +18,70 @@
 package golang
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/apache/rocketmq-clients/golang/credentials"
+	v2 "github.com/apache/rocketmq-clients/golang/protocol/v2"
 	gomock "github.com/golang/mock/gomock"
 	"github.com/prashantv/gostub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
+
+func BuildCLient(t *testing.T) *defaultClient {
+	stubs := gostub.Stub(&defaultClientManagerOptions, clientManagerOptions{
+		RPC_CLIENT_MAX_IDLE_DURATION: time.Second,
+
+		RPC_CLIENT_IDLE_CHECK_INITIAL_DELAY: time.Hour,
+		RPC_CLIENT_IDLE_CHECK_PERIOD:        time.Hour,
+
+		HEART_BEAT_INITIAL_DELAY: time.Hour,
+		HEART_BEAT_PERIOD:        time.Hour,
+
+		LOG_STATS_INITIAL_DELAY: time.Hour,
+		LOG_STATS_PERIOD:        time.Hour,
+
+		SYNC_SETTINGS_DELAY:  time.Hour,
+		SYNC_SETTINGS_PERIOD: time.Hour,
+	})
+
+	stubs2 := gostub.Stub(&NewRpcClient, func(target string, opts ...RpcClientOption) (RpcClient, error) {
+		if target == fakeAddress {
+			return MOCK_RPC_CLIENT, nil
+		}
+		return nil, fmt.Errorf("invalid target=%s", target)
+	})
+
+	defer func() {
+		stubs.Reset()
+		stubs2.Reset()
+	}()
+
+	MOCK_RPC_CLIENT.EXPECT().Telemetry(gomock.Any()).Return(&MOCK_MessagingService_TelemetryClient{
+		trace: make([]string, 0),
+	}, nil)
+
+	endpoints := fmt.Sprintf("%s:%d", fakeHost, fakePort)
+	cli, err := NewClientConcrete(&Config{
+		Endpoint:    endpoints,
+		Credentials: &credentials.SessionCredentials{},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	sugarBaseLogger.Info(cli)
+	err = cli.startUp()
+	if err != nil {
+		t.Error(err)
+	}
+
+	return cli
+}
 
 func TestCLINewClient(t *testing.T) {
 	stubs := gostub.Stub(&defaultClientManagerOptions, clientManagerOptions{
@@ -73,4 +129,87 @@ func TestCLINewClient(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+func Test_acquire_observer_uninitialized(t *testing.T) {
+	// given
+	cli := BuildCLient(t)
+	default_cli_session, err := cli.getDefaultClientSession(fakeAddress)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// when
+	observer, acquired_observer := default_cli_session._acquire_observer()
+
+	// then
+	if acquired_observer {
+		t.Error("Acquired observer even though it is uninitialized")
+	}
+	if observer != nil {
+		t.Error("Observer should be nil")
+	}
+}
+
+func Test_acquire_observer_initialized(t *testing.T) {
+	// given
+	cli := BuildCLient(t)
+	default_cli_session, err := cli.getDefaultClientSession(fakeAddress)
+	if err != nil {
+		t.Error(err)
+	}
+	default_cli_session.publish(context.TODO(), &v2.TelemetryCommand{})
+
+	// when
+	observer, acquired_observer := default_cli_session._acquire_observer()
+
+	// then
+	if !acquired_observer {
+		t.Error("Failed to acquire observer even though it is uninitialized")
+	}
+	if observer == nil {
+		t.Error("Observer should be not nil")
+	}
+}
+
+func Test_execute_server_telemetry_command_fail(t *testing.T) {
+	// given
+	cli := BuildCLient(t)
+	default_cli_session, err := cli.getDefaultClientSession(fakeAddress)
+	if err != nil {
+		t.Error(err)
+	}
+	default_cli_session.publish(context.TODO(), &v2.TelemetryCommand{})
+	observedZapCore, observedLogs := observer.New(zap.InfoLevel)
+	observedLogger := zap.New(observedZapCore)
+	cli.log = observedLogger.Sugar()
+
+	// when
+	default_cli_session._execute_server_telemetry_command(&v2.TelemetryCommand{})
+
+	// then
+	require.Equal(t, 1, observedLogs.Len())
+	commandExecutionLog := observedLogs.All()[0]
+	assert.Equal(t, "telemetryCommand recv err=%!w(*errors.errorString=&{handleTelemetryCommand err = Command is nil})", commandExecutionLog.Message)
+}
+
+func Test_execute_server_telemetry_command(t *testing.T) {
+	// given
+	cli := BuildCLient(t)
+	default_cli_session, err := cli.getDefaultClientSession(fakeAddress)
+	if err != nil {
+		t.Error(err)
+	}
+	default_cli_session.publish(context.TODO(), &v2.TelemetryCommand{})
+	observedZapCore, observedLogs := observer.New(zap.InfoLevel)
+	observedLogger := zap.New(observedZapCore)
+	cli.log = observedLogger.Sugar()
+
+	// when
+	default_cli_session._execute_server_telemetry_command(&v2.TelemetryCommand{Command: &v2.TelemetryCommand_RecoverOrphanedTransactionCommand{}})
+
+	// then
+	require.Equal(t, 2, observedLogs.Len())
+	commandExecutionLog := observedLogs.All()[1]
+	assert.Equal(t, "Executed command successfully", commandExecutionLog.Message)
 }

--- a/golang/rpc_client_mock.go
+++ b/golang/rpc_client_mock.go
@@ -215,9 +215,7 @@ func (mr *MockRpcClientMockRecorder) Telemetry(ctx interface{}) *gomock.Call {
 // idleDuration mocks base method.
 func (m *MockRpcClient) idleDuration() time.Duration {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "idleDuration")
-	ret0, _ := ret[0].(time.Duration)
-	return ret0
+	return time.Hour
 }
 
 // idleDuration indicates an expected call of idleDuration.


### PR DESCRIPTION
I'm trying to solve the issue described by @guyinyou in #182 

The new flow of execution after transmission error looks as follows:
 - we encounter a server TelemetryCommand transmission error
 - we set the state of recovery to true and skip to the next loop iteration
 - if there is a transmission error when we are in recovery we release the observer and set the state of recovery to false
 - if we manage to read the message we check if each of the servers is healthy, if not we release the observer and set the state of recovery to false
 - if we managed to read the message and each server is healthy we process the message and set the state of recovery to false. 

I'm going to write the unit tests for this next. 