### PR TITLE
feat(rust): implement simple consumer

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -58,6 +58,9 @@ siphasher = "0.3.10"
 
 [build-dependencies]
 tonic-build = "0.9.0"
+which = "4.4.0"
+version_check = "0.9.4"
+regex = "1.7.3"
 
 [dev-dependencies]
 wiremock-grpc = "0.0.3-alpha2"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,6 +33,7 @@ anyhow = "1.0.70"
 parking_lot = "0.12"
 hmac = "0.12"
 hostname = "0.3.1"
+os_type = "2.6.0"
 
 slog = {version = "2.7.0", features=["max_level_trace", "release_max_level_info"]}
 slog-term = "2.9.0"

--- a/rust/README.md
+++ b/rust/README.md
@@ -14,7 +14,7 @@ Here are some preparations you may need to know (or refer to [here](https://rock
 
 1. rust and cargo
 2. protoc 3.15.0+
-3. Setup name server, broker, and [proxy](https://github.com/apache/rocketmq/tree/develop/proxy).
+3. setup name server, broker, and [proxy](https://github.com/apache/rocketmq/tree/develop/proxy).
 
 ### Run Example
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,4 +1,4 @@
-# The Java Implementation of Apache RocketMQ Client
+# The Rust Implementation of Apache RocketMQ Client
 
 [RocketMQ Website](https://rocketmq.apache.org/)
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,29 @@
+# The Java Implementation of Apache RocketMQ Client
+
+[RocketMQ Website](https://rocketmq.apache.org/)
+
+## Overview
+
+Here is the rust implementation of the client for [Apache RocketMQ](https://rocketmq.apache.org/). Different from the [remoting-based client](https://github.com/apache/rocketmq/tree/develop/client), the current implementation is based on separating architecture for computing and storage, which is the more recommended way to access the RocketMQ service.
+
+Here are some preparations you may need to know (or refer to [here](https://rocketmq.apache.org/docs/quickStart/02quickstart)).
+
+## Getting Started
+
+### Requirements
+
+1. rust and cargo
+2. protoc 3.15.0+
+3. Setup name server, broker, and [proxy](https://github.com/apache/rocketmq/tree/develop/proxy).
+
+### Run Example
+
+Run the following command to start the example:
+
+```sh
+# send message via producer
+cargo run --example producer
+
+# consume message via simple consumer
+cargo run --example simple_consumer
+```

--- a/rust/examples/producer.rs
+++ b/rust/examples/producer.rs
@@ -24,7 +24,6 @@ async fn main() {
     // producer will prefetch topic route when start and failed fast if topic not exist
     let mut producer_option = ProducerOption::default();
     producer_option.set_topics(vec!["test_topic"]);
-    producer_option.set_producer_group("ProducerGroup");
 
     // set which rocketmq proxy to connect
     let mut client_option = ClientOption::default();

--- a/rust/examples/producer.rs
+++ b/rust/examples/producer.rs
@@ -14,21 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use rocketmq::{ClientOption, MessageImpl, Producer, ProducerOption};
+use rocketmq::conf::{ClientOption, ProducerOption};
+use rocketmq::model::message::MessageImpl;
+use rocketmq::Producer;
 
 #[tokio::main]
 async fn main() {
-    // specify which topic(s) you would like to send message to
+    // recommend to specify which topic(s) you would like to send message to
     // producer will prefetch topic route when start and failed fast if topic not exist
     let mut producer_option = ProducerOption::default();
     producer_option.set_topics(vec!["test_topic".to_string()]);
+    producer_option.set_producer_group("ProducerGroup".to_string());
 
     // set which rocketmq proxy to connect
     let mut client_option = ClientOption::default();
     client_option.set_access_url("localhost:8081".to_string());
 
     // build and start producer
-    let producer = Producer::new(producer_option, client_option).await.unwrap();
+    let producer = Producer::new(producer_option, client_option).unwrap();
     producer.start().await.unwrap();
 
     // build message

--- a/rust/examples/producer.rs
+++ b/rust/examples/producer.rs
@@ -23,12 +23,12 @@ async fn main() {
     // recommend to specify which topic(s) you would like to send message to
     // producer will prefetch topic route when start and failed fast if topic not exist
     let mut producer_option = ProducerOption::default();
-    producer_option.set_topics(vec!["test_topic".to_string()]);
-    producer_option.set_producer_group("ProducerGroup".to_string());
+    producer_option.set_topics(vec!["test_topic"]);
+    producer_option.set_producer_group("ProducerGroup");
 
     // set which rocketmq proxy to connect
     let mut client_option = ClientOption::default();
-    client_option.set_access_url("localhost:8081".to_string());
+    client_option.set_access_url("localhost:8081");
 
     // build and start producer
     let producer = Producer::new(producer_option, client_option).unwrap();
@@ -36,8 +36,8 @@ async fn main() {
 
     // build message
     let message = MessageImpl::builder()
-        .set_topic("test_topic".to_string())
-        .set_tags("test_tag".to_string())
+        .set_topic("test_topic")
+        .set_tags("test_tag")
         .set_body("hello world".as_bytes().to_vec())
         .build()
         .unwrap();

--- a/rust/examples/simple_consumer.rs
+++ b/rust/examples/simple_consumer.rs
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use rocketmq::conf::{ClientOption, SimpleConsumerOption};
+use rocketmq::model::common::{FilterExpression, FilterType};
+use rocketmq::SimpleConsumer;
+
+#[tokio::main]
+async fn main() {
+    // recommend to specify which topic(s) you would like to send message to
+    // simple consumer will prefetch topic route when start and failed fast if topic not exist
+    let mut consumer_option = SimpleConsumerOption::default();
+    consumer_option.set_topics(vec!["test_topic".to_string()]);
+    consumer_option.set_consumer_group("SimpleConsumerGroup".to_string());
+
+    // set which rocketmq proxy to connect
+    let mut client_option = ClientOption::default();
+    client_option.set_access_url("localhost:8081".to_string());
+
+    // build and start simple consumer
+    let consumer = SimpleConsumer::new(consumer_option, client_option).unwrap();
+    consumer.start().await.unwrap();
+
+    // pop message from rocketmq proxy
+    let receive_result = consumer
+        .receive(
+            "test_topic",
+            &FilterExpression::new(FilterType::Tag, "test_tag".to_string()),
+        )
+        .await;
+    debug_assert!(
+        receive_result.is_ok(),
+        "receive message failed: {:?}",
+        receive_result.unwrap_err()
+    );
+
+    let messages = receive_result.unwrap();
+    for message in messages {
+        println!("receive message: {:?}", message);
+        // ack message to rocketmq proxy
+        let ack_result = consumer.ack(message).await;
+        debug_assert!(
+            ack_result.is_ok(),
+            "ack message failed: {:?}",
+            ack_result.unwrap_err()
+        );
+    }
+}

--- a/rust/examples/simple_consumer.rs
+++ b/rust/examples/simple_consumer.rs
@@ -23,12 +23,12 @@ async fn main() {
     // recommend to specify which topic(s) you would like to send message to
     // simple consumer will prefetch topic route when start and failed fast if topic not exist
     let mut consumer_option = SimpleConsumerOption::default();
-    consumer_option.set_topics(vec!["test_topic".to_string()]);
-    consumer_option.set_consumer_group("SimpleConsumerGroup".to_string());
+    consumer_option.set_topics(vec!["test_topic"]);
+    consumer_option.set_consumer_group("SimpleConsumerGroup");
 
     // set which rocketmq proxy to connect
     let mut client_option = ClientOption::default();
-    client_option.set_access_url("localhost:8081".to_string());
+    client_option.set_access_url("localhost:8081");
 
     // build and start simple consumer
     let consumer = SimpleConsumer::new(consumer_option, client_option).unwrap();
@@ -37,8 +37,8 @@ async fn main() {
     // pop message from rocketmq proxy
     let receive_result = consumer
         .receive(
-            "test_topic",
-            &FilterExpression::new(FilterType::Tag, "test_tag".to_string()),
+            "test_topic".to_string(),
+            &FilterExpression::new(FilterType::Tag, "test_tag"),
         )
         .await;
     debug_assert!(

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -14,31 +14,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use crate::model::common::ClientType;
+use std::time::Duration;
+
 #[derive(Debug, Clone)]
 pub struct ClientOption {
-    name_space: String,
-    access_url: String,
-    enable_tls: bool,
+    pub(crate) client_type: ClientType,
+    pub(crate) group: String,
+    pub(crate) namespace: String,
+    pub(crate) access_url: String,
+    pub(crate) enable_tls: bool,
+    pub(crate) timeout: Duration,
+    pub(crate) long_polling_timeout: Duration,
 }
 
 impl Default for ClientOption {
     fn default() -> Self {
         ClientOption {
-            name_space: "".to_string(),
+            client_type: ClientType::Producer,
+            group: "".to_string(),
+            namespace: "".to_string(),
             access_url: "localhost:8081".to_string(),
             enable_tls: false,
+            timeout: Duration::from_secs(10),
+            long_polling_timeout: Duration::from_secs(40),
         }
     }
 }
 
 impl ClientOption {
-    pub fn name_space(&self) -> &str {
-        &self.name_space
-    }
-    pub fn set_name_space(&mut self, name_space: String) {
-        self.name_space = name_space;
-    }
-
     pub fn access_url(&self) -> &str {
         &self.access_url
     }
@@ -52,6 +56,20 @@ impl ClientOption {
     pub fn set_enable_tls(&mut self, enable_tls: bool) {
         self.enable_tls = enable_tls;
     }
+
+    pub fn timeout(&self) -> &Duration {
+        &self.timeout
+    }
+    pub fn set_timeout(&mut self, timeout: Duration) {
+        self.timeout = timeout;
+    }
+
+    pub fn long_polling_timeout(&self) -> &Duration {
+        &self.long_polling_timeout
+    }
+    pub fn set_long_polling_timeout(&mut self, long_polling_timeout: Duration) {
+        self.long_polling_timeout = long_polling_timeout;
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -62,24 +80,35 @@ pub enum LoggingFormat {
 
 #[derive(Debug, Clone)]
 pub struct ProducerOption {
+    producer_group: String,
     logging_format: LoggingFormat,
     prefetch_route: bool,
     topics: Option<Vec<String>>,
     namespace: String,
+    validate_message_type: bool,
 }
 
 impl Default for ProducerOption {
     fn default() -> Self {
         ProducerOption {
+            producer_group: "".to_string(),
             logging_format: LoggingFormat::Terminal,
             prefetch_route: true,
             topics: None,
             namespace: "".to_string(),
+            validate_message_type: true,
         }
     }
 }
 
 impl ProducerOption {
+    pub fn producer_group(&self) -> &str {
+        &self.producer_group
+    }
+    pub fn set_producer_group(&mut self, producer_group: String) {
+        self.producer_group = producer_group;
+    }
+
     pub fn logging_format(&self) -> &LoggingFormat {
         &self.logging_format
     }
@@ -106,5 +135,79 @@ impl ProducerOption {
     }
     pub fn set_namespace(&mut self, name_space: String) {
         self.namespace = name_space;
+    }
+
+    pub fn validate_message_type(&self) -> bool {
+        self.validate_message_type
+    }
+    pub fn set_validate_message_type(&mut self, validate_message_type: bool) {
+        self.validate_message_type = validate_message_type;
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SimpleConsumerOption {
+    logging_format: LoggingFormat,
+    consumer_group: String,
+    prefetch_route: bool,
+    topics: Option<Vec<String>>,
+    namespace: String,
+    await_duration: Duration,
+}
+
+impl Default for SimpleConsumerOption {
+    fn default() -> Self {
+        SimpleConsumerOption {
+            logging_format: LoggingFormat::Terminal,
+            consumer_group: "".to_string(),
+            prefetch_route: true,
+            topics: None,
+            namespace: "".to_string(),
+            await_duration: Duration::from_secs(1),
+        }
+    }
+}
+
+impl SimpleConsumerOption {
+    pub fn logging_format(&self) -> &LoggingFormat {
+        &self.logging_format
+    }
+    pub fn set_logging_format(&mut self, logging_format: LoggingFormat) {
+        self.logging_format = logging_format;
+    }
+
+    pub fn consumer_group(&self) -> &str {
+        &self.consumer_group
+    }
+    pub fn set_consumer_group(&mut self, consumer_group: String) {
+        self.consumer_group = consumer_group;
+    }
+
+    pub fn prefetch_route(&self) -> &bool {
+        &self.prefetch_route
+    }
+    pub fn set_prefetch_route(&mut self, prefetch_route: bool) {
+        self.prefetch_route = prefetch_route;
+    }
+
+    pub fn topics(&self) -> &Option<Vec<String>> {
+        &self.topics
+    }
+    pub fn set_topics(&mut self, topics: Vec<String>) {
+        self.topics = Some(topics);
+    }
+
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+    pub fn set_namespace(&mut self, name_space: String) {
+        self.namespace = name_space;
+    }
+
+    pub fn await_duration(&self) -> &Duration {
+        &self.await_duration
+    }
+    pub fn set_await_duration(&mut self, await_duration: Duration) {
+        self.await_duration = await_duration;
     }
 }

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -36,7 +36,7 @@ impl Default for ClientOption {
             namespace: "".to_string(),
             access_url: "localhost:8081".to_string(),
             enable_tls: false,
-            timeout: Duration::from_secs(10),
+            timeout: Duration::from_secs(3),
             long_polling_timeout: Duration::from_secs(40),
         }
     }
@@ -80,7 +80,6 @@ pub enum LoggingFormat {
 
 #[derive(Debug, Clone)]
 pub struct ProducerOption {
-    producer_group: String,
     logging_format: LoggingFormat,
     prefetch_route: bool,
     topics: Option<Vec<String>>,
@@ -91,7 +90,6 @@ pub struct ProducerOption {
 impl Default for ProducerOption {
     fn default() -> Self {
         ProducerOption {
-            producer_group: "".to_string(),
             logging_format: LoggingFormat::Terminal,
             prefetch_route: true,
             topics: None,
@@ -102,13 +100,6 @@ impl Default for ProducerOption {
 }
 
 impl ProducerOption {
-    pub fn producer_group(&self) -> &str {
-        &self.producer_group
-    }
-    pub fn set_producer_group(&mut self, producer_group: impl Into<String>) {
-        self.producer_group = producer_group.into();
-    }
-
     pub fn logging_format(&self) -> &LoggingFormat {
         &self.logging_format
     }
@@ -130,10 +121,11 @@ impl ProducerOption {
         self.topics = Some(topics.into_iter().map(|t| t.into()).collect());
     }
 
-    pub fn namespace(&self) -> &str {
+    // not expose to user for now
+    pub(crate) fn namespace(&self) -> &str {
         &self.namespace
     }
-    pub fn set_namespace(&mut self, name_space: impl Into<String>) {
+    pub(crate) fn set_namespace(&mut self, name_space: impl Into<String>) {
         self.namespace = name_space.into();
     }
 
@@ -152,7 +144,6 @@ pub struct SimpleConsumerOption {
     prefetch_route: bool,
     topics: Option<Vec<String>>,
     namespace: String,
-    await_duration: Duration,
 }
 
 impl Default for SimpleConsumerOption {
@@ -163,7 +154,6 @@ impl Default for SimpleConsumerOption {
             prefetch_route: true,
             topics: None,
             namespace: "".to_string(),
-            await_duration: Duration::from_secs(1),
         }
     }
 }
@@ -197,17 +187,11 @@ impl SimpleConsumerOption {
         self.topics = Some(topics.into_iter().map(|t| t.into()).collect());
     }
 
-    pub fn namespace(&self) -> &str {
+    // not expose to user for now
+    pub(crate) fn namespace(&self) -> &str {
         &self.namespace
     }
-    pub fn set_namespace(&mut self, name_space: impl Into<String>) {
+    pub(crate) fn set_namespace(&mut self, name_space: impl Into<String>) {
         self.namespace = name_space.into();
-    }
-
-    pub fn await_duration(&self) -> &Duration {
-        &self.await_duration
-    }
-    pub fn set_await_duration(&mut self, await_duration: Duration) {
-        self.await_duration = await_duration;
     }
 }

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -46,8 +46,8 @@ impl ClientOption {
     pub fn access_url(&self) -> &str {
         &self.access_url
     }
-    pub fn set_access_url(&mut self, access_url: String) {
-        self.access_url = access_url;
+    pub fn set_access_url(&mut self, access_url: impl Into<String>) {
+        self.access_url = access_url.into();
     }
 
     pub fn enable_tls(&self) -> bool {
@@ -105,8 +105,8 @@ impl ProducerOption {
     pub fn producer_group(&self) -> &str {
         &self.producer_group
     }
-    pub fn set_producer_group(&mut self, producer_group: String) {
-        self.producer_group = producer_group;
+    pub fn set_producer_group(&mut self, producer_group: impl Into<String>) {
+        self.producer_group = producer_group.into();
     }
 
     pub fn logging_format(&self) -> &LoggingFormat {
@@ -126,15 +126,15 @@ impl ProducerOption {
     pub fn topics(&self) -> &Option<Vec<String>> {
         &self.topics
     }
-    pub fn set_topics(&mut self, topics: Vec<String>) {
-        self.topics = Some(topics);
+    pub fn set_topics(&mut self, topics: Vec<impl Into<String>>) {
+        self.topics = Some(topics.into_iter().map(|t| t.into()).collect());
     }
 
     pub fn namespace(&self) -> &str {
         &self.namespace
     }
-    pub fn set_namespace(&mut self, name_space: String) {
-        self.namespace = name_space;
+    pub fn set_namespace(&mut self, name_space: impl Into<String>) {
+        self.namespace = name_space.into();
     }
 
     pub fn validate_message_type(&self) -> bool {
@@ -179,8 +179,8 @@ impl SimpleConsumerOption {
     pub fn consumer_group(&self) -> &str {
         &self.consumer_group
     }
-    pub fn set_consumer_group(&mut self, consumer_group: String) {
-        self.consumer_group = consumer_group;
+    pub fn set_consumer_group(&mut self, consumer_group: impl Into<String>) {
+        self.consumer_group = consumer_group.into();
     }
 
     pub fn prefetch_route(&self) -> &bool {
@@ -193,15 +193,15 @@ impl SimpleConsumerOption {
     pub fn topics(&self) -> &Option<Vec<String>> {
         &self.topics
     }
-    pub fn set_topics(&mut self, topics: Vec<String>) {
-        self.topics = Some(topics);
+    pub fn set_topics(&mut self, topics: Vec<impl Into<String>>) {
+        self.topics = Some(topics.into_iter().map(|t| t.into()).collect());
     }
 
     pub fn namespace(&self) -> &str {
         &self.namespace
     }
-    pub fn set_namespace(&mut self, name_space: String) {
-        self.namespace = name_space;
+    pub fn set_namespace(&mut self, name_space: impl Into<String>) {
+        self.namespace = name_space.into();
     }
 
     pub fn await_duration(&self) -> &Duration {

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -38,6 +38,9 @@ pub enum ErrorKind {
     #[error("Client internal error")]
     ClientInternal,
 
+    #[error("Client is not running")]
+    ClientIsNotRunning,
+
     #[error("Failed to send message via channel")]
     ChannelSend,
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 #[allow(dead_code)]
-mod conf;
+pub mod conf;
 #[allow(dead_code)]
 mod error;
 #[allow(dead_code)]
@@ -29,11 +29,12 @@ mod pb;
 mod session;
 
 #[allow(dead_code)]
-mod model;
+pub mod model;
+mod util;
+
 mod producer;
+mod simple_consumer;
 
 // Export structs that are part of crate API.
-pub use conf::ClientOption;
-pub use conf::ProducerOption;
-pub use model::message::MessageImpl;
 pub use producer::Producer;
+pub use simple_consumer::SimpleConsumer;

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -19,7 +19,7 @@ use std::fs::OpenOptions;
 use slog::{o, Drain, Logger};
 use slog_async::OverflowStrategy;
 
-use crate::conf::{LoggingFormat, ProducerOption};
+use crate::conf::LoggingFormat;
 
 pub(crate) fn terminal_logger() -> Logger {
     let decorator = slog_term::TermDecorator::new().build();
@@ -47,8 +47,8 @@ fn json_logger(filepath: &str) -> Logger {
     Logger::root(drain, o!())
 }
 
-pub(crate) fn logger(_option: &ProducerOption) -> Logger {
-    match _option.logging_format() {
+pub(crate) fn logger(logging_format: &LoggingFormat) -> Logger {
+    match logging_format {
         LoggingFormat::Terminal => terminal_logger(),
         LoggingFormat::Json => json_logger("logs/rocketmq_client.log"),
     }

--- a/rust/src/model/common.rs
+++ b/rust/src/model/common.rs
@@ -190,10 +190,10 @@ pub struct FilterExpression {
 }
 
 impl FilterExpression {
-    pub fn new(filter_type: FilterType, expression: String) -> Self {
+    pub fn new(filter_type: FilterType, expression: impl Into<String>) -> Self {
         FilterExpression {
             filter_type,
-            expression,
+            expression: expression.into(),
         }
     }
 }

--- a/rust/src/model/message.rs
+++ b/rust/src/model/message.rs
@@ -135,8 +135,8 @@ pub struct MessageBuilder {
 impl MessageBuilder {
     const OPERATION_BUILD_MESSAGE: &'static str = "build_message";
 
-    pub fn set_topic(mut self, topic: String) -> Self {
-        self.message.topic = topic;
+    pub fn set_topic(mut self, topic: impl Into<String>) -> Self {
+        self.message.topic = topic.into();
         self
     }
 
@@ -145,23 +145,31 @@ impl MessageBuilder {
         self
     }
 
-    pub fn set_tags(mut self, tags: String) -> Self {
-        self.message.tags = Some(tags);
+    pub fn set_tags(mut self, tags: impl Into<String>) -> Self {
+        self.message.tags = Some(tags.into());
         self
     }
 
-    pub fn set_keys(mut self, keys: Vec<String>) -> Self {
-        self.message.keys = Some(keys);
+    pub fn set_keys(mut self, keys: Vec<impl Into<String>>) -> Self {
+        self.message.keys = Some(keys.into_iter().map(|k| k.into()).collect());
         self
     }
 
-    pub fn set_properties(mut self, properties: HashMap<String, String>) -> Self {
-        self.message.properties = Some(properties);
+    pub fn set_properties(
+        mut self,
+        properties: HashMap<impl Into<String>, impl Into<String>>,
+    ) -> Self {
+        self.message.properties = Some(
+            properties
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        );
         self
     }
 
-    pub fn set_message_group(mut self, message_group: String) -> Self {
-        self.message.message_group = Some(message_group);
+    pub fn set_message_group(mut self, message_group: impl Into<String>) -> Self {
+        self.message.message_group = Some(message_group.into());
         self
     }
 

--- a/rust/src/model/mod.rs
+++ b/rust/src/model/mod.rs
@@ -14,6 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-pub(crate) mod common;
-pub(crate) mod message;
+pub mod common;
+pub mod message;
 pub(crate) mod message_id;

--- a/rust/src/producer.rs
+++ b/rust/src/producer.rs
@@ -225,15 +225,11 @@ mod tests {
     async fn producer_transform_messages_to_protobuf() {
         let producer = Producer::new(ProducerOption::default(), ClientOption::default()).unwrap();
         let messages = vec![MessageImpl::builder()
-            .set_topic("DefaultCluster".to_string())
+            .set_topic("DefaultCluster")
             .set_body("hello world".as_bytes().to_vec())
-            .set_tags("tag".to_string())
-            .set_keys(vec!["key".to_string()])
-            .set_properties(
-                vec![("key".to_string(), "value".to_string())]
-                    .into_iter()
-                    .collect(),
-            )
+            .set_tags("tag")
+            .set_keys(vec!["key"])
+            .set_properties(vec![("key", "value")].into_iter().collect())
             .set_message_group("message_group".to_string())
             .build()
             .unwrap()];
@@ -285,12 +281,12 @@ mod tests {
 
         let messages = vec![
             MessageImpl::builder()
-                .set_topic("DefaultCluster".to_string())
+                .set_topic("DefaultCluster")
                 .set_body("hello world".as_bytes().to_vec())
                 .build()
                 .unwrap(),
             MessageImpl::builder()
-                .set_topic("DefaultCluster_dup".to_string())
+                .set_topic("DefaultCluster_dup")
                 .set_body("hello world".as_bytes().to_vec())
                 .build()
                 .unwrap(),
@@ -303,15 +299,15 @@ mod tests {
 
         let messages = vec![
             MessageImpl::builder()
-                .set_topic("DefaultCluster".to_string())
+                .set_topic("DefaultCluster")
                 .set_body("hello world".as_bytes().to_vec())
-                .set_message_group("message_group".to_string())
+                .set_message_group("message_group")
                 .build()
                 .unwrap(),
             MessageImpl::builder()
-                .set_topic("DefaultCluster".to_string())
+                .set_topic("DefaultCluster")
                 .set_body("hello world".as_bytes().to_vec())
-                .set_message_group("message_group_dup".to_string())
+                .set_message_group("message_group_dup")
                 .build()
                 .unwrap(),
         ];

--- a/rust/src/producer.rs
+++ b/rust/src/producer.rs
@@ -53,7 +53,6 @@ impl Producer {
     pub fn new(option: ProducerOption, client_option: ClientOption) -> Result<Self, ClientError> {
         let client_option = ClientOption {
             client_type: ClientType::Producer,
-            group: option.producer_group().to_string(),
             namespace: option.namespace().to_string(),
             ..client_option
         };

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -18,31 +18,56 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use mockall::automock;
-use slog::{info, o, Logger};
-use tokio::sync::Mutex;
+use slog::{debug, error, info, o, Logger};
+use tokio::sync::{mpsc, Mutex};
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::StreamExt;
 use tonic::metadata::AsciiMetadataValue;
 use tonic::transport::{Channel, Endpoint};
 
 use crate::conf::ClientOption;
 use crate::error::ErrorKind;
 use crate::model::common::Endpoints;
-use crate::pb::{QueryRouteRequest, QueryRouteResponse, SendMessageRequest, SendMessageResponse};
+use crate::pb::{
+    AckMessageRequest, AckMessageResponse, HeartbeatRequest, HeartbeatResponse, QueryRouteRequest,
+    QueryRouteResponse, ReceiveMessageRequest, ReceiveMessageResponse, SendMessageRequest,
+    SendMessageResponse, TelemetryCommand,
+};
+use crate::util::{PROTOCOL_VERSION, SDK_LANGUAGE, SDK_VERSION};
 use crate::{error::ClientError, pb::messaging_service_client::MessagingServiceClient};
 
 #[async_trait]
 #[automock]
 pub(crate) trait RPCClient {
+    const OPERATION_START: &'static str = "session.start";
+    const OPERATION_UPDATE_SETTINGS: &'static str = "session.update_settings";
+
     const OPERATION_QUERY_ROUTE: &'static str = "rpc.query_route";
+    const OPERATION_HEARTBEAT: &'static str = "rpc.heartbeat";
     const OPERATION_SEND_MESSAGE: &'static str = "rpc.send_message";
+    const OPERATION_RECEIVE_MESSAGE: &'static str = "rpc.receive_message";
+    const OPERATION_ACK_MESSAGE: &'static str = "rpc.ack_message";
 
     async fn query_route(
         &mut self,
         request: QueryRouteRequest,
     ) -> Result<QueryRouteResponse, ClientError>;
+    async fn heartbeat(
+        &mut self,
+        request: HeartbeatRequest,
+    ) -> Result<HeartbeatResponse, ClientError>;
     async fn send_message(
         &mut self,
         request: SendMessageRequest,
     ) -> Result<SendMessageResponse, ClientError>;
+    async fn receive_message(
+        &mut self,
+        request: ReceiveMessageRequest,
+    ) -> Result<Vec<ReceiveMessageResponse>, ClientError>;
+    async fn ack_message(
+        &mut self,
+        request: AckMessageRequest,
+    ) -> Result<AckMessageResponse, ClientError>;
 }
 
 #[allow(dead_code)]
@@ -50,7 +75,10 @@ pub(crate) trait RPCClient {
 pub(crate) struct Session {
     logger: Logger,
     client_id: String,
+    option: ClientOption,
+    endpoints: Endpoints,
     stub: MessagingServiceClient<Channel>,
+    telemetry_tx: Box<Option<mpsc::Sender<TelemetryCommand>>>,
 }
 
 impl Session {
@@ -75,7 +103,7 @@ impl Session {
         if channel_endpoints.is_empty() {
             return Err(ClientError::new(
                 ErrorKind::Connect,
-                "No endpoint available.",
+                "no endpoint available",
                 Self::OPERATION_CREATE,
             )
             .with_context("peer", peer.clone()));
@@ -85,7 +113,7 @@ impl Session {
             channel_endpoints[0].connect().await.map_err(|e| {
                 ClientError::new(
                     ErrorKind::Connect,
-                    "Failed to connect to peer.",
+                    "failed to connect to peer",
                     Self::OPERATION_CREATE,
                 )
                 .set_source(e)
@@ -97,16 +125,16 @@ impl Session {
 
         let stub = MessagingServiceClient::new(channel);
 
-        info!(
-            logger,
-            "create session success, peer={}",
-            endpoints.endpoint_url()
-        );
+        let logger = logger.new(o!("peer" => peer.clone()));
+        info!(logger, "create session success");
 
         Ok(Session {
-            logger: logger.new(o!("component" => "session", "peer" => peer.clone())),
+            logger,
+            option: option.clone(),
+            endpoints: endpoints.clone(),
             client_id,
             stub,
+            telemetry_tx: Box::new(None),
         })
     }
 
@@ -124,7 +152,7 @@ impl Session {
             .map_err(|e| {
                 ClientError::new(
                     ErrorKind::Connect,
-                    "Failed to create channel endpoint.",
+                    "failed to create channel endpoint",
                     Self::OPERATION_CREATE,
                 )
                 .set_source(e)
@@ -141,24 +169,112 @@ impl Session {
             //     .set_source(e)
             //     .with_context("peer", &peer_addr)
             // })?
-            .connect_timeout(std::time::Duration::from_secs(3))
+            .connect_timeout(option.timeout)
+            .timeout(option.timeout)
             .tcp_nodelay(true);
         Ok(endpoint)
     }
 
-    fn sign(&self, metadata: &mut tonic::metadata::MetadataMap) {
+    pub(crate) fn peer(&self) -> &str {
+        self.endpoints.endpoint_url()
+    }
+
+    fn sign<T>(&self, mut request: tonic::Request<T>) -> tonic::Request<T> {
+        let metadata = request.metadata_mut();
         let _ = AsciiMetadataValue::try_from(&self.client_id)
             .map(|v| metadata.insert("x-mq-client-id", v));
 
-        metadata.insert("x-mq-language", AsciiMetadataValue::from_static("RUST"));
+        metadata.insert(
+            "x-mq-language",
+            AsciiMetadataValue::from_static(SDK_LANGUAGE.as_str_name()),
+        );
         metadata.insert(
             "x-mq-client-version",
-            AsciiMetadataValue::from_static("5.0.0"),
+            AsciiMetadataValue::from_static(SDK_VERSION),
         );
         metadata.insert(
             "x-mq-protocol-version",
-            AsciiMetadataValue::from_static("2.0.0"),
+            AsciiMetadataValue::from_static(PROTOCOL_VERSION),
         );
+
+        request.set_timeout(*self.option.timeout());
+        request
+    }
+
+    pub(crate) async fn start(&mut self, settings: TelemetryCommand) -> Result<(), ClientError> {
+        let (tx, rx) = mpsc::channel(16);
+        tx.send(settings).await.map_err(|e| {
+            ClientError::new(
+                ErrorKind::ChannelSend,
+                "failed to send telemetry command",
+                Self::OPERATION_START,
+            )
+            .set_source(e)
+        })?;
+
+        let request = self.sign(tonic::Request::new(ReceiverStream::new(rx)));
+        let response = self.stub.telemetry(request).await.map_err(|e| {
+            ClientError::new(
+                ErrorKind::ClientInternal,
+                "send rpc telemetry failed",
+                Self::OPERATION_START,
+            )
+            .set_source(e)
+        })?;
+
+        let logger = self.logger.clone();
+        tokio::spawn(async move {
+            let mut stream = response.into_inner();
+            loop {
+                // TODO handle server stream
+                match stream.message().await {
+                    Ok(Some(item)) => {
+                        debug!(logger, "telemetry command: {:?}", item);
+                    }
+                    Ok(None) => {
+                        debug!(logger, "request stream closed");
+                        break;
+                    }
+                    Err(e) => {
+                        error!(logger, "telemetry response error: {:?}", e);
+                    }
+                }
+            }
+        });
+        let _ = self.telemetry_tx.insert(tx);
+        debug!(self.logger, "start session success");
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn is_started(&self) -> bool {
+        self.telemetry_tx.is_some()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn update_settings(
+        &mut self,
+        settings: TelemetryCommand,
+    ) -> Result<(), ClientError> {
+        if !self.is_started() {
+            return Err(ClientError::new(
+                ErrorKind::ClientIsNotRunning,
+                "session is not started",
+                Self::OPERATION_UPDATE_SETTINGS,
+            ));
+        }
+
+        if let Some(tx) = self.telemetry_tx.as_ref() {
+            tx.send(settings).await.map_err(|e| {
+                ClientError::new(
+                    ErrorKind::ChannelSend,
+                    "failed to send telemetry command",
+                    Self::OPERATION_UPDATE_SETTINGS,
+                )
+                .set_source(e)
+            })?;
+        }
+        Ok(())
     }
 }
 
@@ -168,13 +284,28 @@ impl RPCClient for Session {
         &mut self,
         request: QueryRouteRequest,
     ) -> Result<QueryRouteResponse, ClientError> {
-        let mut request = tonic::Request::new(request);
-        self.sign(request.metadata_mut());
+        let request = self.sign(tonic::Request::new(request));
         let response = self.stub.query_route(request).await.map_err(|e| {
             ClientError::new(
                 ErrorKind::ClientInternal,
-                "Query topic route rpc failed.",
+                "send rpc query_route failed",
                 Self::OPERATION_QUERY_ROUTE,
+            )
+            .set_source(e)
+        })?;
+        Ok(response.into_inner())
+    }
+
+    async fn heartbeat(
+        &mut self,
+        request: HeartbeatRequest,
+    ) -> Result<HeartbeatResponse, ClientError> {
+        let request = self.sign(tonic::Request::new(request));
+        let response = self.stub.heartbeat(request).await.map_err(|e| {
+            ClientError::new(
+                ErrorKind::ClientInternal,
+                "send rpc heartbeat failed",
+                Self::OPERATION_HEARTBEAT,
             )
             .set_source(e)
         })?;
@@ -185,13 +316,63 @@ impl RPCClient for Session {
         &mut self,
         request: SendMessageRequest,
     ) -> Result<SendMessageResponse, ClientError> {
-        let mut request = tonic::Request::new(request);
-        self.sign(request.metadata_mut());
+        let request = self.sign(tonic::Request::new(request));
         let response = self.stub.send_message(request).await.map_err(|e| {
             ClientError::new(
                 ErrorKind::ClientInternal,
-                "Send message rpc failed.",
+                "send rpc send_message failed",
                 Self::OPERATION_SEND_MESSAGE,
+            )
+            .set_source(e)
+        })?;
+        Ok(response.into_inner())
+    }
+
+    async fn receive_message(
+        &mut self,
+        request: ReceiveMessageRequest,
+    ) -> Result<Vec<ReceiveMessageResponse>, ClientError> {
+        let batch_size = request.batch_size;
+        let request = self.sign(tonic::Request::new(request));
+        let mut stream = self
+            .stub
+            .receive_message(request)
+            .await
+            .map_err(|e| {
+                ClientError::new(
+                    ErrorKind::ClientInternal,
+                    "send rpc receive_message failed",
+                    Self::OPERATION_RECEIVE_MESSAGE,
+                )
+                .set_source(e)
+            })?
+            .into_inner();
+
+        let mut responses = Vec::with_capacity(batch_size as usize);
+        while let Some(item) = stream.next().await {
+            let response = item.map_err(|e| {
+                ClientError::new(
+                    ErrorKind::ClientInternal,
+                    "receive message failed: error in reading stream",
+                    Self::OPERATION_RECEIVE_MESSAGE,
+                )
+                .set_source(e)
+            })?;
+            responses.push(response);
+        }
+        Ok(responses)
+    }
+
+    async fn ack_message(
+        &mut self,
+        request: AckMessageRequest,
+    ) -> Result<AckMessageResponse, ClientError> {
+        let request = self.sign(tonic::Request::new(request));
+        let response = self.stub.ack_message(request).await.map_err(|e| {
+            ClientError::new(
+                ErrorKind::ClientInternal,
+                "send rpc ack_message failed",
+                Self::OPERATION_ACK_MESSAGE,
             )
             .set_source(e)
         })?;
@@ -209,7 +390,7 @@ pub(crate) struct SessionManager {
 
 impl SessionManager {
     pub(crate) fn new(logger: &Logger, client_id: String, option: &ClientOption) -> Self {
-        let logger = logger.new(o!("component" => "session_manager"));
+        let logger = logger.new(o!("component" => "session"));
         let session_map = Mutex::new(HashMap::new());
         SessionManager {
             logger,
@@ -219,30 +400,47 @@ impl SessionManager {
         }
     }
 
-    pub(crate) async fn get_session(&self, endpoints: &Endpoints) -> Result<Session, ClientError> {
+    pub(crate) async fn get_or_create_session(
+        &self,
+        endpoints: &Endpoints,
+        settings: TelemetryCommand,
+    ) -> Result<Session, ClientError> {
         let mut session_map = self.session_map.lock().await;
         let endpoint_url = endpoints.endpoint_url().to_string();
         return if session_map.contains_key(&endpoint_url) {
             Ok(session_map.get(&endpoint_url).unwrap().clone())
         } else {
-            let session = Session::new(
+            let mut session = Session::new(
                 &self.logger,
                 endpoints,
                 self.client_id.clone(),
                 &self.option,
             )
             .await?;
+            session.start(settings).await?;
             session_map.insert(endpoint_url.clone(), session.clone());
             Ok(session)
         };
+    }
+
+    pub(crate) async fn get_all_sessions(&self) -> Result<Vec<Session>, ClientError> {
+        let session_map = self.session_map.lock().await;
+        let mut sessions = Vec::new();
+        for (_, session) in session_map.iter() {
+            sessions.push(session.clone());
+        }
+        Ok(sessions)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::log::terminal_logger;
+    use crate::conf::ProducerOption;
     use slog::debug;
     use wiremock_grpc::generate;
+
+    use crate::log::terminal_logger;
+    use crate::util::build_producer_settings;
 
     use super::*;
 
@@ -260,6 +458,7 @@ mod tests {
         )
         .await;
         debug!(logger, "session: {:?}", session);
+        assert!(session.is_ok());
     }
 
     #[tokio::test]
@@ -273,17 +472,61 @@ mod tests {
         )
         .await;
         debug!(logger, "session: {:?}", session);
+        assert!(session.is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn session_start() {
+        let mut server = RocketMQMockServer::start_default().await;
+        server.setup(
+            MockBuilder::when()
+                //    👇 RPC prefix
+                .path("/apache.rocketmq.v2.MessagingService/Telemetry")
+                .then()
+                .return_status(Code::Ok),
+        );
+
+        let logger = terminal_logger();
+        let session = Session::new(
+            &logger,
+            &Endpoints::from_url(&format!("localhost:{}", server.address().port())).unwrap(),
+            "test_client".to_string(),
+            &ClientOption::default(),
+        )
+        .await;
+        debug!(logger, "session: {:?}", session);
+        assert!(session.is_ok());
+
+        let mut session = session.unwrap();
+
+        let result = session
+            .start(build_producer_settings(
+                &ProducerOption::default(),
+                &ClientOption::default(),
+            ))
+            .await;
+        assert!(result.is_ok());
+        assert!(session.is_started());
     }
 
     #[tokio::test]
     async fn session_manager_new() {
-        let server = RocketMQMockServer::start_default().await;
+        let mut server = RocketMQMockServer::start_default().await;
+        server.setup(
+            MockBuilder::when()
+                //    👇 RPC prefix
+                .path("/apache.rocketmq.v2.MessagingService/Telemetry")
+                .then()
+                .return_status(Code::Ok),
+        );
+
         let logger = terminal_logger();
         let session_manager =
             SessionManager::new(&logger, "test_client".to_string(), &ClientOption::default());
         let session = session_manager
-            .get_session(
+            .get_or_create_session(
                 &Endpoints::from_url(&format!("localhost:{}", server.address().port())).unwrap(),
+                build_producer_settings(&ProducerOption::default(), &ClientOption::default()),
             )
             .await
             .unwrap();

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -170,7 +170,6 @@ impl Session {
             //     .with_context("peer", &peer_addr)
             // })?
             .connect_timeout(option.timeout)
-            .timeout(option.timeout)
             .tcp_nodelay(true);
         Ok(endpoint)
     }
@@ -333,7 +332,8 @@ impl RPCClient for Session {
         request: ReceiveMessageRequest,
     ) -> Result<Vec<ReceiveMessageResponse>, ClientError> {
         let batch_size = request.batch_size;
-        let request = self.sign(tonic::Request::new(request));
+        let mut request = self.sign(tonic::Request::new(request));
+        request.set_timeout(*self.option.long_polling_timeout());
         let mut stream = self
             .stub
             .receive_message(request)

--- a/rust/src/simple_consumer.rs
+++ b/rust/src/simple_consumer.rs
@@ -83,10 +83,10 @@ impl SimpleConsumer {
 
     pub async fn receive(
         &self,
-        topic: &str,
+        topic: impl AsRef<str>,
         expression: &FilterExpression,
     ) -> Result<Vec<MessageView>, ClientError> {
-        self.receive_with_batch_size(topic, expression, 32, Duration::from_secs(15))
+        self.receive_with_batch_size(topic.as_ref(), expression, 32, Duration::from_secs(15))
             .await
     }
 

--- a/rust/src/simple_consumer.rs
+++ b/rust/src/simple_consumer.rs
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::time::Duration;
+
+use slog::{info, Logger};
+
+use crate::client::Client;
+use crate::conf::{ClientOption, SimpleConsumerOption};
+use crate::error::{ClientError, ErrorKind};
+use crate::model::common::{ClientType, FilterExpression};
+use crate::model::message::{AckMessageEntry, MessageView};
+use crate::util::{
+    build_endpoints_by_message_queue, build_simple_consumer_settings, select_message_queue,
+};
+use crate::{log, pb};
+
+#[derive(Debug)]
+pub struct SimpleConsumer {
+    option: SimpleConsumerOption,
+    logger: Logger,
+    client: Client,
+}
+
+impl SimpleConsumer {
+    const OPERATION_START_SIMPLE_CONSUMER: &'static str = "simple_consumer.start";
+    const OPERATION_RECEIVE_MESSAGE: &'static str = "simple_consumer.receive_message";
+
+    pub fn new(
+        option: SimpleConsumerOption,
+        client_option: ClientOption,
+    ) -> Result<Self, ClientError> {
+        let client_option = ClientOption {
+            client_type: ClientType::SimpleConsumer,
+            group: option.consumer_group().to_string(),
+            namespace: option.namespace().to_string(),
+            ..client_option
+        };
+        let logger = log::logger(option.logging_format());
+        let settings = build_simple_consumer_settings(&option, &client_option);
+        let client = Client::new(&logger, client_option, settings)?;
+        Ok(SimpleConsumer {
+            option,
+            logger,
+            client,
+        })
+    }
+
+    pub async fn start(&self) -> Result<(), ClientError> {
+        if self.option.consumer_group().is_empty() {
+            return Err(ClientError::new(
+                ErrorKind::Config,
+                "required option is missing: consumer group is empty",
+                Self::OPERATION_START_SIMPLE_CONSUMER,
+            ));
+        }
+        if let Some(topics) = self.option.topics() {
+            for topic in topics {
+                self.client.topic_route(topic, true).await?;
+            }
+        }
+        self.client.start();
+        info!(
+            self.logger,
+            "start simple consumer success, client_id: {}",
+            self.client.client_id()
+        );
+        Ok(())
+    }
+
+    pub async fn receive(
+        &self,
+        topic: &str,
+        expression: &FilterExpression,
+    ) -> Result<Vec<MessageView>, ClientError> {
+        self.receive_with_batch_size(topic, expression, 32, Duration::from_secs(15))
+            .await
+    }
+
+    pub async fn receive_with_batch_size(
+        &self,
+        topic: &str,
+        expression: &FilterExpression,
+        batch_size: i32,
+        invisible_duration: Duration,
+    ) -> Result<Vec<MessageView>, ClientError> {
+        let route = self.client.topic_route(topic, true).await?;
+        let message_queue = select_message_queue(route);
+        let endpoints =
+            build_endpoints_by_message_queue(&message_queue, Self::OPERATION_RECEIVE_MESSAGE)?;
+        let messages = self
+            .client
+            .receive_message(
+                &endpoints,
+                message_queue,
+                pb::FilterExpression {
+                    r#type: expression.filter_type as i32,
+                    expression: expression.expression.clone(),
+                },
+                batch_size,
+                prost_types::Duration::try_from(invisible_duration).unwrap(),
+            )
+            .await?;
+        Ok(messages
+            .into_iter()
+            .map(|message| MessageView::from_pb_message(message, endpoints.clone()))
+            .collect())
+    }
+
+    pub async fn ack(&self, ack_entry: impl AckMessageEntry) -> Result<(), ClientError> {
+        self.client.ack_message(ack_entry).await?;
+        Ok(())
+    }
+}

--- a/rust/src/util.rs
+++ b/rust/src/util.rs
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::hash::Hasher;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use crate::conf::{ClientOption, ProducerOption, SimpleConsumerOption};
+use siphasher::sip::SipHasher24;
+
+use crate::error::{ClientError, ErrorKind};
+use crate::model::common::{Endpoints, Route};
+use crate::pb::settings::PubSub;
+use crate::pb::telemetry_command::Command;
+use crate::pb::{
+    Language, MessageQueue, Publishing, Resource, Settings, Subscription, TelemetryCommand, Ua,
+};
+
+pub(crate) static SDK_LANGUAGE: Language = Language::Rust;
+pub(crate) static SDK_VERSION: &str = "5.0.0";
+pub(crate) static PROTOCOL_VERSION: &str = "2.0.0";
+
+lazy_static::lazy_static! {
+    pub(crate) static ref HOST_NAME: String = match hostname::get() {
+        Ok(name) => name.to_str().unwrap_or("localhost").to_string(),
+        Err(_) => "localhost".to_string(),
+    };
+}
+
+pub(crate) fn select_message_queue(route: Arc<Route>) -> MessageQueue {
+    let i = route.index.fetch_add(1, Ordering::Relaxed);
+    route.queue[i % route.queue.len()].clone()
+}
+
+pub(crate) fn select_message_queue_by_message_group(
+    route: Arc<Route>,
+    message_group: String,
+) -> MessageQueue {
+    let mut sip_hasher24 = SipHasher24::default();
+    sip_hasher24.write(message_group.as_bytes());
+    let index = sip_hasher24.finish() % route.queue.len() as u64;
+    route.queue[index as usize].clone()
+}
+
+pub(crate) fn build_endpoints_by_message_queue(
+    message_queue: &MessageQueue,
+    operation: &'static str,
+) -> Result<Endpoints, ClientError> {
+    let topic = message_queue.topic.clone().unwrap().name;
+    if message_queue.broker.is_none() {
+        return Err(ClientError::new(
+            ErrorKind::NoBrokerAvailable,
+            "message queue do not have a available endpoint",
+            operation,
+        )
+        .with_context("message_queue", format!("{:?}", message_queue)));
+    }
+
+    let broker = message_queue.broker.clone().unwrap();
+    if broker.endpoints.is_none() {
+        return Err(ClientError::new(
+            ErrorKind::NoBrokerAvailable,
+            "message queue do not have a available endpoint",
+            operation,
+        )
+        .with_context("broker", broker.name)
+        .with_context("topic", topic)
+        .with_context("queue_id", message_queue.id.to_string()));
+    }
+
+    Ok(Endpoints::from_pb_endpoints(broker.endpoints.unwrap()))
+}
+
+pub(crate) fn build_producer_settings(
+    option: &ProducerOption,
+    client_options: &ClientOption,
+) -> TelemetryCommand {
+    let topics = option
+        .topics()
+        .clone()
+        .unwrap_or(vec![])
+        .iter()
+        .map(|topic| Resource {
+            name: topic.to_string(),
+            resource_namespace: option.namespace().to_string(),
+        })
+        .collect();
+    let platform = os_type::current_platform();
+    TelemetryCommand {
+        command: Some(Command::Settings(Settings {
+            client_type: Some(client_options.client_type.clone() as i32),
+            request_timeout: Some(prost_types::Duration {
+                seconds: client_options.timeout().as_secs() as i64,
+                nanos: client_options.timeout().subsec_nanos() as i32,
+            }),
+            pub_sub: Some(PubSub::Publishing(Publishing {
+                topics,
+                validate_message_type: option.validate_message_type(),
+                ..Publishing::default()
+            })),
+            user_agent: Some(Ua {
+                language: SDK_LANGUAGE as i32,
+                version: SDK_VERSION.to_string(),
+                platform: format!("{:?} {}", platform.os_type, platform.version),
+                hostname: HOST_NAME.clone(),
+            }),
+            ..Settings::default()
+        })),
+        ..TelemetryCommand::default()
+    }
+}
+
+pub(crate) fn build_simple_consumer_settings(
+    option: &SimpleConsumerOption,
+    client_option: &ClientOption,
+) -> TelemetryCommand {
+    let platform = os_type::current_platform();
+    TelemetryCommand {
+        command: Some(Command::Settings(Settings {
+            client_type: Some(client_option.client_type.clone() as i32),
+            request_timeout: Some(prost_types::Duration {
+                seconds: client_option.timeout().as_secs() as i64,
+                nanos: client_option.timeout().subsec_nanos() as i32,
+            }),
+            pub_sub: Some(PubSub::Subscription(Subscription {
+                group: Some(Resource {
+                    name: option.consumer_group().to_string(),
+                    resource_namespace: option.namespace().to_string(),
+                }),
+                subscriptions: vec![],
+                fifo: Some(false),
+                receive_batch_size: None,
+                long_polling_timeout: Some(prost_types::Duration {
+                    seconds: client_option.long_polling_timeout().as_secs() as i64,
+                    nanos: client_option.long_polling_timeout().subsec_nanos() as i32,
+                }),
+            })),
+            user_agent: Some(Ua {
+                language: SDK_LANGUAGE as i32,
+                version: SDK_VERSION.to_string(),
+                platform: format!("{:?} {}", platform.os_type, platform.version),
+                hostname: HOST_NAME.clone(),
+            }),
+            ..Settings::default()
+        })),
+        ..TelemetryCommand::default()
+    }
+}


### PR DESCRIPTION
close #475 

Brief changelog:

1. implement heartbeat and telemetry rpc for both producer and simple consumer
2. implement receive and ack message rpc for simple consumer
3. add util module to abstract common functions
4. add simple consumer example and some tests