### PR TITLE
update out-of-date java client examples

### DIFF
--- a/java/client/src/main/java/org/apache/rocketmq/client/java/example/AsyncProducerExample.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/example/AsyncProducerExample.java
@@ -67,6 +67,6 @@ public class AsyncProducerExample {
         Thread.sleep(Long.MAX_VALUE);
         // Close the producer when you don't need it anymore.
         // You could close it manually or add this into the JVM shutdown hook.
-        // producer.shutdown();
+        // producer.close();
     }
 }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/example/AsyncSimpleConsumerExample.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/example/AsyncSimpleConsumerExample.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Semaphore;
 import java.util.stream.Collectors;
 import org.apache.rocketmq.client.apis.ClientConfiguration;
 import org.apache.rocketmq.client.apis.ClientException;
@@ -46,7 +45,7 @@ public class AsyncSimpleConsumerExample {
     }
 
     @SuppressWarnings({"resource", "InfiniteLoopStatement"})
-    public static void main(String[] args) throws ClientException, InterruptedException {
+    public static void main(String[] args) throws ClientException {
         final ClientServiceProvider provider = ClientServiceProvider.loadService();
 
         // Credential provider is optional for client configuration.
@@ -78,9 +77,6 @@ public class AsyncSimpleConsumerExample {
             // Set the subscription for the consumer.
             .setSubscriptionExpressions(Collections.singletonMap(topic, filterExpression))
             .build();
-        // Max polling request size
-        int maxPollingSize = 32;
-        Semaphore semaphore = new Semaphore(maxPollingSize);
         // Max message num for each long polling.
         int maxMessageNum = 16;
         // Set message invisible duration after it is received.
@@ -91,11 +87,9 @@ public class AsyncSimpleConsumerExample {
         ExecutorService ackCallbackExecutor = Executors.newCachedThreadPool();
         // Receive message.
         do {
-            semaphore.acquire();
             final CompletableFuture<List<MessageView>> future0 = consumer.receiveAsync(maxMessageNum,
                 invisibleDuration);
             future0.whenCompleteAsync(((messages, throwable) -> {
-                semaphore.release();
                 if (null != throwable) {
                     log.error("Failed to receive message from remote", throwable);
                     // Return early.

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/example/ProducerDelayMessageExample.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/example/ProducerDelayMessageExample.java
@@ -61,6 +61,6 @@ public class ProducerDelayMessageExample {
         }
         // Close the producer when you don't need it anymore.
         // You could close it manually or add this into the JVM shutdown hook.
-        // producer.shutdown();
+        // producer.close();
     }
 }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/example/ProducerFifoMessageExample.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/example/ProducerFifoMessageExample.java
@@ -59,6 +59,6 @@ public class ProducerFifoMessageExample {
         }
         // Close the producer when you don't need it anymore.
         // You could close it manually or add this into the JVM shutdown hook.
-        // producer.shutdown();
+        // producer.close();
     }
 }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/example/ProducerNormalMessageExample.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/example/ProducerNormalMessageExample.java
@@ -57,6 +57,6 @@ public class ProducerNormalMessageExample {
         }
         // Close the producer when you don't need it anymore.
         // You could close it manually or add this into the JVM shutdown hook.
-        // producer.shutdown();
+        // producer.close();
     }
 }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/example/ProducerTransactionMessageExample.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/example/ProducerTransactionMessageExample.java
@@ -73,6 +73,6 @@ public class ProducerTransactionMessageExample {
 
         // Close the producer when you don't need it anymore.
         // You could close it manually or add this into the JVM shutdown hook.
-        // producer.shutdown();
+        // producer.close();
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

no issue related

### Brief Description

1. java client producer examples have some out-of-date comments;
2. add maxPollingSize limit in AsyncSimpleConsumerExample, to avoid "polling full" error.

### How Did You Test This Change?

no need to test
