### PR TITLE
[ISSUE#667] Java client Bug gzip&zlib compliance

### DIFF
--- a/golang/pkg/utils/utils.go
+++ b/golang/pkg/utils/utils.go
@@ -20,12 +20,9 @@ package utils
 import (
 	"bytes"
 	"compress/gzip"
-	"compress/zlib"
 	"context"
 	"encoding/hex"
-	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net"
 	"net/url"
@@ -143,33 +140,8 @@ func MatchMessageType(mq *v2.MessageQueue, messageType v2.MessageType) bool {
 	return false
 }
 
-func detectCompressionFormat(in []byte) (string, error) {
-	if len(in) < 2 {
-		return "", errors.New("body too short")
-	}
-	if in[0] == 0x1f && in[1] == 0x8b {
-		return "GZIP", nil
-	} else if in[0] == 0x78 {
-		return "ZLIB", nil
-	} else {
-		return "", errors.New("unknown format")
-	}
-}
-
 func GZIPDecode(in []byte) ([]byte, error) {
-	format, err := detectCompressionFormat(in)
-	if err != nil {
-		return nil, err
-	}
-	var reader io.ReadCloser
-	switch format {
-	case "GZIP":
-		reader, err = gzip.NewReader(bytes.NewReader(in))
-	case "ZLIB":
-		reader, err = zlib.NewReader(bytes.NewReader(in))
-	default:
-		return nil, errors.New("unsupported compression format")
-	}
+	reader, err := gzip.NewReader(bytes.NewReader(in))
 	if err != nil {
 		var out []byte
 		return out, err

--- a/golang/pkg/utils/utils_test.go
+++ b/golang/pkg/utils/utils_test.go
@@ -19,6 +19,8 @@ package utils
 
 import (
 	"compress/gzip"
+	"compress/zlib"
+	"strings"
 	"testing"
 
 	v2 "github.com/apache/rocketmq-clients/golang/v5/protocol/v2"
@@ -113,10 +115,24 @@ func TestMatchMessageType(t *testing.T) {
 
 func TestGZIPDecode(t *testing.T) {
 	_, err := GZIPDecode([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
-	if err != gzip.ErrHeader {
+	if err != gzip.ErrHeader && !strings.Contains(err.Error(), "unknown format") {
 		t.Error()
 	}
 	bytes, err := GZIPDecode([]byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 42, 202, 79, 206, 78, 45, 201, 45, 212, 77, 206, 201, 76, 205, 43, 209, 77, 207, 7, 0, 0, 0, 255, 255, 1, 0, 0, 255, 255, 97, 36, 132, 114, 18, 0, 0, 0})
+	if err != nil {
+		t.Error()
+	}
+	if string(bytes) != "rocketmq-client-go" {
+		t.Error()
+	}
+}
+
+func TestZLIBDecode(t *testing.T) {
+	_, err := GZIPDecode([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+	if err != zlib.ErrHeader && !strings.Contains(err.Error(), "unknown format") {
+		t.Error()
+	}
+	bytes, err := GZIPDecode([]byte{120, 156, 42, 202, 79, 206, 78, 45, 201, 45, 212, 77, 206, 201, 76, 205, 43, 209, 77, 207, 7, 4, 0, 0, 255, 255, 68, 223, 7, 22})
 	if err != nil {
 		t.Error()
 	}

--- a/golang/pkg/utils/utils_test.go
+++ b/golang/pkg/utils/utils_test.go
@@ -19,8 +19,6 @@ package utils
 
 import (
 	"compress/gzip"
-	"compress/zlib"
-	"strings"
 	"testing"
 
 	v2 "github.com/apache/rocketmq-clients/golang/v5/protocol/v2"
@@ -115,24 +113,10 @@ func TestMatchMessageType(t *testing.T) {
 
 func TestGZIPDecode(t *testing.T) {
 	_, err := GZIPDecode([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
-	if err != gzip.ErrHeader && !strings.Contains(err.Error(), "unknown format") {
+	if err != gzip.ErrHeader {
 		t.Error()
 	}
 	bytes, err := GZIPDecode([]byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 42, 202, 79, 206, 78, 45, 201, 45, 212, 77, 206, 201, 76, 205, 43, 209, 77, 207, 7, 0, 0, 0, 255, 255, 1, 0, 0, 255, 255, 97, 36, 132, 114, 18, 0, 0, 0})
-	if err != nil {
-		t.Error()
-	}
-	if string(bytes) != "rocketmq-client-go" {
-		t.Error()
-	}
-}
-
-func TestZLIBDecode(t *testing.T) {
-	_, err := GZIPDecode([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
-	if err != zlib.ErrHeader && !strings.Contains(err.Error(), "unknown format") {
-		t.Error()
-	}
-	bytes, err := GZIPDecode([]byte{120, 156, 42, 202, 79, 206, 78, 45, 201, 45, 212, 77, 206, 201, 76, 205, 43, 209, 77, 207, 7, 4, 0, 0, 255, 255, 68, 223, 7, 22})
 	if err != nil {
 		t.Error()
 	}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #667 

### Brief Description

I has made compatibility processing for the ZLIB data format that may be passed into the GZIP decompression method, and added a new test case for ZLIB compression.

### How Did You Test This Change?

I wrote a test case golang/pkg/utils/utils_test.go#TestZLIBDecoder and built two scenarios. First input non ZLIB format data and test exception handling; second input ZLIB format data to test whether the decompression is correct
