### PR TITLE
[rust]sync client settings periodically

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -447,11 +447,11 @@ where
         Ok(response)
     }
 
-    async fn sync_setting<T: RPCClient + 'static>(
-        mut rpc_client: T,
+    async fn sync_setting(
+        mut session: Session,
         command: TelemetryCommand,
     ) -> Result<(), ClientError> {
-        rpc_client.write_telemetry_command(command).await
+        session.update_settings(command).await
     }
 
     pub(crate) async fn send_message(

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -797,7 +797,7 @@ pub(crate) mod tests {
         assert_eq!(
             result.context,
             vec![
-                ("code", "BAD_REQUEST".to_string()),
+                ("code", format!("{}", Code::BadRequest as i32)),
                 ("message", "test failed".to_string()),
             ]
         );

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -188,13 +188,13 @@ where
                             error!(logger, "sync settings failed: failed to get sessions: {}", sessions.unwrap_err());
                             continue;
                         }
-                        for session in sessions.unwrap() {
+                        for mut session in sessions.unwrap() {
                             let command;
                             {
                                 command = settings.read().await.build_telemetry_command();
                             }
                             let peer = session.peer().to_string();
-                            let result = Self::sync_setting(session, command).await;
+                            let result = session.update_settings(command).await;
                             if result.is_err() {
                                 error!(logger, "sync settings failed: failed to call rpc: {}", result.unwrap_err());
                                 continue;
@@ -445,13 +445,6 @@ where
         };
         let response = rpc_client.heartbeat(request).await?;
         Ok(response)
-    }
-
-    async fn sync_setting(
-        mut session: Session,
-        command: TelemetryCommand,
-    ) -> Result<(), ClientError> {
-        session.update_settings(command).await
     }
 
     pub(crate) async fn send_message(

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -626,20 +626,16 @@ pub fn handle_response_status(
     status: Option<Status>,
     operation: &'static str,
 ) -> Result<(), ClientError> {
-    if status.is_none() {
-        return Err(ClientError::new(
-            ErrorKind::Server,
-            "server do not return status, this may be a bug",
-            operation,
-        ));
-    }
+    let status = status.ok_or(ClientError::new(
+        ErrorKind::Server,
+        "server do not return status, this may be a bug",
+        operation,
+    ))?;
 
-    let status = status.unwrap();
-    let status_code = Code::from_i32(status.code).unwrap();
-    if !status_code.eq(&Code::Ok) {
+    if status.code != Code::Ok as i32 {
         return Err(
             ClientError::new(ErrorKind::Server, "server return an error", operation)
-                .with_context("code", status_code.as_str_name())
+                .with_context("code", format!("{}", status.code))
                 .with_context("message", status.message),
         );
     }

--- a/rust/src/model/transaction.rs
+++ b/rust/src/model/transaction.rs
@@ -21,7 +21,7 @@ use std::fmt::{Debug, Formatter};
 
 use async_trait::async_trait;
 
-use crate::client::Client;
+use crate::client::handle_response_status;
 use crate::error::ClientError;
 use crate::model::common::SendReceipt;
 use crate::model::message::MessageView;
@@ -95,7 +95,7 @@ impl TransactionImpl {
                 trace_context: "".to_string(),
             })
             .await?;
-        Client::handle_response_status(response.status, "end transaction")
+        handle_response_status(response.status, "end transaction")
     }
 }
 

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -33,7 +33,7 @@ use crate::error::ErrorKind;
 use crate::model::common::Endpoints;
 use crate::pb::telemetry_command::Command;
 use crate::pb::{
-    self, AckMessageRequest, AckMessageResponse, ChangeInvisibleDurationRequest,
+    AckMessageRequest, AckMessageResponse, ChangeInvisibleDurationRequest,
     ChangeInvisibleDurationResponse, EndTransactionRequest, EndTransactionResponse,
     HeartbeatRequest, HeartbeatResponse, NotifyClientTerminationRequest,
     NotifyClientTerminationResponse, QueryRouteRequest, QueryRouteResponse, ReceiveMessageRequest,
@@ -91,7 +91,7 @@ pub(crate) trait RPCClient {
     ) -> Result<NotifyClientTerminationResponse, ClientError>;
     async fn write_telemetry_command(
         &mut self,
-        request: pb::TelemetryCommand,
+        request: TelemetryCommand,
     ) -> Result<(), ClientError>;
 }
 
@@ -555,7 +555,7 @@ impl RPCClient for Session {
 
     async fn write_telemetry_command(
         &mut self,
-        request: pb::TelemetryCommand,
+        request: TelemetryCommand,
     ) -> Result<(), ClientError> {
         if let Some(telemetry_tx) = self.telemetry_tx.as_ref() {
             telemetry_tx.send(request).await.map_err(|e| {

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -89,10 +89,6 @@ pub(crate) trait RPCClient {
         &mut self,
         request: NotifyClientTerminationRequest,
     ) -> Result<NotifyClientTerminationResponse, ClientError>;
-    async fn write_telemetry_command(
-        &mut self,
-        request: TelemetryCommand,
-    ) -> Result<(), ClientError>;
 }
 
 #[derive(Debug)]
@@ -551,29 +547,6 @@ impl RPCClient for Session {
                 .set_source(e)
             })?;
         Ok(response.into_inner())
-    }
-
-    async fn write_telemetry_command(
-        &mut self,
-        request: TelemetryCommand,
-    ) -> Result<(), ClientError> {
-        if let Some(telemetry_tx) = self.telemetry_tx.as_ref() {
-            telemetry_tx.send(request).await.map_err(|e| {
-                ClientError::new(
-                    ErrorKind::ChannelSend,
-                    "failed to send telemetry command",
-                    OPERATION_START,
-                )
-                .set_source(e)
-            })?;
-        } else {
-            return Err(ClientError::new(
-                ErrorKind::ChannelSend,
-                "failed to send telemetry command",
-                OPERATION_START,
-            ));
-        }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #issue_id

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
To align with Java implementations, the rust client should synchronize client settings per 30 seconds by default.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
