### PR TITLE
[ISSUE #1049] [Rust] Add heartbeat health check API to Client

### DIFF
--- a/rust/src/producer.rs
+++ b/rust/src/producer.rs
@@ -459,6 +459,10 @@ impl Producer {
         }
         self.client.shutdown().await
     }
+
+    pub fn is_heartbeat_healthy(&self) -> bool {
+        self.client.is_heartbeat_healthy()
+    }
 }
 
 #[cfg(test)]

--- a/rust/src/push_consumer.rs
+++ b/rust/src/push_consumer.rs
@@ -335,6 +335,10 @@ impl PushConsumer {
         }
         Ok(messages)
     }
+
+    pub fn is_heartbeat_healthy(&self) -> bool {
+        self.client.is_heartbeat_healthy()
+    }
 }
 
 #[derive(Debug)]

--- a/rust/src/simple_consumer.rs
+++ b/rust/src/simple_consumer.rs
@@ -205,6 +205,10 @@ impl SimpleConsumer {
             )
             .await
     }
+
+    pub fn is_heartbeat_healthy(&self) -> bool {
+        self.client.is_heartbeat_healthy()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Add is_heartbeat_healthy() method to Client for checking heartbeat status
- Expose heartbeat health check in PushConsumer, Producer, and SimpleConsumer via public method
- Heartbeat status is updated every 30s in client background task
- Initialize heartbeat status as unhealthy on client creation
- Add related unit tests to cover heartbeat health logic

<!-- Please make sure the target branch is right. In most cases, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

[ISSUE [#1049](https://github.com/apache/rocketmq-clients/issues/1049)] [Rust] Add heartbeat health check API to Client

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Add a heartbeat health check API to the RocketMQ Rust client.
Expose is_heartbeat_healthy(), Producer, and SimpleConsumer to allow applications to check if the client maintains a healthy heartbeat with the broker. Heartbeat status is updated periodically by the client background task.

### How Did You Test This Change?
Added and updated unit tests to verify the heartbeat health check logic in Client.
Manually validated that the health status reflects heartbeat success and failure scenarios.

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
