### PR TITLE
fix(doc): correct incorrect statements in Design and Workflow sections

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -55,7 +55,7 @@ Client identifier provides identity information for each client event within the
 
 * `macbook-pro`: hostname of device;
 * `90009`: process identifier;
-* `2`: client index within current process;
+* `0`: client index within current process;
 * `2dyeb8lep`: the unique string within process.
 
 >**Note**: Implementations of client identifier by different languages may vary slightly, but the uniqueness is the first principle that must be followed.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -75,7 +75,7 @@ The receiving procedure is as follows:
 1. Fetch the latest queue assignment from server.
 2. If flow control occurs during message receiving, consumer will retry after 20 milliseconds, otherwise go to step3.
 3. Cache message and trigger the consumption(Once the lifecycle of message is over, it will removed from cache immediately).
-4. Check if the cache is full. If the cache is full, the consumer will attempt to receive a message after 1 second, otherwise, it will retry immediately.
+4. Check if the cache is full. If the cache is full, the consumer will attempt to receive the message after 1 second; otherwise, it will retry immediately.
 
 ### Message Consumption in Push Consumer(Non-FIFO)
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -75,7 +75,7 @@ The receiving procedure is as follows:
 1. Fetch the latest queue assignment from server.
 2. If flow control occurs during message receiving, consumer will retry after 20 milliseconds, otherwise go to step3.
 3. Cache message and trigger the consumption(Once the lifecycle of message is over, it will removed from cache immediately).
-4. Check the cache is full, consumer will try to receive message immediately, otherwise retry after 1 seconds.
+4. Check if the cache is full. If the cache is full, the consumer will attempt to receive a message after 1 second, otherwise, it will retry immediately.
 
 ### Message Consumption in Push Consumer(Non-FIFO)
 


### PR DESCRIPTION
### Brief Description

1. The client identifier "macbook-pro@90009@0@2dyeb8lep" can be divided into four parts using the separator "@".Among these parts, the client index within the current process should be 0.

2. The sentence "Check the cache is full, consumer will try to receive message immediately, otherwise retry after 1 second" is expressed incorrectly. It should be stated that when the cache is full, the consumer should retry after 1 second.
