### PR TITLE
Resolve the issue of garbled characters in the Golang language message body GzipDecoder

### DIFF
--- a/golang/pkg/utils/utils.go
+++ b/golang/pkg/utils/utils.go
@@ -19,11 +19,11 @@ package utils
 
 import (
 	"bytes"
-	"compress/gzip"
+	"compress/zlib"
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/url"
 	"os"
@@ -141,13 +141,20 @@ func MatchMessageType(mq *v2.MessageQueue, messageType v2.MessageType) bool {
 }
 
 func GZIPDecode(in []byte) ([]byte, error) {
-	reader, err := gzip.NewReader(bytes.NewReader(in))
+	// Create a zlib reader
+	byteArrayInputStream := bytes.NewReader(in)
+	inflatesInputStream, err := zlib.NewReader(byteArrayInputStream)
 	if err != nil {
-		var out []byte
-		return out, err
+		return nil, err
 	}
-	defer reader.Close()
-	return ioutil.ReadAll(reader)
+	defer inflatesInputStream.Close()
+	// Create a buffer to store decompressed data
+	var byteArrayOutputStream bytes.Buffer
+	_, err = io.Copy(&byteArrayOutputStream, inflatesInputStream)
+	if err != nil {
+		return nil, err
+	}
+	return byteArrayOutputStream.Bytes(), nil
 }
 
 var clientIdx int64 = 0


### PR DESCRIPTION
When the amount of data in the message body is relatively large, decompression may result in errors;
当客户发发送一个数据量大的消息体时，由于进行了gzip 压缩，golang 版本的代码，消费数据时，原先GZIPDecode 方法有问题，解压出来是乱码，优化后，可以正常消费和解压缩，测试没有问题

Fixes #issue_id

#667