### PR TITLE
ci: add `protoc` install in Rust build

### DIFF
--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -13,6 +13,12 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build
         working-directory: ./rust
         run: cargo build


### PR DESCRIPTION
Fix: #454 

solution reference [tonic's build CI](https://github.com/hyperium/tonic/blob/fa06bafcc0f5a6534da1a1694a902c3e51c82d43/.github/workflows/CI.yml#L34-L37)