### PR TITLE
Switch back to VS2019 for passing the cpp build

### DIFF
--- a/.github/workflows/cpp_build.yml
+++ b/.github/workflows/cpp_build.yml
@@ -7,7 +7,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019, windows-2022]
+        # switch back to VS 2019 when https://github.com/bazelbuild/bazel/issues/18592 issue is solved
+        # os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019, windows-2022]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019]
     steps:
       - uses: actions/checkout@v2
       - name: Compile On Linux


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #569 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

This change only affects the Bazel build in the CI and makes the CI green again. Because of an update of Visual Studio the Bazel Windows Build is failing - more details here: https://github.com/bazelbuild/bazel/issues/18592

One workaround is to use VS 2019 for now, until this is fixed. Another option would be to modify the directory of VS2022. Once this is fixed the Bazel Windows CI build will switch back to VS2022.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
