### PR TITLE
[ISSUE #608] Print message id and message queue when consume result is failure

### DIFF
--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeTask.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeTask.java
@@ -63,7 +63,8 @@ public class ConsumeTask implements Callable<ConsumeResult> {
         try {
             consumeResult = messageListener.consume(messageView);
         } catch (Throwable t) {
-            log.error("Message listener raised an exception while consuming messages, clientId={}", clientId, t);
+            log.error("Message listener raised an exception while consuming messages, clientId={}, mq={}, " +
+                "messageId={}", clientId, messageView.getMessageQueue(), messageView.getMessageId(), t);
             // If exception was thrown during the period of message consumption, mark it as failure.
             consumeResult = ConsumeResult.FAILURE;
         }


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #608

### Brief Description

Print message id and message queue when consume result is failure to provide more information.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
