### PR TITLE
[rust] remove is_started condition check because telemetry_command_tx…

### DIFF
--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -367,15 +367,6 @@ impl Session {
         &mut self,
         settings: TelemetryCommand,
     ) -> Result<(), ClientError> {
-        if !self.is_started() {
-            return Err(ClientError::new(
-                ErrorKind::ClientIsNotRunning,
-                "session is not started",
-                OPERATION_UPDATE_SETTINGS,
-            )
-            .with_context("url", self.endpoints.endpoint_url()));
-        }
-
         if let Some(tx) = self.telemetry_tx.as_ref() {
             tx.send(settings).await.map_err(|e| {
                 ClientError::new(


### PR DESCRIPTION
… is suffice to tell

<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #707 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
There is no need to check `is_started` because telemetry_command_tx is suffice to tell if client is ready.
### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
