### PR TITLE
[ISSUE #1098] [Golang] Support returns error information, such as authentication failure

### DIFF
--- a/golang/simple_consumer.go
+++ b/golang/simple_consumer.go
@@ -232,6 +232,8 @@ func (sc *defaultSimpleConsumer) receiveMessage(ctx context.Context, request *v2
 			}
 			if err != nil {
 				sc.cli.log.Errorf("simpleConsumer recv msg err=%v, requestId=%s", err, utils.GetRequestID(ctx))
+				done <- true
+				defer close(done)
 				break
 			}
 			sugarBaseLogger.Debugf("receiveMessage response: %v", resp)


### PR DESCRIPTION

Currently, if an authentication error occurs, only a timeout will be seen in the client log.   Support returns error information, such as authentication failure


<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1098

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

add close to ensure the result.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
