### PR TITLE
chore: fix compile error in rust 1.81.0

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -58,7 +58,7 @@ minitrace = "0.4"
 byteorder = "1"
 mac_address = "1.1.4"
 hex = "0.4.3"
-time = { version = "0.3", features = ["local-offset"] }
+time = { version = "0.3.36", features = ["local-offset"] }
 once_cell = "1.18.0"
 
 mockall = "0.11.4"


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

after ❯ rustc --version
rustc 1.80.0

cargo build will failed


Fixes #issue_id

### Brief Description

```
error[E0282]: type annotations needed for `Box<_>`
  --> /Users/bystander/.cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.3.19/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
   = note: this is an inference error on crate `time` caused by an API change in Rust 1.80.0; update `time` to version `>=0.3.35` by calling `cargo update`

```
### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

cargo build