### PR TITLE
[rust]support message type check on rust client

### DIFF
--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -33,6 +33,9 @@ pub enum ErrorKind {
     #[error("Message is invalid")]
     InvalidMessage,
 
+    #[error("Message type not match with topic accept message type")]
+    MessageTypeNotMatch,
+
     #[error("Server error")]
     Server,
 

--- a/rust/src/model/message.rs
+++ b/rust/src/model/message.rs
@@ -25,6 +25,7 @@ use crate::model::message::MessageType::{DELAY, FIFO, NORMAL, TRANSACTION};
 use crate::model::message_id::UNIQ_ID_GENERATOR;
 use crate::pb;
 
+#[derive(Clone)]
 pub enum MessageType {
     NORMAL = 1,
     FIFO = 2,
@@ -107,7 +108,7 @@ impl Message for MessageImpl {
     }
 
     fn get_message_type(&self) -> i32 {
-        transform_to_pb_message_type(&self.message_type)
+        self.message_type.clone() as i32
     }
 }
 

--- a/rust/src/model/message.rs
+++ b/rust/src/model/message.rs
@@ -33,16 +33,6 @@ pub enum MessageType {
     TRANSACTION = 4,
 }
 
-fn transform_to_pb_message_type(message_type: &MessageType) -> i32 {
-    let pb_message_type = match message_type {
-        NORMAL => pb::MessageType::Normal as i32,
-        FIFO => pb::MessageType::Fifo as i32,
-        DELAY => pb::MessageType::Delay as i32,
-        TRANSACTION => pb::MessageType::Transaction as i32,
-    };
-    pb_message_type
-}
-
 /// [`Message`] is the data model for sending.
 pub trait Message {
     fn take_message_id(&mut self) -> String;

--- a/rust/src/producer.rs
+++ b/rust/src/producer.rs
@@ -263,7 +263,8 @@ impl Producer {
                             message_type, message_queue.accept_message_types
                         )
                         .as_str(),
-                        Self::OPERATION_SEND_MESSAGE));
+                        Self::OPERATION_SEND_MESSAGE,
+                    ));
                 }
             }
         }

--- a/rust/src/producer.rs
+++ b/rust/src/producer.rs
@@ -504,7 +504,7 @@ mod tests {
                             addresses: vec![],
                         }),
                     }),
-                    accept_message_types: vec![1],
+                    accept_message_types: vec![MessageType::NORMAL as i32],
                 }],
             }))
         });
@@ -552,7 +552,7 @@ mod tests {
                             addresses: vec![],
                         }),
                     }),
-                    accept_message_types: vec![4],
+                    accept_message_types: vec![MessageType::TRANSACTION as i32],
                 }],
             }))
         });

--- a/rust/src/producer.rs
+++ b/rust/src/producer.rs
@@ -256,10 +256,14 @@ impl Producer {
         if self.option.validate_message_type() {
             for message_type in message_type_check_vec {
                 if !message_queue.accept_message_types.contains(&message_type) {
-                    return Err(ClientError::new(ErrorKind::MessageTypeNotMatch,
-                                                format!("Current message type {} not match with accepted types {:?}.",
-                                                        message_type, message_queue.accept_message_types).as_str(),
-                                                Self::OPERATION_SEND_MESSAGE));
+                    return Err(ClientError::new(
+                        ErrorKind::MessageTypeNotMatch,
+                        format!(
+                            "Current message type {} not match with accepted types {:?}.",
+                            message_type, message_queue.accept_message_types
+                        )
+                        .as_str(),
+                        Self::OPERATION_SEND_MESSAGE));
                 }
             }
         }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #issue_id

### Brief Description

The rust client doesn't have feature of checking message type with topic type. This pull request is to implement it.

### How Did You Test This Change?

I've modified test cases in producer.rs to ensure tests to pass. Those tests are quite sufficient to test this feature.
