### PR TITLE
Sync state of consume-message-service according to start/shutdown lifecycle management

### DIFF
--- a/cpp/source/rocketmq/include/ConsumeMessageServiceImpl.h
+++ b/cpp/source/rocketmq/include/ConsumeMessageServiceImpl.h
@@ -30,48 +30,57 @@ ROCKETMQ_NAMESPACE_BEGIN
 
 class PushConsumerImpl;
 
-class ConsumeMessageServiceImpl : public ConsumeMessageService,
-                                  public std::enable_shared_from_this<ConsumeMessageServiceImpl> {
+class ConsumeMessageServiceImpl
+    : public ConsumeMessageService,
+      public std::enable_shared_from_this<ConsumeMessageServiceImpl> {
 public:
   ConsumeMessageServiceImpl(std::weak_ptr<PushConsumerImpl> consumer,
-                            int thread_count,
-                            MessageListener message_listener);
+                            int thread_count, MessageListener message_listener);
 
   ~ConsumeMessageServiceImpl() override = default;
 
   /**
    * Make it noncopyable.
    */
-  ConsumeMessageServiceImpl(const ConsumeMessageServiceImpl& other) = delete;
-  ConsumeMessageServiceImpl& operator=(const ConsumeMessageServiceImpl& other) = delete;
+  ConsumeMessageServiceImpl(const ConsumeMessageServiceImpl &other) = delete;
+  ConsumeMessageServiceImpl &
+  operator=(const ConsumeMessageServiceImpl &other) = delete;
 
   void start() override;
 
   void shutdown() override;
 
-  MessageListener& listener() override {
-    return message_listener_;
-  }
+  MessageListener &listener() override { return message_listener_; }
 
-  bool preHandle(const Message& message) override;
+  bool preHandle(const Message &message) override;
 
-  bool postHandle(const Message& message, ConsumeResult result) override;
+  bool postHandle(const Message &message, ConsumeResult result) override;
 
   void submit(std::shared_ptr<ConsumeTask> task) override;
 
-  void dispatch(std::shared_ptr<ProcessQueue> process_queue, std::vector<MessageConstSharedPtr> messages) override;
+  void dispatch(std::shared_ptr<ProcessQueue> process_queue,
+                std::vector<MessageConstSharedPtr> messages) override;
 
-  void ack(const Message& message, std::function<void(const std::error_code&)> cb) override;
+  void ack(const Message &message,
+           std::function<void(const std::error_code &)> cb) override;
 
-  void nack(const Message& message, std::function<void(const std::error_code&)> cb) override;
+  void nack(const Message &message,
+            std::function<void(const std::error_code &)> cb) override;
 
-  void forward(const Message& message, std::function<void(const std::error_code&)> cb) override;
+  void forward(const Message &message,
+               std::function<void(const std::error_code &)> cb) override;
 
-  void schedule(std::shared_ptr<ConsumeTask> task, std::chrono::milliseconds delay) override;
+  void schedule(std::shared_ptr<ConsumeTask> task,
+                std::chrono::milliseconds delay) override;
 
   std::size_t maxDeliveryAttempt() override;
 
   std::weak_ptr<PushConsumerImpl> consumer() override;
+
+  /**
+   * Current state of the consume message service.
+   */
+  State state() const;
 
 protected:
   std::atomic<State> state_;

--- a/cpp/source/rocketmq/tests/BUILD.bazel
+++ b/cpp/source/rocketmq/tests/BUILD.bazel
@@ -52,3 +52,11 @@ cc_test(
     ],
     deps = base_deps,
 )
+
+cc_test(
+    name = "consume_message_service_test",
+    srcs = [
+        "ConsumeMessageServiceTest.cpp",
+    ],
+    deps = base_deps,
+)

--- a/cpp/source/rocketmq/tests/ConsumeMessageServiceTest.cpp
+++ b/cpp/source/rocketmq/tests/ConsumeMessageServiceTest.cpp
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <memory>
+
+#include "ConsumeMessageServiceImpl.h"
+#include "PushConsumerImpl.h"
+#include "gtest/gtest.h"
+#include "rocketmq/ConsumeResult.h"
+#include "rocketmq/RocketMQ.h"
+
+ROCKETMQ_NAMESPACE_BEGIN
+
+TEST(ConsumeMessageServiceTest, testLifecycle) {
+  auto listener = [](const Message&) { return ConsumeResult::SUCCESS; };
+  std::weak_ptr<PushConsumerImpl> consumer;
+  auto svc = std::make_shared<ConsumeMessageServiceImpl>(consumer, 2, listener);
+  svc->start();
+  ASSERT_EQ(State::STARTED, svc->state());
+
+  svc->shutdown();
+  ASSERT_EQ(State::STOPPED, svc->state());
+}
+
+ROCKETMQ_NAMESPACE_END


### PR DESCRIPTION
…tdown lifecycle management

<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes
fix #521 
<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #issue_id

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
