### PR TITLE
[rust]support handling settings command in telemetry rpc

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -26,8 +26,8 @@ use parking_lot::Mutex;
 use prost_types::Duration;
 use slog::{debug, error, info, o, warn, Logger};
 use tokio::select;
-use tokio::sync::{mpsc, oneshot};
 use tokio::sync::RwLock as TokioRwLock;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::conf::ClientOption;
 use crate::error::{ClientError, ErrorKind};
@@ -327,7 +327,10 @@ impl Client {
             .session_manager
             .get_or_create_session(
                 &self.access_endpoints,
-                self.settings.read().await.to_telemetry_command(&self.option),
+                self.settings
+                    .read()
+                    .await
+                    .to_telemetry_command(&self.option),
                 self.telemetry_command_tx.clone().unwrap(),
             )
             .await?;
@@ -342,7 +345,10 @@ impl Client {
             .session_manager
             .get_or_create_session(
                 endpoints,
-                self.settings.read().await.to_telemetry_command(&self.option),
+                self.settings
+                    .read()
+                    .await
+                    .to_telemetry_command(&self.option),
                 self.telemetry_command_tx.clone().unwrap(),
             )
             .await?;

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -27,7 +27,7 @@ use prost_types::Duration;
 use slog::{debug, error, info, o, warn, Logger};
 use tokio::select;
 use tokio::sync::{mpsc, oneshot};
-use tokio::sync::Mutex as TokioMutex;
+use tokio::sync::RwLock as TokioRwLock;
 
 use crate::conf::ClientOption;
 use crate::error::{ClientError, ErrorKind};
@@ -55,7 +55,7 @@ pub(crate) struct Client {
     route_table: Mutex<HashMap<String /* topic */, RouteStatus>>,
     id: String,
     access_endpoints: Endpoints,
-    settings: Arc<TokioMutex<dyn common::Settings>>,
+    settings: Arc<TokioRwLock<dyn common::Settings>>,
     transaction_checker: Option<Box<TransactionChecker>>,
     telemetry_command_tx: Option<mpsc::Sender<pb::telemetry_command::Command>>,
     shutdown_tx: Option<oneshot::Sender<()>>,
@@ -90,7 +90,7 @@ impl Client {
     pub(crate) fn new(
         logger: &Logger,
         option: ClientOption,
-        settings: Arc<TokioMutex<dyn common::Settings>>,
+        settings: Arc<TokioRwLock<dyn common::Settings>>,
     ) -> Result<Self, ClientError> {
         let id = Self::generate_client_id();
         let endpoints = Endpoints::from_url(option.access_url())
@@ -247,7 +247,7 @@ impl Client {
         transaction_checker: &Option<Box<TransactionChecker>>,
         endpoints: Endpoints,
         command: pb::telemetry_command::Command,
-        settings: Arc<TokioMutex<dyn common::Settings>>,
+        settings: Arc<TokioRwLock<dyn common::Settings>>,
     ) -> Result<(), ClientError> {
         return match command {
             RecoverOrphanedTransactionCommand(command) => {
@@ -286,7 +286,7 @@ impl Client {
                 }
             }
             Settings(settings_command) => {
-                settings.lock().await.sync(settings_command);
+                settings.write().await.sync(settings_command);
                 Ok(())
             }
             _ => Err(ClientError::new(
@@ -327,7 +327,7 @@ impl Client {
             .session_manager
             .get_or_create_session(
                 &self.access_endpoints,
-                self.settings.lock().await.to_telemetry_command(&self.option),
+                self.settings.read().await.to_telemetry_command(&self.option),
                 self.telemetry_command_tx.clone().unwrap(),
             )
             .await?;
@@ -342,7 +342,7 @@ impl Client {
             .session_manager
             .get_or_create_session(
                 endpoints,
-                self.settings.lock().await.to_telemetry_command(&self.option),
+                self.settings.read().await.to_telemetry_command(&self.option),
                 self.telemetry_command_tx.clone().unwrap(),
             )
             .await?;
@@ -706,7 +706,7 @@ pub(crate) mod tests {
 
     use once_cell::sync::Lazy;
     use parking_lot::Mutex;
-    use tokio::sync::Mutex as TokioMutex;
+    use tokio::sync::RwLock as TokioRwLock;
 
     use crate::client::Client;
     use crate::conf::{ClientOption, ProducerOption};
@@ -740,7 +740,7 @@ pub(crate) mod tests {
             route_table: Mutex::new(HashMap::new()),
             id: Client::generate_client_id(),
             access_endpoints: Endpoints::from_url("http://localhost:8081").unwrap(),
-            settings: Arc::new(TokioMutex::new(common::MockSettings::new())),
+            settings: Arc::new(TokioRwLock::new(common::MockSettings::new())),
             transaction_checker: None,
             telemetry_command_tx: None,
             shutdown_tx: None,
@@ -756,7 +756,7 @@ pub(crate) mod tests {
             route_table: Mutex::new(HashMap::new()),
             id: Client::generate_client_id(),
             access_endpoints: Endpoints::from_url("http://localhost:8081").unwrap(),
-            settings: Arc::new(TokioMutex::new(ProducerOption::default())),
+            settings: Arc::new(TokioRwLock::new(ProducerOption::default())),
             transaction_checker: None,
             telemetry_command_tx: Some(tx),
             shutdown_tx: None,
@@ -778,7 +778,7 @@ pub(crate) mod tests {
         Client::new(
             &terminal_logger(),
             ClientOption::default(),
-            Arc::new(TokioMutex::new(ProducerOption::default())),
+            Arc::new(TokioRwLock::new(ProducerOption::default())),
         )?;
         Ok(())
     }
@@ -1169,7 +1169,7 @@ pub(crate) mod tests {
                 }),
                 transaction_id: "".to_string(),
             }),
-            Arc::new(TokioMutex::new(common::MockSettings::new())),
+            Arc::new(TokioRwLock::new(common::MockSettings::new())),
         )
         .await;
         assert!(result.is_ok())
@@ -1178,7 +1178,7 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn client_handle_settings_command() {
         let mock = session::MockRPCClient::new();
-        let producer_option = Arc::new(TokioMutex::new(ProducerOption::default()));
+        let producer_option = Arc::new(TokioRwLock::new(ProducerOption::default()));
         let mut remote_producer_option = ProducerOption::default();
         remote_producer_option.set_validate_message_type(false);
         let client_option = ClientOption::default();
@@ -1189,10 +1189,10 @@ pub(crate) mod tests {
             util::build_producer_settings(&remote_producer_option, &client_option)
                 .command
                 .unwrap(),
-            Arc::clone(&producer_option) as Arc<TokioMutex<ProducerOption>>,
+            Arc::clone(&producer_option) as Arc<TokioRwLock<ProducerOption>>,
         )
         .await;
         assert!(result.is_ok());
-        assert!(!producer_option.lock().await.validate_message_type())
+        assert!(!producer_option.read().await.validate_message_type())
     }
 }

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -275,7 +275,7 @@ impl SimpleConsumerOption {
 
 impl Settings for SimpleConsumerOption {
     fn to_telemetry_command(&self, client_option: &ClientOption) -> TelemetryCommand {
-        build_simple_consumer_settings(&self, client_option)
+        build_simple_consumer_settings(self, client_option)
     }
 
     fn sync(&mut self, _settings_command: crate::pb::Settings) {

--- a/rust/src/model/common.rs
+++ b/rust/src/model/common.rs
@@ -17,15 +17,17 @@
 
 //! Common data model of RocketMQ rust client.
 
+use mockall::automock;
 use std::net::IpAddr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
+use crate::conf::ClientOption;
 use tokio::sync::oneshot;
 
 use crate::error::{ClientError, ErrorKind};
 use crate::pb;
-use crate::pb::{Address, AddressScheme, MessageQueue};
+use crate::pb::{Address, AddressScheme, MessageQueue, TelemetryCommand};
 
 #[derive(Debug, Clone)]
 pub(crate) enum ClientType {
@@ -255,6 +257,13 @@ impl SendReceipt {
     pub fn transaction_id(&self) -> &str {
         &self.transaction_id
     }
+}
+
+#[automock]
+pub(crate) trait Settings: Send + Sync {
+    fn to_telemetry_command(&self, client_option: &ClientOption) -> TelemetryCommand;
+
+    fn sync(&mut self, settings_command: pb::Settings);
 }
 
 #[cfg(test)]

--- a/rust/src/producer.rs
+++ b/rust/src/producer.rs
@@ -19,9 +19,9 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use mockall_double::double;
-use tokio::sync::RwLock;
 use prost_types::Timestamp;
 use slog::{info, Logger};
+use tokio::sync::RwLock;
 
 #[double]
 use crate::client::Client;
@@ -68,12 +68,8 @@ impl Producer {
         };
         let logger = log::logger(option.logging_format());
         let producer_option = Arc::new(RwLock::new(option));
-        let settings= Arc::clone(&producer_option) ;
-        let client = Client::new(
-            &logger,
-            client_option,
-            settings,
-        )?;
+        let settings = Arc::clone(&producer_option);
+        let client = Client::new(&logger, client_option, settings)?;
         Ok(Producer {
             option: producer_option,
             logger,

--- a/rust/src/simple_consumer.rs
+++ b/rust/src/simple_consumer.rs
@@ -26,7 +26,7 @@ use slog::{info, Logger};
 use crate::client::Client;
 use crate::conf::{ClientOption, SimpleConsumerOption};
 use crate::error::{ClientError, ErrorKind};
-use crate::model::common::{ClientType, FilterExpression};
+use crate::model::common::{ClientType, FilterExpression, Settings};
 use crate::model::message::{AckMessageEntry, MessageView};
 use crate::util::{build_endpoints_by_message_queue, select_message_queue};
 use crate::{log, pb};
@@ -73,8 +73,7 @@ impl SimpleConsumer {
         };
         let logger = log::logger(option.logging_format());
         let consumer_option = Arc::new(RwLock::new(option));
-        let o1 = Arc::clone(&consumer_option);
-        let client = Client::new(&logger, client_option, o1)?;
+        let client = Client::new(&logger, client_option, Arc::clone(&consumer_option) as Arc<RwLock<dyn Settings>>)?;
         Ok(SimpleConsumer {
             option: consumer_option,
             logger,

--- a/rust/src/simple_consumer.rs
+++ b/rust/src/simple_consumer.rs
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-use tokio::sync::RwLock;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::RwLock;
 
 use mockall_double::double;
 use slog::{info, Logger};

--- a/rust/src/simple_consumer.rs
+++ b/rust/src/simple_consumer.rs
@@ -73,7 +73,11 @@ impl SimpleConsumer {
         };
         let logger = log::logger(option.logging_format());
         let consumer_option = Arc::new(RwLock::new(option));
-        let client = Client::new(&logger, client_option, Arc::clone(&consumer_option) as Arc<RwLock<dyn Settings>>)?;
+        let client = Client::new(
+            &logger,
+            client_option,
+            Arc::clone(&consumer_option) as Arc<RwLock<dyn Settings>>,
+        )?;
         Ok(SimpleConsumer {
             option: consumer_option,
             logger,

--- a/rust/src/simple_consumer.rs
+++ b/rust/src/simple_consumer.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use parking_lot::RwLock;
+use tokio::sync::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -42,7 +42,7 @@ use crate::{log, pb};
 /// [`SimpleConsumer`] is `Send` and `Sync` by design, so that developers may get started easily.
 #[derive(Debug)]
 pub struct SimpleConsumer {
-    option: Arc<RwLock<SimpleConsumerOption>>,
+    option: Arc<Mutex<SimpleConsumerOption>>,
     logger: Logger,
     client: Client,
 }
@@ -72,11 +72,11 @@ impl SimpleConsumer {
             ..client_option
         };
         let logger = log::logger(option.logging_format());
-        let consumer_option = Arc::new(RwLock::new(option));
+        let consumer_option = Arc::new(Mutex::new(option));
         let client = Client::new(
             &logger,
             client_option,
-            Arc::clone(&consumer_option) as Arc<RwLock<dyn Settings>>,
+            Arc::clone(&consumer_option) as Arc<Mutex<dyn Settings>>,
         )?;
         Ok(SimpleConsumer {
             option: consumer_option,
@@ -87,7 +87,7 @@ impl SimpleConsumer {
 
     /// Start the simple consumer
     pub async fn start(&mut self) -> Result<(), ClientError> {
-        if self.option.read().consumer_group().is_empty() {
+        if self.option.lock().await.consumer_group().is_empty() {
             return Err(ClientError::new(
                 ErrorKind::Config,
                 "required option is missing: consumer group is empty",
@@ -95,7 +95,7 @@ impl SimpleConsumer {
             ));
         }
         self.client.start().await?;
-        if let Some(topics) = self.option.read().topics() {
+        if let Some(topics) = self.option.lock().await.topics() {
             for topic in topics {
                 self.client.topic_route(topic, true).await?;
             }
@@ -273,7 +273,7 @@ mod tests {
             .expect_ack_message()
             .returning(|_: &MessageView| Ok(AckMessageResultEntry::default()));
         let simple_consumer = SimpleConsumer {
-            option: Arc::new(RwLock::new(SimpleConsumerOption::default())),
+            option: Arc::new(Mutex::new(SimpleConsumerOption::default())),
             logger: terminal_logger(),
             client,
         };


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #598 
Fixes #634 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

I added code that handles settings command in telemetry rpc call. At this moment , I have only implemented updating validate_message_type in ProducerOption. More will be added in future.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

add test case client_handle_settings_command
