### PR TITLE
[Java] optimize rpcClientTable lock

### DIFF
--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/ClientManagerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/ClientManagerImpl.java
@@ -39,7 +39,6 @@ import apache.rocketmq.v2.SendMessageRequest;
 import apache.rocketmq.v2.SendMessageResponse;
 import apache.rocketmq.v2.TelemetryCommand;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.grpc.Metadata;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
@@ -48,14 +47,15 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.net.ssl.SSLException;
 import org.apache.rocketmq.client.apis.ClientException;
 import org.apache.rocketmq.client.java.exception.InternalErrorException;
@@ -94,9 +94,9 @@ public class ClientManagerImpl extends ClientManager {
 
     private final Client client;
 
-    @GuardedBy("rpcClientTableLock")
     private final Map<Endpoints, RpcClient> rpcClientTable;
-    private final ReadWriteLock rpcClientTableLock;
+
+    private final BlockingQueue<RpcClientWrap> idleClients;
 
     /**
      * In charge of all scheduled tasks.
@@ -110,20 +110,20 @@ public class ClientManagerImpl extends ClientManager {
 
     public ClientManagerImpl(Client client) {
         this.client = client;
-        this.rpcClientTable = new HashMap<>();
-        this.rpcClientTableLock = new ReentrantReadWriteLock();
+        this.rpcClientTable = new ConcurrentHashMap<>();
+        this.idleClients = new ArrayBlockingQueue<>(1000);
         final long clientIndex = client.getClientId().getIndex();
         this.scheduler = new ScheduledThreadPoolExecutor(
-            Runtime.getRuntime().availableProcessors(),
-            new ThreadFactoryImpl("ClientScheduler", clientIndex));
+                Runtime.getRuntime().availableProcessors(),
+                new ThreadFactoryImpl("ClientScheduler", clientIndex));
 
         this.asyncWorker = new ThreadPoolExecutor(
-            Runtime.getRuntime().availableProcessors(),
-            Runtime.getRuntime().availableProcessors(),
-            60,
-            TimeUnit.SECONDS,
-            new LinkedBlockingQueue<>(50000),
-            new ThreadFactoryImpl("ClientAsyncWorker", clientIndex));
+                Runtime.getRuntime().availableProcessors(),
+                Runtime.getRuntime().availableProcessors(),
+                60,
+                TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(50000),
+                new ThreadFactoryImpl("ClientAsyncWorker", clientIndex));
     }
 
     /**
@@ -133,25 +133,36 @@ public class ClientManagerImpl extends ClientManager {
      * @throws InterruptedException if the thread has been interrupted
      */
     private void clearIdleRpcClients() throws InterruptedException {
-        rpcClientTableLock.writeLock().lock();
-        try {
-            final Iterator<Map.Entry<Endpoints, RpcClient>> it = rpcClientTable.entrySet().iterator();
-            while (it.hasNext()) {
-                final Map.Entry<Endpoints, RpcClient> entry = it.next();
-                final Endpoints endpoints = entry.getKey();
-                final RpcClient rpcClient = entry.getValue();
+        final Iterator<Map.Entry<Endpoints, RpcClient>> it = rpcClientTable.entrySet().iterator();
+        while (it.hasNext()) {
+            final Map.Entry<Endpoints, RpcClient> entry = it.next();
+            final Endpoints endpoints = entry.getKey();
+            final RpcClient rpcClient = entry.getValue();
 
-                final Duration idleDuration = rpcClient.idleDuration();
-                if (idleDuration.compareTo(RPC_CLIENT_MAX_IDLE_DURATION) > 0) {
-                    it.remove();
-                    rpcClient.shutdown();
-                    log.info("Rpc client has been idle for a long time, endpoints={}, idleDuration={}, " +
-                            "rpcClientMaxIdleDuration={}, clientId={}", endpoints, idleDuration,
-                        RPC_CLIENT_MAX_IDLE_DURATION, client.getClientId());
-                }
+            final Duration idleDuration = rpcClient.idleDuration();
+            if (idleDuration.compareTo(RPC_CLIENT_MAX_IDLE_DURATION) > 0) {
+                it.remove();
+                idleClients.put(RpcClientWrap.wrap(endpoints, rpcClient));
             }
-        } finally {
-            rpcClientTableLock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * It is well-founded that a {@link RpcClient} is deprecated if it is idle for a long time, so it is essential to
+     * shutdown it.
+     *
+     * @throws InterruptedException if the thread has been interrupted
+     */
+    private void shutdownIdleRpcClients() throws InterruptedException {
+        RpcClientWrap clientWrap = idleClients.poll(10, TimeUnit.SECONDS);
+        while (null != clientWrap) {
+            final Endpoints endpoints = clientWrap.endpoints;
+            final RpcClient rpcClient = clientWrap.rpcClient;
+            rpcClient.shutdown();
+            log.info("Rpc client has been idle for a long time, endpoints={}, idleDuration={}, " +
+                            "rpcClientMaxIdleDuration={}, clientId={}", endpoints, rpcClient.idleDuration(),
+                    RPC_CLIENT_MAX_IDLE_DURATION, client.getClientId());
+            clientWrap = idleClients.poll(10, TimeUnit.SECONDS);
         }
     }
 
@@ -164,43 +175,39 @@ public class ClientManagerImpl extends ClientManager {
      */
     private RpcClient getRpcClient(Endpoints endpoints) throws ClientException {
         RpcClient rpcClient;
-        rpcClientTableLock.readLock().lock();
-        try {
-            rpcClient = rpcClientTable.get(endpoints);
-            if (null != rpcClient) {
-                return rpcClient;
-            }
-        } finally {
-            rpcClientTableLock.readLock().unlock();
-        }
-        rpcClientTableLock.writeLock().lock();
-        try {
-            rpcClient = rpcClientTable.get(endpoints);
-            if (null != rpcClient) {
-                return rpcClient;
-            }
-            try {
-                rpcClient = new RpcClientImpl(endpoints, client.isSslEnabled());
-            } catch (SSLException e) {
-                log.error("Failed to get RPC client, endpoints={}, clientId={}", endpoints, client.getClientId(), e);
-                throw new ClientException("Failed to generate RPC client", e);
-            }
-            rpcClientTable.put(endpoints, rpcClient);
+        rpcClient = rpcClientTable.get(endpoints);
+        if (null != rpcClient) {
             return rpcClient;
-        } finally {
-            rpcClientTableLock.writeLock().unlock();
         }
+        rpcClient = rpcClientTable.get(endpoints);
+        if (null != rpcClient) {
+            return rpcClient;
+        }
+        synchronized (endpoints) {
+            rpcClient = rpcClientTable.get(endpoints);
+            if (null == rpcClient) {
+                try {
+                    rpcClient = new RpcClientImpl(endpoints, client.isSslEnabled());
+                } catch (SSLException e) {
+                    log.error("Failed to get RPC client, endpoints={}, clientId={}", endpoints, client.getClientId(), e);
+                    throw new ClientException("Failed to generate RPC client", e);
+                }
+                rpcClientTable.put(endpoints, rpcClient);
+            }
+        }
+
+        return rpcClient;
     }
 
     @Override
     public RpcFuture<QueryRouteRequest, QueryRouteResponse> queryRoute(Endpoints endpoints, QueryRouteRequest request,
-        Duration duration) {
+                                                                       Duration duration) {
         try {
             final Metadata metadata = client.sign();
             final Context context = new Context(endpoints, metadata);
             final RpcClient rpcClient = getRpcClient(endpoints);
             final ListenableFuture<QueryRouteResponse> future = rpcClient.queryRoute(metadata, request, asyncWorker,
-                duration);
+                    duration);
             return new RpcFuture<>(context, request, future);
         } catch (Throwable t) {
             return new RpcFuture<>(t);
@@ -209,7 +216,7 @@ public class ClientManagerImpl extends ClientManager {
 
     @Override
     public RpcFuture<HeartbeatRequest, HeartbeatResponse> heartbeat(Endpoints endpoints, HeartbeatRequest request,
-        Duration duration) {
+                                                                    Duration duration) {
         try {
             final Metadata metadata = client.sign();
             final Context context = new Context(endpoints, metadata);
@@ -223,13 +230,13 @@ public class ClientManagerImpl extends ClientManager {
 
     @Override
     public RpcFuture<SendMessageRequest, SendMessageResponse> sendMessage(Endpoints endpoints,
-        SendMessageRequest request, Duration duration) {
+                                                                          SendMessageRequest request, Duration duration) {
         try {
             final Metadata metadata = client.sign();
             final Context context = new Context(endpoints, metadata);
             final RpcClient rpcClient = getRpcClient(endpoints);
             final ListenableFuture<SendMessageResponse> future =
-                rpcClient.sendMessage(metadata, request, asyncWorker, duration);
+                    rpcClient.sendMessage(metadata, request, asyncWorker, duration);
             return new RpcFuture<>(context, request, future);
         } catch (Throwable t) {
             return new RpcFuture<>(t);
@@ -238,13 +245,13 @@ public class ClientManagerImpl extends ClientManager {
 
     @Override
     public RpcFuture<QueryAssignmentRequest, QueryAssignmentResponse> queryAssignment(Endpoints endpoints,
-        QueryAssignmentRequest request, Duration duration) {
+                                                                                      QueryAssignmentRequest request, Duration duration) {
         try {
             final Metadata metadata = client.sign();
             final Context context = new Context(endpoints, metadata);
             final RpcClient rpcClient = getRpcClient(endpoints);
             final ListenableFuture<QueryAssignmentResponse> future =
-                rpcClient.queryAssignment(metadata, request, asyncWorker, duration);
+                    rpcClient.queryAssignment(metadata, request, asyncWorker, duration);
             return new RpcFuture<>(context, request, future);
         } catch (Throwable t) {
             return new RpcFuture<>(t);
@@ -253,13 +260,13 @@ public class ClientManagerImpl extends ClientManager {
 
     @Override
     public RpcFuture<ReceiveMessageRequest, List<ReceiveMessageResponse>> receiveMessage(Endpoints endpoints,
-        ReceiveMessageRequest request, Duration duration) {
+                                                                                         ReceiveMessageRequest request, Duration duration) {
         try {
             final Metadata metadata = client.sign();
             final Context context = new Context(endpoints, metadata);
             final RpcClient rpcClient = getRpcClient(endpoints);
             final ListenableFuture<List<ReceiveMessageResponse>> future =
-                rpcClient.receiveMessage(metadata, request, asyncWorker, duration);
+                    rpcClient.receiveMessage(metadata, request, asyncWorker, duration);
             return new RpcFuture<>(context, request, future);
         } catch (Throwable t) {
             return new RpcFuture<>(t);
@@ -268,13 +275,13 @@ public class ClientManagerImpl extends ClientManager {
 
     @Override
     public RpcFuture<AckMessageRequest, AckMessageResponse> ackMessage(Endpoints endpoints, AckMessageRequest request,
-        Duration duration) {
+                                                                       Duration duration) {
         try {
             final Metadata metadata = client.sign();
             final Context context = new Context(endpoints, metadata);
             final RpcClient rpcClient = getRpcClient(endpoints);
             final ListenableFuture<AckMessageResponse> future =
-                rpcClient.ackMessage(metadata, request, asyncWorker, duration);
+                    rpcClient.ackMessage(metadata, request, asyncWorker, duration);
             return new RpcFuture<>(context, request, future);
         } catch (Throwable t) {
             return new RpcFuture<>(t);
@@ -284,13 +291,13 @@ public class ClientManagerImpl extends ClientManager {
     @Override
     public RpcFuture<ChangeInvisibleDurationRequest, ChangeInvisibleDurationResponse>
     changeInvisibleDuration(Endpoints endpoints, ChangeInvisibleDurationRequest request,
-        Duration duration) {
+                            Duration duration) {
         try {
             final Metadata metadata = client.sign();
             final Context context = new Context(endpoints, metadata);
             final RpcClient rpcClient = getRpcClient(endpoints);
             final ListenableFuture<ChangeInvisibleDurationResponse> future =
-                rpcClient.changeInvisibleDuration(metadata, request, asyncWorker, duration);
+                    rpcClient.changeInvisibleDuration(metadata, request, asyncWorker, duration);
             return new RpcFuture<>(context, request, future);
         } catch (Throwable t) {
             return new RpcFuture<>(t);
@@ -300,13 +307,13 @@ public class ClientManagerImpl extends ClientManager {
     @Override
     public RpcFuture<ForwardMessageToDeadLetterQueueRequest, ForwardMessageToDeadLetterQueueResponse>
     forwardMessageToDeadLetterQueue(Endpoints endpoints, ForwardMessageToDeadLetterQueueRequest request,
-        Duration duration) {
+                                    Duration duration) {
         try {
             final Metadata metadata = client.sign();
             final Context context = new Context(endpoints, metadata);
             final RpcClient rpcClient = getRpcClient(endpoints);
             final ListenableFuture<ForwardMessageToDeadLetterQueueResponse> future =
-                rpcClient.forwardMessageToDeadLetterQueue(metadata, request, asyncWorker, duration);
+                    rpcClient.forwardMessageToDeadLetterQueue(metadata, request, asyncWorker, duration);
             return new RpcFuture<>(context, request, future);
         } catch (Throwable t) {
             return new RpcFuture<>(t);
@@ -315,13 +322,13 @@ public class ClientManagerImpl extends ClientManager {
 
     @Override
     public RpcFuture<EndTransactionRequest, EndTransactionResponse> endTransaction(Endpoints endpoints,
-        EndTransactionRequest request, Duration duration) {
+                                                                                   EndTransactionRequest request, Duration duration) {
         try {
             final Metadata metadata = client.sign();
             final Context context = new Context(endpoints, metadata);
             final RpcClient rpcClient = getRpcClient(endpoints);
             final ListenableFuture<EndTransactionResponse> future =
-                rpcClient.endTransaction(metadata, request, asyncWorker, duration);
+                    rpcClient.endTransaction(metadata, request, asyncWorker, duration);
             return new RpcFuture<>(context, request, future);
         } catch (Throwable t) {
             return new RpcFuture<>(t);
@@ -331,13 +338,13 @@ public class ClientManagerImpl extends ClientManager {
     @Override
     public RpcFuture<NotifyClientTerminationRequest, NotifyClientTerminationResponse>
     notifyClientTermination(Endpoints endpoints, NotifyClientTerminationRequest request,
-        Duration duration) {
+                            Duration duration) {
         try {
             final Metadata metadata = client.sign();
             final Context context = new Context(endpoints, metadata);
             final RpcClient rpcClient = getRpcClient(endpoints);
             final ListenableFuture<NotifyClientTerminationResponse> future =
-                rpcClient.notifyClientTermination(metadata, request, asyncWorker, duration);
+                    rpcClient.notifyClientTermination(metadata, request, asyncWorker, duration);
             return new RpcFuture<>(context, request, future);
         } catch (Throwable t) {
             return new RpcFuture<>(t);
@@ -346,7 +353,7 @@ public class ClientManagerImpl extends ClientManager {
 
     @Override
     public StreamObserver<TelemetryCommand> telemetry(Endpoints endpoints, Duration duration,
-        StreamObserver<TelemetryCommand> responseObserver) throws ClientException {
+                                                      StreamObserver<TelemetryCommand> responseObserver) throws ClientException {
         try {
             final Metadata metadata = client.sign();
             final RpcClient rpcClient = getRpcClient(endpoints);
@@ -366,59 +373,72 @@ public class ClientManagerImpl extends ClientManager {
         final ClientId clientId = client.getClientId();
         log.info("Begin to start the client manager, clientId={}", clientId);
         scheduler.scheduleWithFixedDelay(
-            () -> {
-                try {
-                    clearIdleRpcClients();
-                } catch (Throwable t) {
-                    log.error("Exception raised during the clearing of idle rpc clients, clientId={}", clientId, t);
-                }
-            },
-            RPC_CLIENT_IDLE_CHECK_INITIAL_DELAY.toNanos(),
-            RPC_CLIENT_IDLE_CHECK_PERIOD.toNanos(),
-            TimeUnit.NANOSECONDS
+                () -> {
+                    try {
+                        clearIdleRpcClients();
+                    } catch (Throwable t) {
+                        log.error("Exception raised during the clearing of idle rpc clients, clientId={}", clientId, t);
+                    }
+                },
+                RPC_CLIENT_IDLE_CHECK_INITIAL_DELAY.toNanos(),
+                RPC_CLIENT_IDLE_CHECK_PERIOD.toNanos(),
+                TimeUnit.NANOSECONDS
         );
 
         scheduler.scheduleWithFixedDelay(
-            () -> {
-                try {
-                    client.doHeartbeat();
-                } catch (Throwable t) {
-                    log.error("Exception raised during heartbeat, clientId={}", clientId, t);
-                }
-            },
-            HEART_BEAT_INITIAL_DELAY.toNanos(),
-            HEART_BEAT_PERIOD.toNanos(),
-            TimeUnit.NANOSECONDS
+                () -> {
+                    try {
+                        shutdownIdleRpcClients();
+                    } catch (Throwable t) {
+                        log.error("Exception raised during the shutdown of idle rpc clients, clientId={}", clientId, t);
+                    }
+                },
+                RPC_CLIENT_IDLE_CHECK_INITIAL_DELAY.toNanos(),
+                RPC_CLIENT_IDLE_CHECK_PERIOD.toNanos(),
+                TimeUnit.NANOSECONDS
         );
 
         scheduler.scheduleWithFixedDelay(
-            () -> {
-                try {
-                    log.info("Start to log statistics, clientVersion={}, clientWrapperVersion={}, "
-                            + "clientEndpoints={}, os description=[{}], java description=[{}], clientId={}",
-                        MetadataUtils.getVersion(), MetadataUtils.getWrapperVersion(), client.getEndpoints(),
-                        Utilities.getOsDescription(), Utilities.getJavaDescription(), clientId);
-                    client.doStats();
-                } catch (Throwable t) {
-                    log.error("Exception raised during statistics logging, clientId={}", clientId, t);
-                }
-            },
-            LOG_STATS_INITIAL_DELAY.toNanos(),
-            LOG_STATS_PERIOD.toNanos(),
-            TimeUnit.NANOSECONDS
+                () -> {
+                    try {
+                        client.doHeartbeat();
+                    } catch (Throwable t) {
+                        log.error("Exception raised during heartbeat, clientId={}", clientId, t);
+                    }
+                },
+                HEART_BEAT_INITIAL_DELAY.toNanos(),
+                HEART_BEAT_PERIOD.toNanos(),
+                TimeUnit.NANOSECONDS
         );
 
         scheduler.scheduleWithFixedDelay(
-            () -> {
-                try {
-                    client.syncSettings();
-                } catch (Throwable t) {
-                    log.error("Exception raised during the setting synchronization, clientId={}", clientId, t);
-                }
-            },
-            SYNC_SETTINGS_DELAY.toNanos(),
-            SYNC_SETTINGS_PERIOD.toNanos(),
-            TimeUnit.NANOSECONDS
+                () -> {
+                    try {
+                        log.info("Start to log statistics, clientVersion={}, clientWrapperVersion={}, "
+                                        + "clientEndpoints={}, os description=[{}], java description=[{}], clientId={}",
+                                MetadataUtils.getVersion(), MetadataUtils.getWrapperVersion(), client.getEndpoints(),
+                                Utilities.getOsDescription(), Utilities.getJavaDescription(), clientId);
+                        client.doStats();
+                    } catch (Throwable t) {
+                        log.error("Exception raised during statistics logging, clientId={}", clientId, t);
+                    }
+                },
+                LOG_STATS_INITIAL_DELAY.toNanos(),
+                LOG_STATS_PERIOD.toNanos(),
+                TimeUnit.NANOSECONDS
+        );
+
+        scheduler.scheduleWithFixedDelay(
+                () -> {
+                    try {
+                        client.syncSettings();
+                    } catch (Throwable t) {
+                        log.error("Exception raised during the setting synchronization, clientId={}", clientId, t);
+                    }
+                },
+                SYNC_SETTINGS_DELAY.toNanos(),
+                SYNC_SETTINGS_PERIOD.toNanos(),
+                TimeUnit.NANOSECONDS
         );
         log.info("The client manager starts successfully, clientId={}", clientId);
     }
@@ -434,17 +454,12 @@ public class ClientManagerImpl extends ClientManager {
             } else {
                 log.info("Shutdown the client scheduler successfully, clientId={}", clientId);
             }
-            rpcClientTableLock.writeLock().lock();
-            try {
-                final Iterator<Map.Entry<Endpoints, RpcClient>> it = rpcClientTable.entrySet().iterator();
-                while (it.hasNext()) {
-                    final Map.Entry<Endpoints, RpcClient> entry = it.next();
-                    final RpcClient rpcClient = entry.getValue();
-                    it.remove();
-                    rpcClient.shutdown();
-                }
-            } finally {
-                rpcClientTableLock.writeLock().unlock();
+            final Iterator<Map.Entry<Endpoints, RpcClient>> it = rpcClientTable.entrySet().iterator();
+            while (it.hasNext()) {
+                final Map.Entry<Endpoints, RpcClient> entry = it.next();
+                final RpcClient rpcClient = entry.getValue();
+                it.remove();
+                rpcClient.shutdown();
             }
             log.info("Shutdown all rpc client(s) successfully, clientId={}", clientId);
             asyncWorker.shutdown();
@@ -464,5 +479,19 @@ public class ClientManagerImpl extends ClientManager {
     @Override
     protected String serviceName() {
         return super.serviceName() + "-" + client.getClientId().getIndex();
+    }
+
+    private static class RpcClientWrap {
+        Endpoints endpoints;
+        RpcClient rpcClient;
+
+        public RpcClientWrap(Endpoints endpoints, RpcClient rpcClient) {
+            this.endpoints = endpoints;
+            this.rpcClient = rpcClient;
+        }
+
+        public static RpcClientWrap wrap(Endpoints endpoints, RpcClient rpcClient){
+            return new RpcClientWrap(endpoints, rpcClient);
+        }
     }
 }


### PR DESCRIPTION
1. drop rpcClientTableLock, use ConcurrentHashMap instead HashMap
2. use endpoints synchronized ignore concurrent put
3. idleClient split to shutdown



### Which Issue(s) This PR Fixes

Fixes #857 

### Brief Description

Minimize lock control to avoid read and write blocking caused by write locks, and handle independent shutdown idle client

### How Did You Test This Change?

use ClientManagerImplTest 
