### PR TITLE
golang: Add ClientFunc option for simple consumer

### DIFF
--- a/golang/simple_consumer_options.go
+++ b/golang/simple_consumer_options.go
@@ -85,7 +85,7 @@ func newFuncSimpleConsumerOption(f func(*simpleConsumerOptions)) *funcSimpleCons
 	}
 }
 
-// WithClientFuncForSimpleConsumer returns a consumerOption that sets ClientFunc for consumer.
+// WithClientFuncForSimpleConsumer returns a consumerOption that sets ClientFunc for simple consumer.
 // Default is nameserver.New.
 func WithClientFuncForSimpleConsumer(f NewClientFunc) SimpleConsumerOption {
 	return newFuncSimpleConsumerOption(func(o *simpleConsumerOptions) {

--- a/golang/simple_consumer_options.go
+++ b/golang/simple_consumer_options.go
@@ -85,6 +85,14 @@ func newFuncSimpleConsumerOption(f func(*simpleConsumerOptions)) *funcSimpleCons
 	}
 }
 
+// WithClientFuncForSimpleConsumer returns a consumerOption that sets ClientFunc for consumer.
+// Default is nameserver.New.
+func WithClientFuncForSimpleConsumer(f NewClientFunc) SimpleConsumerOption {
+	return newFuncSimpleConsumerOption(func(o *simpleConsumerOptions) {
+		o.clientFunc = f
+	})
+}
+
 // WithTag returns a consumerOption that sets tag for consumer.
 // Note: Default it uses *.
 func WithSubscriptionExpressions(subscriptionExpressions map[string]*FilterExpression) SimpleConsumerOption {


### PR DESCRIPTION
Provides the clientFunc option for `NewSimpleConsumer`, ensuring consistency with `NewProducer`. This allows for the replacement of the `NewClient` process when necessary.