### PR TITLE
Replace lazy_static with once_cell

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -36,7 +36,6 @@ tokio = { version = "1", features = ["full"] }
 tokio-rustls = { version = "0.24.0", features = ["default", "dangerous_configuration"] }
 tokio-stream = "0.1.12"
 async-trait = "0.1.68"
-lazy_static = "1.4"
 tonic = { version = "0.9.0", features = ["tls", "default", "channel", "tls-roots"] }
 prost = "0.11.8"
 prost-types = "0.11.8"
@@ -60,7 +59,7 @@ byteorder = "1"
 mac_address = "1.1.4"
 hex = "0.4.3"
 time = "0.3"
-once_cell = "1.9.0"
+once_cell = "1.18.0"
 
 mockall = "0.11.4"
 mockall_double = "0.3.0"

--- a/rust/examples/transaction_producer.rs
+++ b/rust/examples/transaction_producer.rs
@@ -17,14 +17,13 @@
 use std::collections::HashSet;
 use std::sync::Mutex;
 
+use once_cell::sync::Lazy;
 use rocketmq::conf::{ClientOption, ProducerOption};
 use rocketmq::model::message::MessageBuilder;
 use rocketmq::model::transaction::{Transaction, TransactionResolution};
 use rocketmq::Producer;
 
-lazy_static::lazy_static! {
-    static  ref MESSAGE_ID_SET: Mutex<HashSet<String>> = Mutex::new(HashSet::new());
-}
+static MESSAGE_ID_SET: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
 
 #[tokio::main]
 async fn main() {

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -21,6 +21,7 @@ use std::{collections::HashMap, sync::atomic::AtomicUsize, sync::Arc};
 
 use mockall::automock;
 use mockall_double::double;
+use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use prost_types::Duration;
 use slog::{debug, error, info, o, warn, Logger};
@@ -58,9 +59,7 @@ pub(crate) struct Client {
     shutdown_tx: Option<oneshot::Sender<()>>,
 }
 
-lazy_static::lazy_static! {
-    static ref CLIENT_ID_SEQUENCE: AtomicUsize = AtomicUsize::new(0);
-}
+static CLIENT_ID_SEQUENCE: Lazy<AtomicUsize> = Lazy::new(|| AtomicUsize::new(0));
 
 const OPERATION_CLIENT_NEW: &str = "client.new";
 const OPERATION_CLIENT_START: &str = "client.start";
@@ -698,7 +697,7 @@ pub(crate) mod tests {
     use std::thread::sleep;
     use std::time::Duration;
 
-    use lazy_static::lazy_static;
+    use once_cell::sync::Lazy;
 
     use crate::client::Client;
     use crate::conf::ClientOption;
@@ -717,10 +716,8 @@ pub(crate) mod tests {
 
     use super::*;
 
-    lazy_static! {
-        // The lock is used to prevent the mocking static function at same time during parallel testing.
-        pub(crate) static ref MTX: Mutex<()> = Mutex::new(());
-    }
+    // The lock is used to prevent the mocking static function at same time during parallel testing.
+    pub(crate) static MTX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
     fn new_client_for_test() -> Client {
         Client {

--- a/rust/src/util.rs
+++ b/rust/src/util.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use once_cell::sync::Lazy;
 use std::hash::Hasher;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -33,12 +34,10 @@ pub(crate) static SDK_LANGUAGE: Language = Language::Rust;
 pub(crate) static SDK_VERSION: &str = "5.0.0";
 pub(crate) static PROTOCOL_VERSION: &str = "2.0.0";
 
-lazy_static::lazy_static! {
-    pub(crate) static ref HOST_NAME: String = match hostname::get() {
-        Ok(name) => name.to_str().unwrap_or("localhost").to_string(),
-        Err(_) => "localhost".to_string(),
-    };
-}
+pub(crate) static HOST_NAME: Lazy<String> = Lazy::new(|| match hostname::get() {
+    Ok(name) => name.to_str().unwrap_or("localhost").to_string(),
+    Err(_) => "localhost".to_string(),
+});
 
 pub(crate) fn select_message_queue(route: Arc<Route>) -> MessageQueue {
     let i = route.index.fetch_add(1, Ordering::Relaxed);


### PR DESCRIPTION
lazy_static is almost inactive, most of the projects in the rust community use once_cell instead of lazy_static, while once_cell's performance is  [a little bit more](https://github.com/matklad/once_cell/tree/master/examples) and the development is active.

1. remove lazy_static dependency
2. upgrade once_cell