### PR TITLE
修复获取网卡物理地址的问题

### DIFF
--- a/csharp/rocketmq-client-csharp/Utilities.cs
+++ b/csharp/rocketmq-client-csharp/Utilities.cs
@@ -53,7 +53,7 @@ namespace Org.Apache.Rocketmq
                       nics.FirstOrDefault(x => x.OperationalStatus == OperationalStatus.Unknown) ??
                       nics.FirstOrDefault();
 
-            if(nic == null) { return RandomMacAddressBytes; }
+            if (nic == null) { return RandomMacAddressBytes; }
 
             var mac = nic.GetPhysicalAddress().GetAddressBytes();
 

--- a/csharp/rocketmq-client-csharp/Utilities.cs
+++ b/csharp/rocketmq-client-csharp/Utilities.cs
@@ -45,16 +45,19 @@ namespace Org.Apache.Rocketmq
 
         public static byte[] GetMacAddress()
         {
-            var nic = NetworkInterface.GetAllNetworkInterfaces().FirstOrDefault(
-                          x => x.OperationalStatus == OperationalStatus.Up &&
-                               x.NetworkInterfaceType != NetworkInterfaceType.Loopback) ??
-                      NetworkInterface.GetAllNetworkInterfaces().FirstOrDefault(
-                          x => x.OperationalStatus == OperationalStatus.Unknown &&
-                               x.NetworkInterfaceType != NetworkInterfaceType.Loopback) ??
-                      NetworkInterface.GetAllNetworkInterfaces().FirstOrDefault(
-                          x => x.NetworkInterfaceType != NetworkInterfaceType.Loopback);
+            var nics = NetworkInterface.GetAllNetworkInterfaces().Where(
+                x => x.NetworkInterfaceType != NetworkInterfaceType.Loopback &&
+                     (int)x.NetworkInterfaceType != 53);
 
-            return nic != null ? nic.GetPhysicalAddress().GetAddressBytes() : RandomMacAddressBytes;
+            var nic = nics.FirstOrDefault(x => x.OperationalStatus == OperationalStatus.Up) ??
+                      nics.FirstOrDefault(x => x.OperationalStatus == OperationalStatus.Unknown) ??
+                      nics.FirstOrDefault();
+
+            if( nic == null ) { return RandomMacAddressBytes; }
+
+            var mac = nic.GetPhysicalAddress().GetAddressBytes();
+
+            return mac.Length < 6 ? mac : RandomMacAddressBytes;
         }
 
         public static int GetProcessId()

--- a/csharp/rocketmq-client-csharp/Utilities.cs
+++ b/csharp/rocketmq-client-csharp/Utilities.cs
@@ -53,7 +53,7 @@ namespace Org.Apache.Rocketmq
                       nics.FirstOrDefault(x => x.OperationalStatus == OperationalStatus.Unknown) ??
                       nics.FirstOrDefault();
 
-            if( nic == null ) { return RandomMacAddressBytes; }
+            if(nic == null) { return RandomMacAddressBytes; }
 
             var mac = nic.GetPhysicalAddress().GetAddressBytes();
 

--- a/csharp/tests/UtilitiesTest.cs
+++ b/csharp/tests/UtilitiesTest.cs
@@ -51,7 +51,7 @@ namespace tests
         public void TestGetMacAddress()
         {
             var macAddress = Utilities.GetMacAddress();
-            Assert.IsNotNull(macAddress);
+            Assert.IsTrue(macAddress != null && macAddress.Length >=6);
         }
     }
 }

--- a/csharp/tests/UtilitiesTest.cs
+++ b/csharp/tests/UtilitiesTest.cs
@@ -51,7 +51,7 @@ namespace tests
         public void TestGetMacAddress()
         {
             var macAddress = Utilities.GetMacAddress();
-            Assert.IsTrue(macAddress != null && macAddress.Length >=6);
+            Assert.IsTrue(macAddress != null && macAddress.Length >= 6);
         }
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #702

### Brief Description

获取地址时排除 ```NetworkInterfaceType``` 值为 ```53``` 的网卡，在返回时再次检测物理地址的长度是否小于要求长度(```6```)，如果小于，则返回 ```RandomMacAddressBytes```，如果大于，则返回物理地址。

### How Did You Test This Change?

更新相关联的单元测试，加入物理地址长度的检测。