### PR TITLE
[JAVA]only readable message queues are allowed to be assigned to push consumer

### DIFF
--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
@@ -34,6 +34,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -389,6 +390,14 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
                             }
                             log.info("Attention!!! acquired empty assignments from remote, but existed assignments"
                                 + " is not empty, topic={}, clientId={}", topic, clientId);
+                        } else {
+                            List<Assignment> newAssignmentList = new ArrayList<>(latest.getAssignmentList().size());
+                            for (Assignment assignment : latest.getAssignmentList()) {
+                                if (assignment.getMessageQueue().getPermission().isReadable()) {
+                                    newAssignmentList.add(assignment);
+                                }
+                            }
+                            latest = new Assignments(newAssignmentList);
                         }
 
                         if (!latest.equals(existed)) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

When PushConsumer gets new assignments from the server, it does not check permission of message queues.

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
