### PR TITLE
[ISSUE #872] [Java] feat: should add default keepalive for grpc channel

### DIFF
--- a/java/client/src/main/java/org/apache/rocketmq/client/java/rpc/RpcClientImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/rpc/RpcClientImpl.java
@@ -64,6 +64,9 @@ import org.apache.rocketmq.client.java.route.Endpoints;
 
 public class RpcClientImpl implements RpcClient {
     private static final int CONNECT_TIMEOUT_MILLIS = 3 * 1000;
+    // the grpc server default permitted min keep alive is 5min, so by default we should not less than 5min.
+    private static final int KEEP_ALIVE_TIME_MILLIS = 300 * 1000;
+    private static final int KEEP_ALIVE_TIMEOUT_MILLIS = 30 * 1000;
     private static final int GRPC_MAX_MESSAGE_SIZE = Integer.MAX_VALUE;
 
     private final ManagedChannel channel;
@@ -77,6 +80,9 @@ public class RpcClientImpl implements RpcClient {
         final NettyChannelBuilder channelBuilder =
             NettyChannelBuilder.forTarget(endpoints.getGrpcTarget())
                 .withOption(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MILLIS)
+                .keepAliveTime(KEEP_ALIVE_TIME_MILLIS, TimeUnit.MILLISECONDS)
+                .keepAliveTimeout(KEEP_ALIVE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+                .keepAliveWithoutCalls(true)
                 .maxInboundMessageSize(GRPC_MAX_MESSAGE_SIZE)
                 .intercept(LoggingInterceptor.getInstance());
 


### PR DESCRIPTION
Change-Id: Ie14d6990373cb011da3f4c60aef3ca280ed63819

<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #872 

### Brief Description

By default, the keep alive is not enabled. If the tcp has no response, without keep alive, it need longer time to find it broken.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
