### PR TITLE
[ISSUE #872][Golang]fix: should add default keepalive for grpc

### DIFF
--- a/golang/conn_options.go
+++ b/golang/conn_options.go
@@ -27,6 +27,7 @@ import (
 	"github.com/apache/rocketmq-clients/golang/v5/pkg/zaplog"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 )
 
 type connOptions struct {
@@ -68,7 +69,14 @@ var defaultConnOptions = connOptions{
 		RootCAs:            x509.NewCertPool(),
 		InsecureSkipVerify: true,
 	},
-	Logger:            zaplog.New(),
+	Logger: zaplog.New(),
+	DialOptions: []grpc.DialOption{
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                300 * time.Second,
+			Timeout:             30 * time.Second,
+			PermitWithoutStream: true,
+		}),
+	},
 }
 
 // A ConnOption sets options such as tls.Config, etc.


### PR DESCRIPTION
Change-Id: I14a3e12300206d63c523a80a76fc930dc70e3571

<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #872

### Brief Description

Same as Java, we should enable default grpc keepalive to make sure we can auto heal after network issue.

### How Did You Test This Change?
