### PR TITLE
Use script to check changed files instead for dorny/paths-filter@v2 in action workflows.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   paths-filter:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       java: ${{ steps.java.outputs.java }}
       cpp: ${{ steps.cpp.outputs.cpp }}
@@ -19,7 +21,7 @@ jobs:
       python: ${{ steps.python.outputs.python }}
       nodejs: ${{ steps.nodejs.outputs.nodejs }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Get changed files (Push/Pull Request)
         id: changed_files
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,14 @@ jobs:
         id: changed_files
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA=${{ github.event.pull_request.base.sha }}
-            HEAD_SHA=${{ github.event.pull_request.head.sha }}
-            CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
+            PR_NUMBER=${{ github.event.pull_request.number }}
+            REPO_OWNER=${{ github.repository_owner }}
+            REPO_NAME=${{ github.event.repository.name }}
+
+            # 调用 GitHub API 获取文件列表
+            CHANGED_FILES=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+              "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUMBER/files" | \
+              jq -r '.[].filename' | tr '\n' ' ')
           else
             CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,36 +10,97 @@ jobs:
   paths-filter:
     runs-on: ubuntu-latest
     outputs:
-      java: ${{ steps.filter.outputs.java }}
-      cpp: ${{ steps.filter.outputs.cpp }}
-      golang: ${{ steps.filter.outputs.golang }}
-      csharp: ${{ steps.filter.outputs.csharp }}
-      php: ${{ steps.filter.outputs.php }}
-      rust: ${{ steps.filter.outputs.rust }}
-      python: ${{ steps.filter.outputs.python }}
-      nodejs: ${{ steps.filter.outputs.nodejs }}
+      java: ${{ steps.java.outputs.java }}
+      cpp: ${{ steps.cpp.outputs.cpp }}
+      golang: ${{ steps.golang.outputs.golang }}
+      csharp: ${{ steps.csharp.outputs.csharp }}
+      php: ${{ steps.php.outputs.php }}
+      rust: ${{ steps.rust.outputs.rust }}
+      python: ${{ steps.python.outputs.python }}
+      nodejs: ${{ steps.nodejs.outputs.nodejs }}
     steps:
       - uses: actions/checkout@v2
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            java:
-              - 'java/**'
-            cpp:
-              - 'cpp/**'
-            golang:
-              - 'golang/**'
-            csharp:
-              - 'csharp/**'
-            php:
-              - 'php/**'
-            rust:
-              - 'rust/**'
-            python:
-              - 'python/**'
-            nodejs:
-              - 'nodejs/**'
+      - name: Get changed files (Push/Pull Request)
+        id: changed_files
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED_FILES=$(jq -r '.pull_request.changed_files[]' <<< ${{ toJson(github.event) }})
+          else
+            CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
+          fi
+          echo "::set-output name=files::$CHANGED_FILES"
+
+      - name: Check Java changes
+        id: java
+        run: |
+          if echo "${{ steps.changed_files.outputs.files }}" | grep -qE '^(java/|pom.xml)'; then
+            echo "::set-output name=java::true"
+          else
+            echo "::set-output name=java::false"
+          fi
+
+      - name: Check C++ changes
+        id: cpp
+        run: |
+          if echo "${{ steps.changed_files.outputs.files }}" | grep -qE '^cpp/'; then
+            echo "::set-output name=cpp::true"
+          else
+            echo "::set-output name=cpp::false"
+          fi
+
+      - name: Check Golang changes
+        id: golang
+        run: |
+          if echo "${{ steps.changed_files.outputs.files }}" | grep -qE '^golang/'; then
+            echo "::set-output name=golang::true"
+          else
+            echo "::set-output name=golang::false"
+          fi
+
+      - name: Check C# changes
+        id: csharp
+        run: |
+          if echo "${{ steps.changed_files.outputs.files }}" | grep -qE '^csharp/'; then
+            echo "::set-output name=csharp::true"
+          else
+            echo "::set-output name=csharp::false"
+          fi
+
+      - name: Check PHP changes
+        id: php
+        run: |
+          if echo "${{ steps.changed_files.outputs.files }}" | grep -qE '^php/'; then
+            echo "::set-output name=php::true"
+          else
+            echo "::set-output name=php::false"
+          fi
+
+      - name: Check Rust changes
+        id: rust
+        run: |
+          if echo "${{ steps.changed_files.outputs.files }}" | grep -qE '^rust/'; then
+            echo "::set-output name=rust::true"
+          else
+            echo "::set-output name=rust::false"
+          fi
+
+      - name: Check Python changes
+        id: python
+        run: |
+          if echo "${{ steps.changed_files.outputs.files }}" | grep -qE '^python/'; then
+            echo "::set-output name=python::true"
+          else
+            echo "::set-output name=python::false"
+          fi
+
+      - name: Check Node.js changes
+        id: nodejs
+        run: |
+          if echo "${{ steps.changed_files.outputs.files }}" | grep -qE '^nodejs/'; then
+            echo "::set-output name=nodejs::true"
+          else
+            echo "::set-output name=nodejs::false"
+          fi
   java-build:
     needs: [paths-filter]
     if: ${{ needs.paths-filter.outputs.java == 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       nodejs: ${{ steps.filter.outputs.nodejs }}
     steps:
       - uses: actions/checkout@v2
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
             REPO_OWNER=${{ github.repository_owner }}
             REPO_NAME=${{ github.event.repository.name }}
 
-            # 调用 GitHub API 获取文件列表
+            # calling GitHub API for changed files in PR
             CHANGED_FILES=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
               "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUMBER/files" | \
               jq -r '.[].filename' | tr '\n' ' ')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,9 @@ jobs:
         id: changed_files
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            CHANGED_FILES=$(jq -r '.pull_request.changed_files[]' <<< ${{ toJson(github.event) }})
+            BASE_SHA=${{ github.event.pull_request.base.sha }}
+            HEAD_SHA=${{ github.event.pull_request.head.sha }}
+            CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
           else
             CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get changed files (Push/Pull Request)
         id: changed_files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             PR_NUMBER=${{ github.event.pull_request.number }}

--- a/java/README.md
+++ b/java/README.md
@@ -65,7 +65,7 @@ We picked [Logback](https://logback.qos.ch/) and shaded it into the client imple
 
 The following logging parameters are all supported for specification by JVM system parameters (for example, `java -Drocketmq.log.level=INFO -jar foobar.jar`) or environment variables.
 
-* `rocketmq.log.level`: log output level, default is INFO.
+* `rocketmq.log.level`: the log output level, default is INFO.
 * `rocketmq.log.root`: the root directory of the log output, default is `$HOME/logs/rocketmq`, so the full path is `$HOME/logs/rocketmq/rocketmq-client.log`.
 * `rocketmq.log.file.maxIndex`: the maximum number of log files to keep, default is 10 (the size of a single log file is limited to 64 MB, no adjustment is supported now).
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -34,7 +34,7 @@ Run the following command to start the example:
 # send message via producer
 cargo run --example producer
 
-# consume message via simple consumer
+# consume message via the simple consumer
 cargo run --example simple_consumer
 ```
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -34,7 +34,7 @@ Run the following command to start the example:
 # send message via producer
 cargo run --example producer
 
-# consume message via the simple consumer
+# consume message via simple consumer
 cargo run --example simple_consumer
 ```
 


### PR DESCRIPTION
…ions.

<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

use script to check changed files instead for dorny/paths-filter@v2 in action workflows.

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
