### PR TITLE
fix: setGroup() invoked twice when wrapAckMessageRequest()

### DIFF
--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumerImpl.java
@@ -128,7 +128,7 @@ abstract class ConsumerImpl extends ClientImpl {
             .setReceiptHandle(messageView.getReceiptHandle())
             .build();
         return AckMessageRequest.newBuilder().setGroup(getProtobufGroup()).setTopic(topicResource)
-            .setGroup(getProtobufGroup()).addEntries(entry).build();
+            .addEntries(entry).build();
     }
 
     private ChangeInvisibleDurationRequest wrapChangeInvisibleDuration(MessageViewImpl messageView,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

This modification is trivial, so I didn't create an issue.

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

When build `AckMessageRequest` in `wrapAckMessageRequest()` ` setGroup()` has been invoked twice, which is unnecessary.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

no need