### PR TITLE
[ISSUE #811][Golang] should not copy sync.Map in loadBalancer

### DIFF
--- a/golang/loadBalancer.go
+++ b/golang/loadBalancer.go
@@ -30,7 +30,7 @@ import (
 
 type PublishingLoadBalancer interface {
 	TakeMessageQueueByMessageGroup(messageGroup *string) ([]*v2.MessageQueue, error)
-	TakeMessageQueues(excluded sync.Map, count int) ([]*v2.MessageQueue, error)
+	TakeMessageQueues(excluded *sync.Map, count int) ([]*v2.MessageQueue, error)
 	CopyAndUpdate([]*v2.MessageQueue) PublishingLoadBalancer
 }
 
@@ -63,7 +63,7 @@ func (plb *publishingLoadBalancer) TakeMessageQueueByMessageGroup(messageGroup *
 	}, nil
 }
 
-func (plb *publishingLoadBalancer) TakeMessageQueues(excluded sync.Map, count int) ([]*v2.MessageQueue, error) {
+func (plb *publishingLoadBalancer) TakeMessageQueues(excluded *sync.Map, count int) ([]*v2.MessageQueue, error) {
 	if len(plb.messageQueues) == 0 {
 		return nil, fmt.Errorf("messageQueues is empty")
 	}

--- a/golang/producer.go
+++ b/golang/producer.go
@@ -79,7 +79,7 @@ func (p *defaultProducer) wrapHeartbeatRequest() *v2.HeartbeatRequest {
 }
 
 func (p *defaultProducer) takeMessageQueues(plb PublishingLoadBalancer) ([]*v2.MessageQueue, error) {
-	return plb.TakeMessageQueues(p.isolated, p.getRetryMaxAttempts())
+	return plb.TakeMessageQueues(&p.isolated, p.getRetryMaxAttempts())
 }
 
 func (p *defaultProducer) getPublishingTopicRouteResult(ctx context.Context, topic string) (PublishingLoadBalancer, error) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #811  

### Brief Description

copy sync.Map will cause the data race, it may report as below
![image](https://github.com/user-attachments/assets/507fa6c5-c69c-493e-9bef-e8d8a1f6f524)


### How Did You Test This Change?

go vet should not report any sync.Map error
