### PR TITLE
During doStats, the consumer records statistics about request latency.

### DIFF
--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImplTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImplTest.java
@@ -284,29 +284,4 @@ public class ProcessQueueImplTest extends TestBase {
             .untilAsserted(() -> verify(pushConsumer, times(forwardingToDeadLetterQueueTimes))
                 .forwardMessageToDeadLetterQueue(any(MessageViewImpl.class)));
     }
-
-    @Test
-    public void testDoStatsWithReceiveLatency() throws NoSuchFieldException, IllegalAccessException {
-        // Test that doStats correctly calculates and resets average receive latency
-        when(pushConsumer.getClientId()).thenReturn(FAKE_CLIENT_ID);
-        
-        // Simulate some receive operations by directly setting the latency fields
-        Field totalSuccessfulLatencyField = ProcessQueueImpl.class.getDeclaredField("totalSuccessfulReceiveLatencyMs");
-        totalSuccessfulLatencyField.setAccessible(true);
-        totalSuccessfulLatencyField.set(processQueue, new AtomicLong(100L)); // 100ms
-        
-        Field successfulCountField = ProcessQueueImpl.class.getDeclaredField("successfulReceiveCount");
-        successfulCountField.setAccessible(true);
-        successfulCountField.set(processQueue, new AtomicLong(2L)); // 2 successful receives
-        
-        // Call doStats
-        processQueue.doStats();
-        
-        // Verify that the fields are reset to 0 after doStats
-        AtomicLong totalSuccessfulLatency = (AtomicLong) totalSuccessfulLatencyField.get(processQueue);
-        AtomicLong successfulCount = (AtomicLong) successfulCountField.get(processQueue);
-        
-        assert totalSuccessfulLatency.get() == 0L : "totalSuccessfulReceiveLatencyMs should be reset to 0";
-        assert successfulCount.get() == 0L : "successfulReceiveCount should be reset to 0";
-    }
 }

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImplTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImplTest.java
@@ -284,4 +284,29 @@ public class ProcessQueueImplTest extends TestBase {
             .untilAsserted(() -> verify(pushConsumer, times(forwardingToDeadLetterQueueTimes))
                 .forwardMessageToDeadLetterQueue(any(MessageViewImpl.class)));
     }
+
+    @Test
+    public void testDoStatsWithReceiveLatency() throws NoSuchFieldException, IllegalAccessException {
+        // Test that doStats correctly calculates and resets average receive latency
+        when(pushConsumer.getClientId()).thenReturn(FAKE_CLIENT_ID);
+        
+        // Simulate some receive operations by directly setting the latency fields
+        Field totalSuccessfulLatencyField = ProcessQueueImpl.class.getDeclaredField("totalSuccessfulReceiveLatencyMs");
+        totalSuccessfulLatencyField.setAccessible(true);
+        totalSuccessfulLatencyField.set(processQueue, new AtomicLong(100L)); // 100ms
+        
+        Field successfulCountField = ProcessQueueImpl.class.getDeclaredField("successfulReceiveCount");
+        successfulCountField.setAccessible(true);
+        successfulCountField.set(processQueue, new AtomicLong(2L)); // 2 successful receives
+        
+        // Call doStats
+        processQueue.doStats();
+        
+        // Verify that the fields are reset to 0 after doStats
+        AtomicLong totalSuccessfulLatency = (AtomicLong) totalSuccessfulLatencyField.get(processQueue);
+        AtomicLong successfulCount = (AtomicLong) successfulCountField.get(processQueue);
+        
+        assert totalSuccessfulLatency.get() == 0L : "totalSuccessfulReceiveLatencyMs should be reset to 0";
+        assert successfulCount.get() == 0L : "successfulReceiveCount should be reset to 0";
+    }
 }

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImplTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImplTest.java
@@ -287,17 +287,21 @@ public class ProcessQueueImplTest extends TestBase {
 
     @Test
     public void testDoStatsWithReceiveLatency() throws NoSuchFieldException, IllegalAccessException {
-        // Test that doStats correctly calculates and resets average receive latency for both successful and failed requests
+        // Test that doStats correctly calculates and resets correctly
         when(pushConsumer.getClientId()).thenReturn(FAKE_CLIENT_ID);
         
         // Simulate some receive operations by directly setting the latency fields
-        Field totalSuccessfulLatencyField = ProcessQueueImpl.class.getDeclaredField("totalSuccessfulReceiveLatencyMs");
+        Field totalSuccessfulLatencyField = ProcessQueueImpl.class
+            .getDeclaredField("totalSuccessfulReceiveLatencyMs");
         totalSuccessfulLatencyField.setAccessible(true);
-        totalSuccessfulLatencyField.set(processQueue, new AtomicLong(200L)); // 200ms total for successful requests
+        // 200ms total for successful requests
+        totalSuccessfulLatencyField.set(processQueue, new AtomicLong(200L));
         
-        Field totalFailedLatencyField = ProcessQueueImpl.class.getDeclaredField("totalFailedReceiveLatencyMs");
+        Field totalFailedLatencyField = ProcessQueueImpl.class
+            .getDeclaredField("totalFailedReceiveLatencyMs");
         totalFailedLatencyField.setAccessible(true);
-        totalFailedLatencyField.set(processQueue, new AtomicLong(150L)); // 150ms total for failed requests
+        // 150ms total for failed requests
+        totalFailedLatencyField.set(processQueue, new AtomicLong(150L)); 
         
         Field successfulCountField = ProcessQueueImpl.class.getDeclaredField("successfulReceiveCount");
         successfulCountField.setAccessible(true);
@@ -328,11 +332,13 @@ public class ProcessQueueImplTest extends TestBase {
         when(pushConsumer.getClientId()).thenReturn(FAKE_CLIENT_ID);
         
         // Set all counts to 0
-        Field totalSuccessfulLatencyField = ProcessQueueImpl.class.getDeclaredField("totalSuccessfulReceiveLatencyMs");
+        Field totalSuccessfulLatencyField = ProcessQueueImpl.class
+            .getDeclaredField("totalSuccessfulReceiveLatencyMs");
         totalSuccessfulLatencyField.setAccessible(true);
         totalSuccessfulLatencyField.set(processQueue, new AtomicLong(0L));
         
-        Field totalFailedLatencyField = ProcessQueueImpl.class.getDeclaredField("totalFailedReceiveLatencyMs");
+        Field totalFailedLatencyField = ProcessQueueImpl.class
+            .getDeclaredField("totalFailedReceiveLatencyMs");
         totalFailedLatencyField.setAccessible(true);
         totalFailedLatencyField.set(processQueue, new AtomicLong(0L));
         


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1085 1085

### Brief Description

Currently, when the consumer performs doStats, only queue-level metrics such as receptionTimes, receivedMessageQuantity, cachedMessageCount, and cachedMessageBytes are collected, and there is a lack of information about the average request latency.

The consumer collects request latency statistics when performing doStats.

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
