### PR TITLE
[rust]sync topic route every 30 seconds

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -372,9 +372,9 @@ where
         let request = QueryRouteRequest {
             topic: Some(Resource {
                 name: topic.to_owned(),
-                resource_namespace: namespace.to_string(),
+                resource_namespace: namespace,
             }),
-            endpoints: Some(access_endpoints.inner().clone()),
+            endpoints: Some(access_endpoints.into_inner()),
         };
 
         let response = rpc_client.query_route(request).await?;

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -212,14 +212,14 @@ where
                         {
                             topics = route_table.lock().keys().cloned().collect();
                         }
-                        info!(logger, "update topic route of topics {:?}", topics);
+                        debug!(logger, "update topic route of topics {:?}", topics);
                         for topic in topics {
                             let result = Self::topic_route_inner(
                                 logger.clone(),
                                 rpc_client.shadow_session(),
                                 Arc::clone(&route_table),
-                                &namespace,
-                                &endpoints,
+                                namespace.clone(),
+                                endpoints.clone(),
                                 topic.as_str(),
                             )
                             .await;
@@ -356,8 +356,8 @@ where
             logger,
             rpc_client,
             route_table,
-            &self.option.namespace,
-            &self.access_endpoints,
+            self.option.namespace.clone(),
+            self.access_endpoints.clone(),
             topic,
         )
         .await
@@ -365,8 +365,8 @@ where
 
     async fn query_topic_route<T: RPCClient + 'static>(
         mut rpc_client: T,
-        namespace: &str,
-        access_endpoints: &Endpoints,
+        namespace: String,
+        access_endpoints: Endpoints,
         topic: &str,
     ) -> Result<Route, ClientError> {
         let request = QueryRouteRequest {
@@ -391,8 +391,8 @@ where
         logger: Logger,
         rpc_client: T,
         route_table: Arc<parking_lot::Mutex<HashMap<String, RouteStatus>>>,
-        namespace: &str,
-        endpoints: &Endpoints,
+        namespace: String,
+        endpoints: Endpoints,
         topic: &str,
     ) -> Result<Arc<Route>, ClientError> {
         debug!(logger, "query route for topic={}", topic);
@@ -913,8 +913,8 @@ pub(crate) mod tests {
             logger,
             mock,
             Arc::clone(&client.route_table),
-            &client.option.namespace,
-            &client.access_endpoints,
+            client.option.namespace.clone(),
+            client.access_endpoints.clone(),
             "DefaultCluster",
         )
         .await;
@@ -948,8 +948,8 @@ pub(crate) mod tests {
                 client_clone.logger.clone(),
                 mock,
                 Arc::clone(&client_clone.route_table),
-                &client_clone.option.namespace,
-                &client_clone.access_endpoints,
+                client_clone.option.namespace.clone(),
+                client_clone.access_endpoints.clone(),
                 "DefaultCluster",
             )
             .await;
@@ -963,8 +963,8 @@ pub(crate) mod tests {
                 client.logger.clone(),
                 mock,
                 Arc::clone(&client.route_table),
-                &client.option.namespace,
-                &client.access_endpoints,
+                client.option.namespace.clone(),
+                client.access_endpoints.clone(),
                 "DefaultCluster",
             )
             .await;
@@ -995,8 +995,8 @@ pub(crate) mod tests {
                 client_clone.logger.clone(),
                 mock,
                 Arc::clone(&client_clone.route_table),
-                &client_clone.option.namespace,
-                &client_clone.access_endpoints,
+                client_clone.option.namespace.clone(),
+                client_clone.access_endpoints.clone(),
                 "DefaultCluster",
             )
             .await;
@@ -1010,8 +1010,8 @@ pub(crate) mod tests {
                 client.logger.clone(),
                 mock,
                 Arc::clone(&client.route_table),
-                &client.option.namespace,
-                &client.access_endpoints,
+                client.option.namespace.clone(),
+                client.access_endpoints.clone(),
                 "DefaultCluster",
             )
             .await;
@@ -1055,8 +1055,8 @@ pub(crate) mod tests {
             client.logger.clone(),
             mock,
             Arc::clone(&client.route_table),
-            &client.option.namespace,
-            &client.access_endpoints,
+            client.option.namespace.clone(),
+            client.access_endpoints.clone(),
             "DefaultCluster",
         )
         .await;
@@ -1075,8 +1075,8 @@ pub(crate) mod tests {
             client.logger.clone(),
             mock,
             Arc::clone(&client.route_table),
-            &client.option.namespace,
-            &client.access_endpoints,
+            client.option.namespace.clone(),
+            client.access_endpoints.clone(),
             "DefaultCluster",
         )
         .await;
@@ -1101,8 +1101,8 @@ pub(crate) mod tests {
             client.logger.clone(),
             mock,
             Arc::clone(&client.route_table),
-            &client.option.namespace,
-            &client.access_endpoints,
+            client.option.namespace.clone(),
+            client.access_endpoints.clone(),
             "DefaultCluster",
         )
         .await;

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -232,7 +232,7 @@ where
                                 );
                             }
                         }
-                },
+                    },
                     _ = &mut shutdown_rx => {
                         info!(logger, "receive shutdown signal, stop heartbeat and telemetry tasks.");
                         break;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #issue_id

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Now the client doesn't update topic route automatically that if topic configuration is updated on server there is no change for client to react on this change other than being restarted. In this PR, the client launches a scheduler to update the route of topics in route table.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
I had run e2e test locally that everything is doing fine.

