### PR TITLE
[ISSUE #1057] [Java] Enhance MessageImpl to allow subclasses to access properties

### DIFF
--- a/java/client/src/main/java/org/apache/rocketmq/client/java/message/GeneralMessageImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/message/GeneralMessageImpl.java
@@ -20,7 +20,7 @@ package org.apache.rocketmq.client.java.message;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.rocketmq.client.apis.message.Message;
@@ -118,7 +118,7 @@ public class GeneralMessageImpl implements GeneralMessage {
 
     @Override
     public Map<String, String> getProperties() {
-        return new HashMap<>(properties);
+        return Collections.unmodifiableMap(properties);
     }
 
     @Override

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/message/MessageImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/message/MessageImpl.java
@@ -21,7 +21,7 @@ import com.google.common.base.MoreObjects;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -45,7 +45,7 @@ public class MessageImpl implements Message {
     @Nullable
     private final Long deliveryTimestamp;
 
-    private final Map<String, String> properties;
+    protected final Map<String, String> properties;
 
     /**
      * The caller is supposed to have validated the arguments and handled throwing exception or
@@ -103,7 +103,7 @@ public class MessageImpl implements Message {
      */
     @Override
     public Map<String, String> getProperties() {
-        return new HashMap<>(properties);
+        return Collections.unmodifiableMap(properties);
     }
 
     /**

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/message/MessageViewImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/message/MessageViewImpl.java
@@ -32,7 +32,7 @@ import java.nio.ByteBuffer;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.rocketmq.client.apis.message.MessageId;
@@ -119,7 +119,7 @@ public class MessageViewImpl implements MessageView {
      */
     @Override
     public Map<String, String> getProperties() {
-        return new HashMap<>(properties);
+        return Collections.unmodifiableMap(properties);
     }
 
     /**


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #[1057](https://github.com/apache/rocketmq-clients/issues/1057)

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
1. Change MessageImpl.properties visibility from private to protected
2. Modify getProperties() to return Collections.unmodifiableMap(properties) instead of new HashMap<>(properties)

This change enables:

- Inheritance-based access to properties in subclasses
- Immutable view of properties to prevent external modifications
- Better performance by avoiding unnecessary HashMap allocations
- Maintains backward compatibility while improving extensibility

