### PR TITLE
Fix Utilities.GetMacAddress may return wrong result

### DIFF
--- a/csharp/rocketmq-client-csharp/Utilities.cs
+++ b/csharp/rocketmq-client-csharp/Utilities.cs
@@ -53,11 +53,12 @@ namespace Org.Apache.Rocketmq
                       nics.FirstOrDefault(x => x.OperationalStatus == OperationalStatus.Unknown) ??
                       nics.FirstOrDefault();
 
-            if (nic == null) { return RandomMacAddressBytes; }
-
-            var mac = nic.GetPhysicalAddress().GetAddressBytes();
-
-            return mac.Length < 6 ? mac : RandomMacAddressBytes;
+            if (nic != null)
+            {
+                var mac = nic.GetPhysicalAddress().GetAddressBytes();
+                if (mac.Length == 6) return mac;
+            }
+            return RandomMacAddressBytes;
         }
 
         public static int GetProcessId()


### PR DESCRIPTION
`Utilities.GetMacAddress` may return empty `byte[]` that crashes `MessageIdGenerator.MessageIdGenerator()` and `MessageIdGenerator`'s type initializer.

https://github.com/apache/rocketmq-clients/blob/33caa017045d6dc0339fc32d61d8f8c7169068af/csharp/rocketmq-client-csharp/MessageIdGenerator.cs#L46