### PR TITLE
[ISSUE #1150] [Java] Support OffsetOption for subscribeLite

### DIFF
--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/LitePushConsumer.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/LitePushConsumer.java
@@ -35,10 +35,18 @@ public interface LitePushConsumer extends Closeable {
      *    evaluate whether the quota is insufficient and promptly unsubscribe from unused subscriptions
      *    using unsubscribeLite() to free up resources.
      *
-     * @param liteTopic the name of the lite topic to subscribe to
+     * @param liteTopic the name of the lite topic to subscribe
      * @throws ClientException if an error occurs during subscription
      */
     void subscribeLite(String liteTopic) throws ClientException;
+
+    /**
+     *  Subscribe to a lite topic with consumeFromOption to specify the consume from offset.
+     * @param liteTopic the name of the lite topic to subscribe
+     * @param offsetOption the consume from offset
+     * @throws ClientException if an error occurs during subscription
+     */
+    void subscribeLite(String liteTopic, OffsetOption offsetOption) throws ClientException;
 
     /**
      * Unsubscribe from a lite topic.

--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/OffsetOption.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/OffsetOption.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.apis.consumer;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+
+public class OffsetOption {
+
+    public static final long POLICY_LAST_VALUE = 0L;
+    public static final long POLICY_MIN_VALUE = 1L;
+    public static final long POLICY_MAX_VALUE = 2L;
+
+    public static final OffsetOption LAST_OFFSET = new OffsetOption(Type.POLICY, POLICY_LAST_VALUE);
+    public static final OffsetOption MIN_OFFSET = new OffsetOption(Type.POLICY, POLICY_MIN_VALUE);
+    public static final OffsetOption MAX_OFFSET = new OffsetOption(Type.POLICY, POLICY_MAX_VALUE);
+
+    private final Type type;
+    private final long value;
+
+    private OffsetOption(Type type, long value) {
+        this.type = type;
+        this.value = value;
+    }
+
+    public static OffsetOption ofOffset(long offset) {
+        if (offset < 0) {
+            throw new IllegalArgumentException("offset must be greater than or equal to 0");
+        }
+        return new OffsetOption(Type.OFFSET, offset);
+    }
+
+    public static OffsetOption ofTailN(long tailN) {
+        if (tailN < 0) {
+            throw new IllegalArgumentException("tailN must be greater than or equal to 0");
+        }
+        return new OffsetOption(Type.TAIL_N, tailN);
+    }
+
+    public static OffsetOption ofTimestamp(long timestamp) {
+        if (timestamp < 0) {
+            throw new IllegalArgumentException("timestamp must be greater than or equal to 0");
+        }
+        return new OffsetOption(Type.TIMESTAMP, timestamp);
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public long getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OffsetOption option = (OffsetOption) o;
+        return value == option.value && type == option.type;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(type);
+        result = 31 * result + Long.hashCode(value);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("type", type)
+            .add("value", value)
+            .toString();
+    }
+
+    public enum Type {
+        POLICY,
+        OFFSET,
+        TAIL_N,
+        TIMESTAMP
+    }
+
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -48,7 +48,7 @@
            ~  1. Whether it is essential, because the current shaded jar is fat enough.
            ~  2. Make sure that it is compatible with Java 8.
          -->
-        <rocketmq-proto.version>2.1.0</rocketmq-proto.version>
+        <rocketmq-proto.version>2.1.1</rocketmq-proto.version>
         <annotations-api.version>1.3.5</annotations-api.version>
         <protobuf.version>3.24.4</protobuf.version>
         <grpc.version>1.50.0</grpc.version>


### PR DESCRIPTION
Change-Id: Icca22d58883c467e74c357e4f7d7aaa719f2e524

<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1150

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Introduce a new method to the LitePushConsumer interface: `subscribeLite(String liteTopic, OffsetOption offsetOption)`.

This allows the SDK to specify the starting consumption offset when subscribing to a lite topic.


### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
Unit Test.
