### PR TITLE
[rust] support handling settings command in Producer

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -58,7 +58,7 @@ minitrace = "0.4"
 byteorder = "1"
 mac_address = "1.1.4"
 hex = "0.4.3"
-time = "0.3"
+time = { version = "0.3", features = ["local-offset"] }
 once_cell = "1.18.0"
 
 mockall = "0.11.4"


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #634 
Fixes #598

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

I've refactored the way of processing telemetry commands. Now the transaction command from the server is processed in Producer instead of Client.  The client with different types can handle telemetry command within its own impl block.


### How Did You Test This Change?

run cargo test and example to make sure it works
