### PR TITLE
Disable fail fast for GitHub Action matrix

### DIFF
--- a/.github/workflows/cpp_build.yml
+++ b/.github/workflows/cpp_build.yml
@@ -6,8 +6,9 @@ jobs:
     name: "${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        # switch back to VS 2019 when https://github.com/bazelbuild/bazel/issues/18592 issue is solved
+        # Disable VS 2022 before https://github.com/bazelbuild/bazel/issues/18592 issue is solved
         # os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019, windows-2022]
         os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019]
     steps:

--- a/.github/workflows/csharp_build.yml
+++ b/.github/workflows/csharp_build.yml
@@ -6,6 +6,7 @@ jobs:
     name: "${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2022]
     steps:

--- a/.github/workflows/golang_build.yml
+++ b/.github/workflows/golang_build.yml
@@ -6,6 +6,7 @@ jobs:
     name: "${{ matrix.os }}, go-${{ matrix.go }}"
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2022]
         go: [1.17]

--- a/.github/workflows/java_build.yml
+++ b/.github/workflows/java_build.yml
@@ -6,6 +6,7 @@ jobs:
     name: "${{ matrix.os }}, jdk-${{ matrix.jdk }}"
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2022]
         jdk: [11, 17]

--- a/.github/workflows/php_build.yml
+++ b/.github/workflows/php_build.yml
@@ -6,6 +6,7 @@ jobs:
     name: "${{ matrix.os }}, PHP-${{ matrix.php-version }}"
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         php-version: ["7.4", "8.0", "8.1"]
         os: [ubuntu-20.04, macos-11, windows-2022]

--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -74,6 +74,7 @@ jobs:
       run:
         working-directory: ./rust
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2022]
         msrv: [1.61]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #570 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

By default, the GitHub Actions matrix strategy enables a "fail-fast" mechanism, which leads to some build results in specific environments being invisible to us due to the cancellation of remaining tasks when any task fails. We hope to disable this "fail-fast" feature so that we can see the complete build results, as the remaining tasks will be allowed to continue running even if a task fails.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

No need testings.
