### PR TITLE
[ISSUE #1037] [Python] Increase dependency version of opentelemetry library

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -23,9 +23,9 @@ setup(
         "grpcio>=1.5.0",
         "grpcio-tools>=1.5.0",
         'protobuf',
-        "opentelemetry-api>=1.2.0",
-        "opentelemetry-sdk>=1.2.0",
-        "opentelemetry-exporter-otlp>=1.2.0"
+        "opentelemetry-api>=1.33.0",
+        "opentelemetry-sdk>=1.33.0",
+        "opentelemetry-exporter-otlp>=1.33.0"
     ],
     python_requires='>=3.7',
 )


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

Fixes [#1037](https://github.com/apache/rocketmq-clients/issues/1037)

### Brief Description

Upgrade the opentelemetry version in setup.py from 1.2.0 to 1.33.0

### How Did You Test This Change?

Successfully run the producer and consumer in the example folder