### PR TITLE
To fix the compilation failure issue of Rust RocketMQ SDK version 5.0.0 

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -59,7 +59,7 @@ minitrace = "0.4"
 byteorder = "1"
 mac_address = "1.1.4"
 hex = "0.4.3"
-time = "0.3"
+time = {version   = "0.3", features = ["local-offset"]}
 once_cell = "1.9.0"
 
 mockall = "0.11.4"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -59,7 +59,7 @@ minitrace = "0.4"
 byteorder = "1"
 mac_address = "1.1.4"
 hex = "0.4.3"
-time = {version   = "0.3", features = ["local-offset"]}
+time = {version = "0.3", features = ["local-offset"]}
 once_cell = "1.9.0"
 
 mockall = "0.11.4"


### PR DESCRIPTION
```
weisong@bj-dl-016:~/work/xremote/server/notification$ cargo check
    Checking rocketmq v5.0.0
error[E0599]: no function or associated item named `now_local` found for struct `OffsetDateTime` in the current scope
   --> /home/weisong/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rocketmq-5.0.0/src/session.rs:253:48
    |
253 |         let date_time_result = OffsetDateTime::now_local();
    |                                                ^^^^^^^^^
    |                                                |
    |                                                function or associated item not found in `OffsetDateTime`
    |                                                help: there is an associated function with a similar name: `now_utc`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `rocketmq` (lib) due to previous error`
```
To fix the compilation failure issue of Rust RocketMQ SDK version 5.0.0, the root cause is that the version of the time library is limited to 0.3, but now the version 0.3.34 is being updated. The now_local method requires adding the feature "local-offset".