### PR TITLE
chore(ci): Replace archived actions-rs actions

### DIFF
--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -13,10 +13,9 @@ jobs:
         with:
           submodules: true
       - name: Install stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: rustfmt
+        run: |
+           rustup toolchain add --component rustfmt stable
+           rustup override set stable
       - name: Code format check
         run: cargo fmt --check
   clippy:
@@ -30,11 +29,9 @@ jobs:
         with:
           submodules: true
       - name: Install stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: clippy
-      # Run clippy
+        run: |
+           rustup toolchain add --component clippy stable
+           rustup override set stable
       - name: clippy check
         run: cargo clippy --all-features -- -D warnings
   doc:
@@ -68,6 +65,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
       - name: Install cargo-msrv
         run: |
           cargo install cargo-msrv

--- a/.github/workflows/rust_coverage.yaml
+++ b/.github/workflows/rust_coverage.yaml
@@ -17,16 +17,14 @@ jobs:
           submodules: true
 
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
 
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
       - name: Install cargo-llvm-cov
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-llvm-cov
+        run: |
+          cargo install cargo-llvm-cov
 
       - name: Generate code coverage
         working-directory: ./rust


### PR DESCRIPTION
The actions-rs org has been archived for years at this point and it doesn't look like it's coming back. For security reasons we are going to remove it from the list of allowed actions in the org soon. (See https://github.com/apache/infrastructure-actions)
