### PR TITLE
[csharp] Optimization message id generator performance.

### DIFF
--- a/csharp/rocketmq-client-csharp/DefaultUtilities.cs
+++ b/csharp/rocketmq-client-csharp/DefaultUtilities.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Org.Apache.Rocketmq
+{
+    internal class DefaultUtilities : IUtilities
+    {
+        private DefaultUtilities()
+        {
+        }
+
+        public static DefaultUtilities Instance { get; } = new DefaultUtilities();
+
+        public byte[] GetMacAddress()
+        {
+            return Utilities.GetMacAddress();
+        }
+
+        public int GetProcessId()
+        {
+            return Utilities.GetProcessId();
+        }
+
+        public string ByteArrayToHexString(ReadOnlySpan<byte> bytes)
+        {
+            return Utilities.ByteArrayToHexString(bytes);
+        }
+    }
+}

--- a/csharp/rocketmq-client-csharp/DefaultUtilities.cs
+++ b/csharp/rocketmq-client-csharp/DefaultUtilities.cs
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 
 namespace Org.Apache.Rocketmq

--- a/csharp/rocketmq-client-csharp/IUtilities.cs
+++ b/csharp/rocketmq-client-csharp/IUtilities.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Org.Apache.Rocketmq
+{
+    internal interface IUtilities
+    {
+        byte[] GetMacAddress();
+        int GetProcessId();
+        string ByteArrayToHexString(ReadOnlySpan<byte> bytes);
+    }
+}

--- a/csharp/rocketmq-client-csharp/IUtilities.cs
+++ b/csharp/rocketmq-client-csharp/IUtilities.cs
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 
 namespace Org.Apache.Rocketmq

--- a/csharp/rocketmq-client-csharp/MessageIdGenerator.cs
+++ b/csharp/rocketmq-client-csharp/MessageIdGenerator.cs
@@ -47,7 +47,7 @@ namespace Org.Apache.Rocketmq
             utilities.GetMacAddress().AsSpan().CopyTo(buffer);
 
             var processId = utilities.GetProcessId();
-            BinaryPrimitives.WriteInt16BigEndian(buffer.Slice(6, 2), (short)processId);
+            BinaryPrimitives.WriteInt16BigEndian(buffer[6..], (short)processId);
 
             _prefix = Version + utilities.ByteArrayToHexString(buffer);
 
@@ -68,7 +68,7 @@ namespace Org.Apache.Rocketmq
             BinaryPrimitives.WriteInt32BigEndian(buffer[..4], (int)deltaSeconds);
 
             var no = Interlocked.Increment(ref _sequence);
-            BinaryPrimitives.WriteInt32BigEndian(buffer[4..4], no);
+            BinaryPrimitives.WriteInt32BigEndian(buffer[4..], no);
 
             return $"{_prefix}{_utilities.ByteArrayToHexString(buffer)}";
         }

--- a/csharp/rocketmq-client-csharp/Utilities.cs
+++ b/csharp/rocketmq-client-csharp/Utilities.cs
@@ -94,6 +94,11 @@ namespace Org.Apache.Rocketmq
             var hashBytes = Sha1.Value.ComputeHash(data);
             return Convert.ToHexString(hashBytes);
         }
+
+        public static string ByteArrayToHexString(ReadOnlySpan<byte> bytes)
+        {
+            return Convert.ToHexString(bytes);
+        }
 #else
         public static string ComputeMd5Hash(byte[] data)
         {
@@ -105,6 +110,20 @@ namespace Org.Apache.Rocketmq
         {
             var hashBytes = Sha1.Value.ComputeHash(data);
             return BitConverter.ToString(hashBytes).Replace("-", "");
+        }
+        
+        public static string ByteArrayToHexString(ReadOnlySpan<byte> bytes)
+        {
+            var result = new StringBuilder(bytes.Length * 2);
+            const string hexAlphabet = "0123456789ABCDEF";
+
+            foreach (var b in bytes)
+            {
+                result.Append(hexAlphabet[(int)(b >> 4)]);
+                result.Append(hexAlphabet[(int)(b & 0xF)]);
+            }
+
+            return result.ToString();
         }
 #endif
 
@@ -120,20 +139,6 @@ namespace Org.Apache.Rocketmq
             }
 
             return result;
-        }
-
-        public static string ByteArrayToHexString(byte[] bytes)
-        {
-            var result = new StringBuilder(bytes.Length * 2);
-            const string hexAlphabet = "0123456789ABCDEF";
-
-            foreach (var b in bytes)
-            {
-                result.Append(hexAlphabet[(int)(b >> 4)]);
-                result.Append(hexAlphabet[(int)(b & 0xF)]);
-            }
-
-            return result.ToString();
         }
 
         public static byte[] CompressBytesGzip(byte[] src, CompressionLevel level)

--- a/csharp/rocketmq-client-csharp/rocketmq-client-csharp.csproj
+++ b/csharp/rocketmq-client-csharp/rocketmq-client-csharp.csproj
@@ -29,6 +29,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.32" />
         <PackageReference Include="NLog.Extensions.Logging" Version="5.3.4" />
         <PackageReference Include="OpenTelemetry" Version="1.3.1" />
@@ -39,4 +40,11 @@
         <Protobuf Include="..\..\protos\apache\rocketmq\v2\service.proto" ProtoRoot="..\..\protos" GrpcServices="Client" />
         <None Include="logo.png" Pack="true" PackagePath="" />
     </ItemGroup>
+
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>tests</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
 </Project>

--- a/csharp/tests/MessageIdGeneratorTest.cs
+++ b/csharp/tests/MessageIdGeneratorTest.cs
@@ -42,7 +42,7 @@ namespace tests
         }
 
         [TestMethod]
-        public void TestNextSuffix()
+        public void TestNextId()
         {
             var fakeTimeProvider = new FakeTimeProvider();
             fakeTimeProvider.SetUtcNow(new DateTime(2023, 1, 1, 0, 0, 1, DateTimeKind.Utc));

--- a/csharp/tests/MessageIdGeneratorTest.cs
+++ b/csharp/tests/MessageIdGeneratorTest.cs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+using System;
+using Microsoft.Extensions.Time.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.Rocketmq;
 
@@ -37,6 +39,39 @@ namespace tests
 
             Assert.AreNotEqual(firstMessageId, secondMessageId);
             Assert.AreEqual(firstMessageId.Substring(0, 24), secondMessageId.Substring(0, 24));
+        }
+
+        [TestMethod]
+        public void TestNextSuffix()
+        {
+            var fakeTimeProvider = new FakeTimeProvider();
+            fakeTimeProvider.SetUtcNow(new DateTime(2023, 1, 1, 0, 0, 1, DateTimeKind.Utc));
+
+            var instance = new MessageIdGenerator(fakeTimeProvider, new FakeUtilities());
+            var firstMessageId = instance.Next();
+            Assert.AreEqual("01000102030405002A03C2670100000001", firstMessageId);
+
+            fakeTimeProvider.SetUtcNow(new DateTime(2023, 1, 1, 0, 0, 2, DateTimeKind.Utc));
+            var secondMessageId = instance.Next();
+            Assert.AreEqual("01000102030405002A03C2670200000002", secondMessageId);
+        }
+
+        private class FakeUtilities : IUtilities
+        {
+            public byte[] GetMacAddress()
+            {
+                return new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 };
+            }
+
+            public int GetProcessId()
+            {
+                return 42;
+            }
+
+            public string ByteArrayToHexString(ReadOnlySpan<byte> bytes)
+            {
+                return Utilities.ByteArrayToHexString(bytes);
+            }
         }
     }
 }

--- a/csharp/tests/tests.csproj
+++ b/csharp/tests/tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.32" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

Optimization message id generator performance.

### Brief Description

We are using RocketMQ for high-throughput message sending and receiving and have identified some performance bottlenecks. This is one of a series of performance optimization pull requests aimed at improving the efficiency of the message ID generator. Based on the following benchmark tests, we can conclude that there has been an approximate 50% reduction in time consumption and a 70% reduction in memory usage.

```
BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.3296/23H2/2023Update/SunValley3)
Intel Core i7-14700K, 1 CPU, 28 logical and 20 physical cores
.NET SDK 8.0.202
  [Host]     : .NET 8.0.3 (8.0.324.11423), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.3 (8.0.324.11423), X64 RyuJIT AVX2


| Method     | Mean     | Error    | StdDev   | Gen0   | Allocated |
|----------- |---------:|---------:|---------:|-------:|----------:|
| Next       | 35.24 ns | 0.274 ns | 0.243 ns | 0.0088 |     152 B |
| BeforeNext | 72.86 ns | 0.567 ns | 0.502 ns | 0.0426 |     736 B |
```

Additionally, the strong dependency of the MessageIdGenerator on time has been decoupled by using the TimeProvider from the .NET base class library. The abstraction of IUtilities decouples the strong dependency on the Utilities static class, facilitating better unit testing and ensuring code quality.

### How Did You Test This Change?

Unit tests were created using the same parameters to record the Ids generated by the old Next method, to compare and verify the consistency between the new and old result methods.
