### PR TITLE
golang: chore: Remove unused validator import and field

### DIFF
--- a/golang/conn.go
+++ b/golang/conn.go
@@ -21,10 +21,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/apache/rocketmq-clients/golang/v5/pkg/utils"
 
 	"github.com/apache/rocketmq-clients/golang/v5/pkg/grpc/middleware/zaplog"
-	validator "github.com/go-playground/validator/v10"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -54,13 +54,11 @@ type clientConn struct {
 	cancel   context.CancelFunc
 	callOpts []grpc.CallOption
 	conn     *grpc.ClientConn
-	validate *validator.Validate
 }
 
 var NewClientConn = func(endpoint string, opts ...ConnOption) (ClientConn, error) {
 	client := &clientConn{
-		opts:     defaultConnOptions,
-		validate: validator.New(),
+		opts: defaultConnOptions,
 	}
 	if len(endpoint) == 0 {
 		return nil, ErrNoAvailableEndpoints


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #issue_id

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

<img width="1095" height="830" alt="Clipboard_Screenshot_1763544045" src="https://github.com/user-attachments/assets/d4aafab9-9d66-4f84-beeb-5d1ceeabd47e" />

在 broker长时间挂掉的时候，客户端一直 new client，这里这个对象占用会比较多，需要等到下次 gc 回收才可以，这个 validator 也没用，减少 new          
When the broker is down for an extended period, the client keeps creating new `client` objects, resulting in a significant amount of memory usage that won't be reclaimed until the next garbage collection. In this case, the validator is useless, so reducing the number of new `client` objects is crucial.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
