### PR TITLE
Polish the cpp examples

### DIFF
--- a/cpp/examples/ExampleProducer.cpp
+++ b/cpp/examples/ExampleProducer.cpp
@@ -72,13 +72,14 @@ int main(int argc, char* argv[]) {
     credentials_provider = std::make_shared<StaticCredentialsProvider>(FLAGS_access_key, FLAGS_access_secret);
   }
 
-  // In most case, you don't need to create too many producers, singletion pattern is recommended.
+  // In most case, you don't need to create too many producers, singleton pattern is recommended.
   auto producer = Producer::newBuilder()
                       .withConfiguration(Configuration::newBuilder()
                                              .withEndpoints(FLAGS_access_point)
                                              .withCredentialsProvider(credentials_provider)
                                              .withSsl(true)
                                              .build())
+                      .withTopics({FLAGS_topic})
                       .build();
 
   std::atomic_bool stopped;

--- a/cpp/examples/ExampleProducerWithAsync.cpp
+++ b/cpp/examples/ExampleProducerWithAsync.cpp
@@ -118,6 +118,7 @@ int main(int argc, char* argv[]) {
                                              .withCredentialsProvider(credentials_provider)
                                              .withSsl(true)
                                              .build())
+                      .withTopics({FLAGS_topic})
                       .build();
 
   std::atomic_bool stopped;

--- a/cpp/examples/ExampleProducerWithFifoMessage.cpp
+++ b/cpp/examples/ExampleProducerWithFifoMessage.cpp
@@ -76,6 +76,7 @@ int main(int argc, char* argv[]) {
                                              .withCredentialsProvider(credentials_provider)
                                              .withSsl(true)
                                              .build())
+                      .withTopics({FLAGS_topic})
                       .build();
 
   std::atomic_bool stopped;


### PR DESCRIPTION
Add `withTopics` in cpp examples.
If this is not enabled, it will cause the connection between the client and the server to fail.