### PR TITLE
python: handle callback submission after client shutdown

### DIFF
--- a/python/rocketmq/v5/client/client.py
+++ b/python/rocketmq/v5/client/client.py
@@ -309,7 +309,10 @@ class Client:
         return self.__rpc_client.get_channel_io_loop()
 
     def _submit_callback(self, callback_result):
-        self.__client_callback_executor.submit(Client.__handle_callback, callback_result)
+        if self.__client_callback_executor is not None:
+            self.__client_callback_executor.submit(Client.__handle_callback, callback_result)
+        else:
+            logger.error(f"{self.__str__()} client callback executor is not running.")
 
     """ private """
 


### PR DESCRIPTION


### Which Issue(s) This PR Fixes
![20250821-160747](https://github.com/user-attachments/assets/bd73aa29-5b40-4626-b75f-0f857a0731a7)
AttributeError during async simple consumer shutdown when pending futures exist
Problem: When shutting down an async simple consumer with unprocessed futures, the code attempts to submit callbacks to a null __client_callback_executor, causing AttributeError: 'NoneType' object has no attribute 'submit'.

### Brief Description

Add null check in _submit_callback to gracefully handle cases where external code attempts to submit callbacks after the client has been shut down and the callback executor is None.

### How Did You Test This Change?


