### PR TITLE
python: doc mistake fixed

### DIFF
--- a/cpp/proto/apache/rocketmq/v2/service.proto
+++ b/cpp/proto/apache/rocketmq/v2/service.proto
@@ -207,7 +207,7 @@ message Publishing {
   int32 max_body_size = 2;
 
   // When `validate_message_type` flag set `false`, no need to validate message's type
-  // with messageQueue's `accept_message_types` before publising.
+  // with messageQueue's `accept_message_types` before publishing.
   bool validate_message_type = 3;
 }
 

--- a/cpp/third_party/opencensus/0.5.0-alpha/opencensus/stats/internal/stats_manager.h
+++ b/cpp/third_party/opencensus/0.5.0-alpha/opencensus/stats/internal/stats_manager.h
@@ -92,7 +92,7 @@ class StatsManager final {
   void AddMeasure(Measure<MeasureT> measure) ABSL_LOCKS_EXCLUDED(mu_);
 
   // Returns a handle that can be used to retrieve data for 'descriptor' (which
-  // may point to a new or re-used ViewInformation).
+  // may point to a new or reused ViewInformation).
   ViewInformation* AddConsumer(const ViewDescriptor& descriptor)
       ABSL_LOCKS_EXCLUDED(mu_);
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -42,7 +42,7 @@ The publishing procedure is as follows:
 1. Check if topic route is cached before or not.
 2. If topic route is not cached, then try to fetch it from server, otherwise go to step 4.
 3. Return failure and end the current process if topic route is failed to fetch, otherwise cache the topic route and go to the next step.
-4. Select writable candicate message queues from topic route to publish meessage.
+4. Select writable candicate message queues from topic route to publish message.
 5. Return failure and end the current process if the type of message queue is not matched with message type.
 6. Attempt to publish message.
 7. Return success and end the current process if message is published successfully.

--- a/php/grpc/Apache/Rocketmq/V2/AdminClient.php
+++ b/php/grpc/Apache/Rocketmq/V2/AdminClient.php
@@ -26,7 +26,7 @@ class AdminClient extends \Grpc\BaseStub {
     /**
      * @param string $hostname hostname
      * @param array $opts channel options
-     * @param \Grpc\Channel $channel (optional) re-use channel object
+     * @param \Grpc\Channel $channel (optional) reuse channel object
      */
     public function __construct($hostname, $opts, $channel = null) {
         parent::__construct($hostname, $opts, $channel);

--- a/php/grpc/Apache/Rocketmq/V2/MessagingServiceClient.php
+++ b/php/grpc/Apache/Rocketmq/V2/MessagingServiceClient.php
@@ -36,7 +36,7 @@ class MessagingServiceClient extends \Grpc\BaseStub {
     /**
      * @param string $hostname hostname
      * @param array $opts channel options
-     * @param \Grpc\Channel $channel (optional) re-use channel object
+     * @param \Grpc\Channel $channel (optional) reuse channel object
      */
     public function __construct($hostname, $opts, $channel = null) {
         parent::__construct($hostname, $opts, $channel);

--- a/php/grpc/Apache/Rocketmq/V2/Publishing.php
+++ b/php/grpc/Apache/Rocketmq/V2/Publishing.php
@@ -31,7 +31,7 @@ class Publishing extends \Google\Protobuf\Internal\Message
     protected $max_body_size = 0;
     /**
      * When `validate_message_type` flag set `false`, no need to validate message's type
-     * with messageQueue's `accept_message_types` before publising.
+     * with messageQueue's `accept_message_types` before publishing.
      *
      * Generated from protobuf field <code>bool validate_message_type = 3;</code>
      */
@@ -53,7 +53,7 @@ class Publishing extends \Google\Protobuf\Internal\Message
      *           client-side check validation.
      *     @type bool $validate_message_type
      *           When `validate_message_type` flag set `false`, no need to validate message's type
-     *           with messageQueue's `accept_message_types` before publising.
+     *           with messageQueue's `accept_message_types` before publishing.
      * }
      */
     public function __construct($data = NULL) {
@@ -123,7 +123,7 @@ class Publishing extends \Google\Protobuf\Internal\Message
 
     /**
      * When `validate_message_type` flag set `false`, no need to validate message's type
-     * with messageQueue's `accept_message_types` before publising.
+     * with messageQueue's `accept_message_types` before publishing.
      *
      * Generated from protobuf field <code>bool validate_message_type = 3;</code>
      * @return bool
@@ -135,7 +135,7 @@ class Publishing extends \Google\Protobuf\Internal\Message
 
     /**
      * When `validate_message_type` flag set `false`, no need to validate message's type
-     * with messageQueue's `accept_message_types` before publising.
+     * with messageQueue's `accept_message_types` before publishing.
      *
      * Generated from protobuf field <code>bool validate_message_type = 3;</code>
      * @param bool $var

--- a/php/protocol/apache/rocketmq/v2/service.proto
+++ b/php/protocol/apache/rocketmq/v2/service.proto
@@ -207,7 +207,7 @@ message Publishing {
   int32 max_body_size = 2;
 
   // When `validate_message_type` flag set `false`, no need to validate message's type
-  // with messageQueue's `accept_message_types` before publising.
+  // with messageQueue's `accept_message_types` before publishing.
   bool validate_message_type = 3;
 }
 

--- a/python/README.md
+++ b/python/README.md
@@ -6,7 +6,7 @@ English | [简体中文](README-CN.md) | [RocketMQ Website](https://rocketmq.apa
 
 Here is the Python implementation of the client for [Apache RocketMQ](https://rocketmq.apache.org/). Different from the [remoting-based client](https://github.com/apache/rocketmq/tree/develop/client), the current implementation is based on separating architecture for computing and storage, which is the more recommended way to access the RocketMQ service.
 
-Here are some preparations you may need to know (or refer to [here](https://rocketmq.apache.org/docs/quickStart/02quickstart/https://rocketmq.apache.org/docs/quickStart/02quickstart/)).
+Here are some preparations you may need to know (or refer to [here](https://rocketmq.apache.org/docs/quickStart/02quickstart/)).
 
 1. Python 3.7 is the minimum version required, Python 3.10 is the recommended version.
 2. Setup namesrv, broker, and [proxy](https://github.com/apache/rocketmq/tree/develop/proxy).


### PR DESCRIPTION
### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

In the doc for python client there is a broken url here
https://github.com/apache/rocketmq-clients/blob/92c627d55af415a5597ee9ea0efff27c313582b5/python/README.md?plain=1#L9
The problem is that the url is repeated twice.

### How Did You Test This Change?
Not needed