### PR TITLE
[ fix 1087]use round_robin as default lb policy when create rpcClient

### DIFF
--- a/java/client/src/main/java/org/apache/rocketmq/client/java/rpc/RpcClientImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/rpc/RpcClientImpl.java
@@ -70,6 +70,7 @@ public class RpcClientImpl implements RpcClient {
     private static final int KEEP_ALIVE_TIME_MILLIS = 300 * 1000;
     private static final int KEEP_ALIVE_TIMEOUT_MILLIS = 30 * 1000;
     private static final int GRPC_MAX_MESSAGE_SIZE = Integer.MAX_VALUE;
+    private static final String GRPC_LB_POLICY_ROUND_ROBIN = "round_robin";
 
     private final ManagedChannel channel;
     private final MessagingServiceGrpc.MessagingServiceFutureStub futureStub;
@@ -86,7 +87,8 @@ public class RpcClientImpl implements RpcClient {
                 .keepAliveTimeout(KEEP_ALIVE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
                 .keepAliveWithoutCalls(true)
                 .maxInboundMessageSize(GRPC_MAX_MESSAGE_SIZE)
-                .intercept(LoggingInterceptor.getInstance());
+                .intercept(LoggingInterceptor.getInstance())
+                .defaultLoadBalancingPolicy(GRPC_LB_POLICY_ROUND_ROBIN);
 
         if (sslEnabled) {
             final SslContextBuilder builder = GrpcSslContexts.forClient();


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1087 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
