### PR TITLE
[ISSUE #1051] Upgrade slf4j version to match current logback version

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -53,7 +53,7 @@
         <protobuf.version>3.24.4</protobuf.version>
         <grpc.version>1.50.0</grpc.version>
         <guava.version>32.0.0-jre</guava.version>
-        <slf4j.version>1.7.30</slf4j.version>
+        <slf4j.version>2.0.13</slf4j.version>
         <logback.version>1.3.15</logback.version>
         <commons-lang3.version>3.4</commons-lang3.version>
         <opentelemetry.version>1.14.0</opentelemetry.version>


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1051 

### Brief Description
Logback version 1.3.15 is incompatible with SLF4J version 1.7.30.
The SLF4J version must be upgraded to 2.0.x.

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
