### PR TITLE
Rust: ungate tokio-util crate dependency, correct MSRV and remove unused dependencies

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,7 +18,7 @@
 name = "rocketmq"
 version = "5.0.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.81.0"
 authors = [
     "SSpirits <admin@lv5.moe>",
     "Zhanhui Li <lizhanhui@gmail.com>",
@@ -51,10 +51,6 @@ slog-term = "2.9.0"
 slog-async = "2.7.0"
 slog-json = "2.6.1"
 
-opentelemetry = { version = "0.19.0", features = ["metrics", "rt-tokio"] }
-opentelemetry-otlp = { version = "0.12.0", features = ["metrics", "grpc-tonic"] }
-minitrace = "0.4"
-
 byteorder = "1"
 mac_address = "1.1.4"
 hex = "0.4.3"
@@ -66,7 +62,7 @@ mockall_double = "0.3.0"
 
 siphasher = "0.3.10"
 ring = "0.16.20"
-tokio-util = { version = "=0.7.10", features = ["rt"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 
 [build-dependencies]
 tonic-build = "0.9.0"


### PR DESCRIPTION
1. Ungate tokio-util from version "=0.7.10" to "0.7".
2. The correct MSRV should be "1.81.0".
3. Remove unused opentelemetry, minitrace related dependencies.

----

```bash
cargo msrv find
  [Meta]   cargo-msrv 0.18.4

Compatibility Check #1: Rust 1.72.1
  [FAIL]   Is incompatible

  ╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │ error: package `predicates-core v1.0.9` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.72.1 │
  │ Either upgrade to rustc 1.74 or newer, or use                                                                                                       │
  │ cargo update -p predicates-core@1.0.9 --precise ver                                                                                                 │
  │ where `ver` is the latest version of `predicates-core` supporting rustc 1.72.1                                                                      │
  │                                                                                                                                                     │
  ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯


Compatibility Check #2: Rust 1.80.1
  [FAIL]   Is incompatible

  ╭────────────────────────────────────────────────────────────────────────╮
  │ error: rustc 1.80.1 is not supported by the following package:         │
  │   home@0.5.11 requires rustc 1.81                                      │
  │ Either upgrade rustc or select compatible dependency versions with     │
  │ `cargo update <name>@<current-ver> --precise <compatible-ver>`         │
  │ where `<compatible-ver>` is the latest version supporting rustc 1.80.1 │
  │                                                                        │
  │                                                                        │
  ╰────────────────────────────────────────────────────────────────────────╯


Compatibility Check #3: Rust 1.84.1
  [OK]     Is compatible

Compatibility Check #4: Rust 1.82.0
  [OK]     Is compatible

Compatibility Check #5: Rust 1.81.0
  [OK]     Is compatible

Result:
   Considered (min … max):   Rust 1.56.1 … Rust 1.87.0
   Search method:            bisect
   MSRV:                     1.81.0
   Target:                   aarch64-apple-darwin
```
