### PR TITLE
Fix: increase wait time in recovery tests to avoid flaking

### DIFF
--- a/.github/workflows/golang_build.yml
+++ b/.github/workflows/golang_build.yml
@@ -18,4 +18,7 @@ jobs:
           go-version: ${{ matrix.go }}
       - name: Build
         working-directory: ./golang
-        run: go build && go test ./...
+        run: go build
+      - name: Test
+        working-directory: ./golang
+        run: go test -v

--- a/.github/workflows/golang_build.yml
+++ b/.github/workflows/golang_build.yml
@@ -1,5 +1,5 @@
 name: Golang Build
-on: 
+on:
   workflow_call:
 jobs:
   build:
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2022]
-        go: [1.17]
+        go: [1.19.4]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/golang_build.yml
+++ b/.github/workflows/golang_build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2022]
-        go: [1.19.4]
+        go: [1.17]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,6 @@ composer.lock
 vendor/
 
 # Go
-*.tests
+golang/*.tests
+golang/*.test
+golang/*.exe

--- a/golang/client.go
+++ b/golang/client.go
@@ -150,16 +150,12 @@ func (cs *defaultClientSession) handleTelemetryCommand(response *v2.TelemetryCom
 	switch c := command.(type) {
 	case *v2.TelemetryCommand_Settings:
 		cs.cli.onSettingsCommand(cs.endpoints, c.Settings)
-		break
 	case *v2.TelemetryCommand_RecoverOrphanedTransactionCommand:
 		cs.cli.onRecoverOrphanedTransactionCommand(cs.endpoints, c.RecoverOrphanedTransactionCommand)
-		break
 	case *v2.TelemetryCommand_VerifyMessageCommand:
 		cs.cli.onVerifyMessageCommand(cs.endpoints, c.VerifyMessageCommand)
-		break
 	case *v2.TelemetryCommand_PrintThreadStackTraceCommand:
 		cs.cli.onPrintThreadStackTraceCommand(cs.endpoints, c.PrintThreadStackTraceCommand)
-		break
 	default:
 		return fmt.Errorf("receive unrecognized command from remote, endpoints=%v, command=%v, clientId=%s", cs.endpoints, command, cs.cli.clientID)
 	}
@@ -512,13 +508,11 @@ func (cli *defaultClient) startUp() error {
 					if err == nil {
 						impl.publishingRouteDataResultCache.Store(topic, plb)
 					}
-					break
 				case *defaultSimpleConsumer:
 					slb, err := NewSubscriptionLoadBalancer(newRoute)
 					if err == nil {
 						impl.subTopicRouteDataResultCache.Store(topic, slb)
 					}
-					break
 				}
 			}
 			return true

--- a/golang/client_manager_test.go
+++ b/golang/client_manager_test.go
@@ -82,6 +82,7 @@ func (mt *MOCK_MessagingService_TelemetryClient) Trailer() metadata.MD {
 // Recv implements v2.MessagingService_TelemetryClient
 func (mt *MOCK_MessagingService_TelemetryClient) Recv() (*v2.TelemetryCommand, error) {
 	mt.trace = append(mt.trace, "recv")
+	sugarBaseLogger.Info("calling recv function", "state", mt.recv_error_count, "cli", mt.cli)
 	if mt.recv_error_count >= 1 {
 		mt.recv_error_count -= 1
 		return nil, io.EOF

--- a/golang/client_test.go
+++ b/golang/client_test.go
@@ -279,7 +279,6 @@ func TestRestoreDefaultClientSessionTwoErrors(t *testing.T) {
 	cli.settings = &simpleConsumerSettings{}
 
 	// when
-	// we wait some time while consumer goroutine runs
 	time.Sleep(5 * time.Second)
 
 	// then

--- a/golang/client_test.go
+++ b/golang/client_test.go
@@ -28,7 +28,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
@@ -191,9 +190,12 @@ func Test_execute_server_telemetry_command_fail(t *testing.T) {
 	default_cli_session._execute_server_telemetry_command(&v2.TelemetryCommand{})
 
 	// then
-	require.Equal(t, 1, observedLogs.Len())
-	commandExecutionLog := observedLogs.All()[0]
-	assert.Equal(t, "telemetryCommand recv err=%!w(*errors.errorString=&{handleTelemetryCommand err = Command is nil})", commandExecutionLog.Message)
+	logs := observedLogs.All()
+	messages := make([]string, len(logs))
+	for index, log := range logs {
+		messages[index] = log.Message
+	}
+	assert.Contains(t, messages, "telemetryCommand recv err=%!w(*errors.errorString=&{handleTelemetryCommand err = Command is nil})")
 }
 
 func Test_execute_server_telemetry_command(t *testing.T) {
@@ -206,9 +208,12 @@ func Test_execute_server_telemetry_command(t *testing.T) {
 	default_cli_session._execute_server_telemetry_command(&v2.TelemetryCommand{Command: &v2.TelemetryCommand_RecoverOrphanedTransactionCommand{}})
 
 	// then
-	require.Equal(t, 2, observedLogs.Len())
-	commandExecutionLog := observedLogs.All()[1]
-	assert.Equal(t, "Executed command successfully", commandExecutionLog.Message)
+	logs := observedLogs.All()
+	messages := make([]string, len(logs))
+	for index, log := range logs {
+		messages[index] = log.Message
+	}
+	assert.Contains(t, messages, "Executed command successfully")
 }
 
 func TestRestoreDefaultClientSessionZeroErrors(t *testing.T) {

--- a/golang/client_test.go
+++ b/golang/client_test.go
@@ -228,8 +228,7 @@ func TestRestoreDefaultClientSessionZeroErrors(t *testing.T) {
 	cli.settings = &simpleConsumerSettings{}
 
 	// when
-	// we wait some time while consumer goroutine runs
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// then
 	commandExecutionLog := observedLogs.All()[:2]
@@ -254,8 +253,7 @@ func TestRestoreDefaultClientSessionOneError(t *testing.T) {
 	cli.settings = &simpleConsumerSettings{}
 
 	// when
-	// we wait some time while consumer goroutine runs
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// then
 	commandExecutionLog := observedLogs.All()[:3]
@@ -282,7 +280,7 @@ func TestRestoreDefaultClientSessionTwoErrors(t *testing.T) {
 
 	// when
 	// we wait some time while consumer goroutine runs
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// then
 	commandExecutionLog := observedLogs.All()[:2]

--- a/golang/client_test.go
+++ b/golang/client_test.go
@@ -73,7 +73,6 @@ func BuildCLient(t *testing.T) *defaultClient {
 	if err != nil {
 		t.Error(err)
 	}
-	sugarBaseLogger.Info(cli)
 	err = cli.startUp()
 	if err != nil {
 		t.Error(err)
@@ -236,6 +235,7 @@ func TestRestoreDefaultClientSessionZeroErrors(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	// then
+	sugarBaseLogger.Info(observedLogs.All())
 	commandExecutionLog := observedLogs.All()[:2]
 	assert.Equal(t, "Executed command successfully", commandExecutionLog[0].Message)
 	assert.Equal(t, "Executed command successfully", commandExecutionLog[1].Message)
@@ -261,6 +261,7 @@ func TestRestoreDefaultClientSessionOneError(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	// then
+	sugarBaseLogger.Info(observedLogs.All())
 	commandExecutionLog := observedLogs.All()[:3]
 	assert.Equal(t, "Encountered error while receiving TelemetryCommand, trying to recover", commandExecutionLog[0].Message)
 	assert.Equal(t, "Managed to recover, executing message", commandExecutionLog[1].Message)
@@ -287,6 +288,7 @@ func TestRestoreDefaultClientSessionTwoErrors(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	// then
+	sugarBaseLogger.Info(observedLogs.All())
 	commandExecutionLog := observedLogs.All()[:2]
 	assert.Equal(t, "Encountered error while receiving TelemetryCommand, trying to recover", commandExecutionLog[0].Message)
 	assert.Equal(t, "Failed to recover, err=%wEOF", commandExecutionLog[1].Message)

--- a/golang/client_test.go
+++ b/golang/client_test.go
@@ -232,7 +232,7 @@ func TestRestoreDefaultClientSessionZeroErrors(t *testing.T) {
 	cli.settings = &simpleConsumerSettings{}
 
 	// when
-	time.Sleep(5 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	// then
 	sugarBaseLogger.Info(observedLogs.All())
@@ -258,7 +258,7 @@ func TestRestoreDefaultClientSessionOneError(t *testing.T) {
 	cli.settings = &simpleConsumerSettings{}
 
 	// when
-	time.Sleep(5 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	// then
 	sugarBaseLogger.Info(observedLogs.All())
@@ -285,7 +285,7 @@ func TestRestoreDefaultClientSessionTwoErrors(t *testing.T) {
 	cli.settings = &simpleConsumerSettings{}
 
 	// when
-	time.Sleep(5 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	// then
 	sugarBaseLogger.Info(observedLogs.All())

--- a/golang/rpc_client.go
+++ b/golang/rpc_client.go
@@ -84,7 +84,7 @@ func (rc *rpcClient) GetTarget() string {
 }
 
 func (rc *rpcClient) idleDuration() time.Duration {
-	return time.Now().Sub(rc.activityNanoTime)
+	return time.Since(rc.activityNanoTime)
 }
 
 func (rc *rpcClient) Close() {}

--- a/golang/simple_consumer.go
+++ b/golang/simple_consumer.go
@@ -269,7 +269,7 @@ func (sc *defaultSimpleConsumer) Receive(ctx context.Context, maxMessageNum int3
 	}
 	sc.subscriptionExpressionsLock.RLock()
 	topics := make([]string, 0, len(sc.subscriptionExpressions))
-	for k, _ := range sc.subscriptionExpressions {
+	for k := range sc.subscriptionExpressions {
 		topics = append(topics, k)
 	}
 	sc.subscriptionExpressionsLock.RUnlock()
@@ -305,7 +305,7 @@ func (sc *defaultSimpleConsumer) isClient() {
 }
 
 func (sc *defaultSimpleConsumer) onRecoverOrphanedTransactionCommand(endpoints *v2.Endpoints, command *v2.RecoverOrphanedTransactionCommand) error {
-	return fmt.Errorf("Ignore orphaned transaction recovery command from remote, which is not expected, client id=%s, command=%v", sc.cli.clientID, command)
+	return fmt.Errorf("ignore orphaned transaction recovery command from remote, which is not expected, client id=%s, command=%v", sc.cli.clientID, command)
 }
 
 func (sc *defaultSimpleConsumer) onVerifyMessageCommand(endpoints *v2.Endpoints, command *v2.VerifyMessageCommand) error {
@@ -344,7 +344,7 @@ var NewSimpleConsumer = func(config *Config, opts ...SimpleConsumerOption) (Simp
 		sc.subscriptionExpressions = make(map[string]*FilterExpression)
 	}
 	sc.cli.initTopics = make([]string, 0)
-	for topic, _ := range scOpts.subscriptionExpressions {
+	for topic := range scOpts.subscriptionExpressions {
 		sc.cli.initTopics = append(sc.cli.initTopics, topic)
 	}
 	endpoints, err := utils.ParseTarget(config.Endpoint)


### PR DESCRIPTION
Currently the tests for recovering after TelemetryCommand transmission failure wait 3 seconds after the initial setup for the telemetry client goroutine to run. This is at the edge of expected wait time for the goroutine to go through all of the required code. Increasing the wait time for five seconds guarantees that by the time that we check the expected logs all of the testing scenario will have already completed. 

Fixes #410 