### PR TITLE
Fix issue with PushConsumer message consumption order

### DIFF
--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/PushConsumerBuilder.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/PushConsumerBuilder.java
@@ -82,6 +82,14 @@ public interface PushConsumerBuilder {
     PushConsumerBuilder setConsumptionThreadCount(int count);
 
     /**
+     * Set the FIFO mode for the consumer.
+     *
+     * @param fifo true if FIFO mode is enabled.
+     * @return the consumer builder instance.
+     */
+    PushConsumerBuilder setFifo(boolean fifo);
+
+    /**
      * Finalize the build of {@link PushConsumer} and start.
      *
      * <p>This method will block until the push consumer starts successfully.

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/example/PushConsumerExample.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/example/PushConsumerExample.java
@@ -63,6 +63,8 @@ public class PushConsumerExample {
             .setClientConfiguration(clientConfiguration)
             // Set the consumer group name.
             .setConsumerGroup(consumerGroup)
+            // Set the message FIFO mode.
+            .setFifo(true)
             // Set the subscription for the consumer.
             .setSubscriptionExpressions(Collections.singletonMap(topic, filterExpression))
             .setMessageListener(messageView -> {

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerBuilderImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerBuilderImpl.java
@@ -41,6 +41,7 @@ public class PushConsumerBuilderImpl implements PushConsumerBuilder {
     private int maxCacheMessageCount = 1024;
     private int maxCacheMessageSizeInBytes = 64 * 1024 * 1024;
     private int consumptionThreadCount = 20;
+    private boolean fifo = false;
 
     /**
      * @see PushConsumerBuilder#setClientConfiguration(ClientConfiguration)
@@ -114,6 +115,15 @@ public class PushConsumerBuilderImpl implements PushConsumerBuilder {
     }
 
     /**
+     * @see PushConsumerBuilder#setFifo
+     */
+    @Override
+    public PushConsumerBuilder setFifo(boolean fifo) {
+        this.fifo = fifo;
+        return this;
+    }
+
+    /**
      * @see PushConsumerBuilder#build()
      */
     @Override
@@ -123,7 +133,7 @@ public class PushConsumerBuilderImpl implements PushConsumerBuilder {
         checkNotNull(messageListener, "messageListener has not been set yet");
         checkArgument(!subscriptionExpressions.isEmpty(), "subscriptionExpressions have not been set yet");
         final PushConsumerImpl pushConsumer = new PushConsumerImpl(clientConfiguration, consumerGroup,
-            subscriptionExpressions, messageListener, maxCacheMessageCount, maxCacheMessageSizeInBytes,
+            subscriptionExpressions, messageListener, fifo, maxCacheMessageCount, maxCacheMessageSizeInBytes,
             consumptionThreadCount);
         pushConsumer.startAsync().awaitRunning();
         return pushConsumer;

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
@@ -123,13 +123,13 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
      * logging warnings already, so we avoid repeating args check here.
      */
     public PushConsumerImpl(ClientConfiguration clientConfiguration, String consumerGroup,
-        Map<String, FilterExpression> subscriptionExpressions, MessageListener messageListener,
+        Map<String, FilterExpression> subscriptionExpressions, MessageListener messageListener, boolean fifo,
         int maxCacheMessageCount, int maxCacheMessageSizeInBytes, int consumptionThreadCount) {
         super(clientConfiguration, consumerGroup, subscriptionExpressions.keySet());
         this.clientConfiguration = clientConfiguration;
         Resource groupResource = new Resource(clientConfiguration.getNamespace(), consumerGroup);
         this.pushSubscriptionSettings = new PushSubscriptionSettings(clientConfiguration.getNamespace(), clientId,
-            endpoints, groupResource, clientConfiguration.getRequestTimeout(), subscriptionExpressions);
+            endpoints, groupResource, clientConfiguration.getRequestTimeout(), subscriptionExpressions, fifo);
         this.consumerGroup = consumerGroup;
         this.subscriptionExpressions = subscriptionExpressions;
         this.cacheAssignments = new ConcurrentHashMap<>();


### PR DESCRIPTION
Addressed an issue where the PushConsumer did not guarantee the order of consuming messages that were not allocated upon the first startup. 
This fix ensures that message consumption order is maintained even for unallocated messages during the initial startup.

<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #754 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

I made the fifo parameter true at the beginning and then ran the example and it worked fine.
