### PR TITLE
[ISSUE #1055] [Golang] Enhance grpc failover resilience

### DIFF
--- a/golang/client_manager.go
+++ b/golang/client_manager.go
@@ -19,14 +19,13 @@ package golang
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/apache/rocketmq-clients/golang/v5/pkg/ticker"
 	"github.com/apache/rocketmq-clients/golang/v5/pkg/utils"
 	v2 "github.com/apache/rocketmq-clients/golang/v5/protocol/v2"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type ClientManager interface {
@@ -59,6 +58,9 @@ type clientManagerOptions struct {
 
 	SYNC_SETTINGS_DELAY  time.Duration
 	SYNC_SETTINGS_PERIOD time.Duration
+
+	CHECK_ISOLATED_ENDPOINTS_INITIAL_DELAY time.Duration
+	CHECK_ISOLATED_ENDPOINTS_PERIOD        time.Duration
 }
 
 var defaultClientManagerOptions = clientManagerOptions{
@@ -75,14 +77,19 @@ var defaultClientManagerOptions = clientManagerOptions{
 
 	SYNC_SETTINGS_DELAY:  time.Second * 1,
 	SYNC_SETTINGS_PERIOD: time.Minute * 5,
+
+	CHECK_ISOLATED_ENDPOINTS_INITIAL_DELAY: time.Second * 1,
+	CHECK_ISOLATED_ENDPOINTS_PERIOD:        time.Second * 5,
 }
 
 type defaultClientManager struct {
-	rpcClientTable     map[string]RpcClient
-	rpcClientTableLock sync.RWMutex
-	clientTable        sync.Map
-	done               chan struct{}
-	opts               clientManagerOptions
+	rpcClientTable      map[string]RpcClient
+	rpcClientTableLock  sync.RWMutex
+	clientTable         sync.Map
+	done                chan struct{}
+	opts                clientManagerOptions
+	selectedEndpointMap sync.Map
+	isolated            sync.Map
 }
 
 var _ = ClientManager(&defaultClientManager{})
@@ -130,6 +137,12 @@ func (cm *defaultClientManager) startUp() {
 		ticker.Tick(cm.syncSettings, (cm.opts.SYNC_SETTINGS_PERIOD), cm.done)
 	}()
 
+	go func() {
+		time.Sleep(cm.opts.CHECK_ISOLATED_ENDPOINTS_INITIAL_DELAY)
+		cm.checkIsolatedEndpoints()
+		ticker.Tick(cm.checkIsolatedEndpoints, (cm.opts.CHECK_ISOLATED_ENDPOINTS_PERIOD), cm.done)
+	}()
+
 	sugarBaseLogger.Info("the client manager starts successfully")
 }
 func (cm *defaultClientManager) deleteRpcClient(rpcClient RpcClient) {
@@ -167,6 +180,24 @@ func (cm *defaultClientManager) syncSettings() {
 		return true
 	})
 }
+func (cm *defaultClientManager) checkIsolatedEndpoints() {
+	sugarBaseLogger.Debug("clientManager start checkIsolatedEndpoints")
+	cm.isolated.Range(func(key, _ interface{}) bool {
+		endpoint, ok := key.(string)
+		if !ok {
+			return true
+		}
+		rpcClient, err := NewRpcClient(endpoint)
+		if err == nil {
+			_, err = rpcClient.HeartBeat(context.TODO(), &v2.HeartbeatRequest{})
+			if err == nil {
+				cm.isolated.Delete(endpoint)
+			}
+			rpcClient.GracefulStop()
+		}
+		return true
+	})
+}
 func (cm *defaultClientManager) shutdown() {
 	sugarBaseLogger.Info("begin to shutdown the client manager")
 	cm.done <- struct{}{}
@@ -183,44 +214,60 @@ func (cm *defaultClientManager) cleanRpcClient() {
 	}
 }
 func (cm *defaultClientManager) getRpcClient(endpoints *v2.Endpoints) (RpcClient, error) {
-	target := utils.ParseAddress(utils.SelectAnAddress(endpoints))
-
+	// Reuse endpoints to get RpcClient
+	targets := utils.FormatTarget(endpoints)
+	if selectedEndpoint, ok := cm.selectedEndpointMap.Load(targets); ok {
+		cm.rpcClientTableLock.RLock()
+		item, ok := cm.rpcClientTable[selectedEndpoint.(string)]
+		cm.rpcClientTableLock.RUnlock()
+		if ok {
+			if ret, ok := item.(*rpcClient); ok {
+				return ret, nil
+			}
+		}
+		cm.selectedEndpointMap.Delete(targets)
+	}
+	// If the RpcClient for the target does not exist, create a new one
+	// Filter out isolated endpoints and select a target address
+	var filtered []*v2.Address
+	for _, addr := range endpoints.GetAddresses() {
+		parsed := utils.ParseAddress(addr)
+		if _, isolated := cm.isolated.Load(parsed); !isolated {
+			filtered = append(filtered, addr)
+		}
+	}
+	// If all addresses are isolated, return an error indicating no available endpoints
+	if len(filtered) == 0 {
+		return nil, fmt.Errorf("no available endpoints for targets %s, all endpoints are isolated", targets)
+	}
+	selectedEndpoint := utils.ParseAddress(utils.SelectAnAddress(&v2.Endpoints{Addresses: filtered}))
 	cm.rpcClientTableLock.RLock()
-	item, ok := cm.rpcClientTable[target]
+	item, ok := cm.rpcClientTable[selectedEndpoint]
 	cm.rpcClientTableLock.RUnlock()
 	if ok {
 		if ret, ok := item.(*rpcClient); ok {
+			cm.selectedEndpointMap.Store(targets, selectedEndpoint)
 			return ret, nil
 		}
 	}
-
-	cm.rpcClientTableLock.Lock()
-	defer cm.rpcClientTableLock.Unlock()
-
-	// double check
-	item, ok = cm.rpcClientTable[target]
-	if ok {
-		if ret, ok := item.(*rpcClient); ok {
-			return ret, nil
-		}
-	}
-	rpcClient, err := NewRpcClient(target)
+	rpcClient, err := NewRpcClient(selectedEndpoint)
 	if err != nil {
-		return nil, err
+		cm.isolated.Store(selectedEndpoint, true)
+		sugarBaseLogger.Warnf("Create newRpcClient failed, err=%v, target=%s, trying to use another available endpoint to retry.", err, selectedEndpoint)
+		return cm.getRpcClient(endpoints)
 	}
-	cm.rpcClientTable[target] = rpcClient
+	cm.selectedEndpointMap.Store(targets, selectedEndpoint)
+	cm.rpcClientTable[selectedEndpoint] = rpcClient
 	return rpcClient, nil
 }
 func (cm *defaultClientManager) handleGrpcError(rpcClient RpcClient, err error) {
 	if err != nil {
-		if e, ok := status.FromError(err); ok {
-			if e.Code() == codes.Unavailable {
-				sugarBaseLogger.Errorf("happened unavailable err=%w, close rpcClient=%s", err, rpcClient.GetTarget())
-				cm.rpcClientTableLock.Lock()
-				defer cm.rpcClientTableLock.Unlock()
-				cm.deleteRpcClient(rpcClient)
-			}
-		}
+		// Mark the target address of this rpcClient as isolated
+		cm.isolated.Store(rpcClient.GetTarget(), true)
+		sugarBaseLogger.Errorf("grpc communication error occurred. err=%v, close rpcClient=%s", err, rpcClient.GetTarget())
+		cm.rpcClientTableLock.Lock()
+		defer cm.rpcClientTableLock.Unlock()
+		cm.deleteRpcClient(rpcClient)
 	}
 }
 func (cm *defaultClientManager) QueryRoute(ctx context.Context, endpoints *v2.Endpoints, request *v2.QueryRouteRequest, duration time.Duration) (*v2.QueryRouteResponse, error) {
@@ -231,6 +278,10 @@ func (cm *defaultClientManager) QueryRoute(ctx context.Context, endpoints *v2.En
 	}
 	ret, err := rpcClient.QueryRoute(ctx, request)
 	cm.handleGrpcError(rpcClient, err)
+	if err != nil {
+		sugarBaseLogger.Warnf("QueryRoute failed, err=%v, target=%s, trying to use another available endpoint to retry", err, rpcClient.GetTarget())
+		return cm.QueryRoute(ctx, endpoints, request, duration)
+	}
 	return ret, err
 }
 
@@ -242,6 +293,10 @@ func (cm *defaultClientManager) QueryAssignments(ctx context.Context, endpoints 
 	}
 	ret, err := rpcClient.QueryAssignments(ctx, request)
 	cm.handleGrpcError(rpcClient, err)
+	if err != nil {
+		sugarBaseLogger.Warnf("QueryAssignments failed, err=%v, target=%s, trying to use another available endpoint to retry", err, rpcClient.GetTarget())
+		return cm.QueryAssignments(ctx, endpoints, request, duration)
+	}
 	return ret, err
 }
 
@@ -253,6 +308,10 @@ func (cm *defaultClientManager) SendMessage(ctx context.Context, endpoints *v2.E
 	}
 	ret, err := rpcClient.SendMessage(ctx, request)
 	cm.handleGrpcError(rpcClient, err)
+	if err != nil {
+		sugarBaseLogger.Warnf("SendMessage failed, err=%v, target=%s, trying to use another available endpoint to retry", err, rpcClient.GetTarget())
+		return cm.SendMessage(ctx, endpoints, request, duration)
+	}
 	return ret, err
 }
 
@@ -264,6 +323,10 @@ func (cm *defaultClientManager) Telemetry(ctx context.Context, endpoints *v2.End
 	}
 	ret, err := rpcClient.Telemetry(ctx)
 	cm.handleGrpcError(rpcClient, err)
+	if err != nil {
+		sugarBaseLogger.Warnf("Telemetry failed, err=%v, target=%s, trying to use another available endpoint to retry", err, rpcClient.GetTarget())
+		return cm.Telemetry(ctx, endpoints, duration)
+	}
 	return ret, err
 }
 
@@ -275,6 +338,10 @@ func (cm *defaultClientManager) EndTransaction(ctx context.Context, endpoints *v
 	}
 	ret, err := rpcClient.EndTransaction(ctx, request)
 	cm.handleGrpcError(rpcClient, err)
+	if err != nil {
+		sugarBaseLogger.Warnf("EndTransaction failed, err=%v, target=%s, trying to use another available endpoint to retry", err, rpcClient.GetTarget())
+		return cm.EndTransaction(ctx, endpoints, request, duration)
+	}
 	return ret, err
 }
 
@@ -287,6 +354,10 @@ func (cm *defaultClientManager) HeartBeat(ctx context.Context, endpoints *v2.End
 
 	ret, err := rpcClient.HeartBeat(ctx, request)
 	cm.handleGrpcError(rpcClient, err)
+	if err != nil {
+		sugarBaseLogger.Warnf("HeartBeat failed, err=%v, target=%s, trying to use another available endpoint to retry", err, rpcClient.GetTarget())
+		return cm.HeartBeat(ctx, endpoints, request, duration)
+	}
 	return ret, err
 }
 
@@ -298,6 +369,10 @@ func (cm *defaultClientManager) NotifyClientTermination(ctx context.Context, end
 	}
 	ret, err := rpcClient.NotifyClientTermination(ctx, request)
 	cm.handleGrpcError(rpcClient, err)
+	if err != nil {
+		sugarBaseLogger.Warnf("NotifyClientTermination failed, err=%v, target=%s, trying to use another available endpoint to retry", err, rpcClient.GetTarget())
+		return cm.NotifyClientTermination(ctx, endpoints, request, duration)
+	}
 	return ret, err
 }
 
@@ -308,6 +383,10 @@ func (cm *defaultClientManager) ReceiveMessage(ctx context.Context, endpoints *v
 	}
 	ret, err := rpcClient.ReceiveMessage(ctx, request)
 	cm.handleGrpcError(rpcClient, err)
+	if err != nil {
+		sugarBaseLogger.Warnf("ReceiveMessages failed, err=%v, target=%s, trying to use another available endpoint to retry", err, rpcClient.GetTarget())
+		return cm.ReceiveMessage(ctx, endpoints, request)
+	}
 	return ret, err
 }
 
@@ -319,6 +398,10 @@ func (cm *defaultClientManager) AckMessage(ctx context.Context, endpoints *v2.En
 	}
 	ret, err := rpcClient.AckMessage(ctx, request)
 	cm.handleGrpcError(rpcClient, err)
+	if err != nil {
+		sugarBaseLogger.Warnf("AckMessage failed, err=%v, target=%s, trying to use another available endpoint to retry", err, rpcClient.GetTarget())
+		return cm.AckMessage(ctx, endpoints, request, duration)
+	}
 	return ret, err
 }
 
@@ -330,6 +413,10 @@ func (cm *defaultClientManager) ChangeInvisibleDuration(ctx context.Context, end
 	}
 	ret, err := rpcClient.ChangeInvisibleDuration(ctx, request)
 	cm.handleGrpcError(rpcClient, err)
+	if err != nil {
+		sugarBaseLogger.Warnf("ChangeInvisibleDuration failed, err=%v, target=%s, trying to use another available endpoint to retry", err, rpcClient.GetTarget())
+		return cm.ChangeInvisibleDuration(ctx, endpoints, request, duration)
+	}
 	return ret, err
 }
 
@@ -341,5 +428,9 @@ func (cm *defaultClientManager) ForwardMessageToDeadLetterQueue(ctx context.Cont
 	}
 	ret, err := rpcClient.ForwardMessageToDeadLetterQueue(ctx, request)
 	cm.handleGrpcError(rpcClient, err)
+	if err != nil {
+		sugarBaseLogger.Warnf("ForwardMessageToDeadLetterQueue failed, err=%v, target=%s, trying to use another available endpoint to retry", err, rpcClient.GetTarget())
+		return cm.ForwardMessageToDeadLetterQueue(ctx, endpoints, request, duration)
+	}
 	return ret, err
 }

--- a/golang/client_manager_test.go
+++ b/golang/client_manager_test.go
@@ -335,6 +335,9 @@ func TestCMClearIdleRpcClients(t *testing.T) {
 
 		SYNC_SETTINGS_DELAY:  time.Hour,
 		SYNC_SETTINGS_PERIOD: time.Hour,
+
+		CHECK_ISOLATED_ENDPOINTS_INITIAL_DELAY: time.Hour,
+		CHECK_ISOLATED_ENDPOINTS_PERIOD:        time.Hour,
 	})
 	defer stubs.Reset()
 

--- a/golang/client_test.go
+++ b/golang/client_test.go
@@ -48,6 +48,9 @@ func BuildCLient(t *testing.T) *defaultClient {
 
 		SYNC_SETTINGS_DELAY:  time.Hour,
 		SYNC_SETTINGS_PERIOD: time.Hour,
+
+		CHECK_ISOLATED_ENDPOINTS_INITIAL_DELAY: time.Hour,
+		CHECK_ISOLATED_ENDPOINTS_PERIOD:        time.Hour,
 	})
 
 	stubs2 := gostub.Stub(&NewRpcClient, func(target string, opts ...RpcClientOption) (RpcClient, error) {
@@ -115,6 +118,9 @@ func TestCLINewClient(t *testing.T) {
 
 		SYNC_SETTINGS_DELAY:  time.Hour,
 		SYNC_SETTINGS_PERIOD: time.Hour,
+
+		CHECK_ISOLATED_ENDPOINTS_INITIAL_DELAY: time.Hour,
+		CHECK_ISOLATED_ENDPOINTS_PERIOD:        time.Hour,
 	})
 
 	stubs2 := gostub.Stub(&NewRpcClient, func(target string, opts ...RpcClientOption) (RpcClient, error) {

--- a/golang/pkg/utils/utils.go
+++ b/golang/pkg/utils/utils.go
@@ -121,6 +121,23 @@ func ParseTarget(target string) (*v2.Endpoints, error) {
 	return ret, nil
 }
 
+func FormatTarget(endpoints *v2.Endpoints) string {
+	if endpoints == nil {
+		return ""
+	}
+	if len(endpoints.GetAddresses()) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for i, address := range endpoints.GetAddresses() {
+		if i > 0 {
+			sb.WriteString(";")
+		}
+		sb.WriteString(ParseAddress(address))
+	}
+	return sb.String()
+}
+
 func GetOsDescription() string {
 	osName := os.Getenv("os.name")
 	if len(osName) == 0 {

--- a/golang/producer_test.go
+++ b/golang/producer_test.go
@@ -44,6 +44,9 @@ func TestProducer(t *testing.T) {
 
 		SYNC_SETTINGS_DELAY:  time.Hour,
 		SYNC_SETTINGS_PERIOD: time.Hour,
+
+		CHECK_ISOLATED_ENDPOINTS_INITIAL_DELAY: time.Hour,
+		CHECK_ISOLATED_ENDPOINTS_PERIOD:        time.Hour,
 	})
 
 	stubs2 := gostub.Stub(&NewRpcClient, func(target string, opts ...RpcClientOption) (RpcClient, error) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes https://github.com/apache/rocketmq-clients/issues/1055

### Brief Description

1. Add nameResolver, endpoint's scheme is ipv4 or ipv6 can be resolved.
2. Optimized the sending method from sending to multiple endpoints sequentially to sending to all endpoints at once.
