### PR TITLE
[Golang] feat: should use os.UserHomeDir() to get home dir for log

### DIFF
--- a/golang/log.go
+++ b/golang/log.go
@@ -80,7 +80,8 @@ func getEncoder() zapcore.Encoder {
 }
 
 func getLogWriter() zapcore.WriteSyncer {
-	clientLogRoot := utils.GetenvWithDef(CLIENT_LOG_ROOT, os.Getenv("user.home")+"/logs/rocketmqlogs")
+	home, _ := os.UserHomeDir()
+	clientLogRoot := utils.GetenvWithDef(CLIENT_LOG_ROOT, home+"/logs/rocketmqlogs")
 	clientLogMaxIndex := utils.GetenvWithDef(CLIENT_LOG_MAXINDEX, "10")
 	clientLogFileName := utils.GetenvWithDef(CLIENT_LOG_FILENAME, "rocketmq_client_go.log")
 	clientLogMaxFileSize := utils.GetenvWithDef(CLIENT_LOG_FILESIZE, "1073741824")


### PR DESCRIPTION
Change-Id: I495c930949474418529e30538851a98e132243f4

<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #871 

### Brief Description

Fix under some OS (mac or linux), the logs can not write to the home dir by default.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
