### PR TITLE
[ISSUE #1159] [C++] Use Pass-by-Value instead of Pass-by-Reference for attemptId in PushConsumer

### DIFF
--- a/cpp/source/rocketmq/ProcessQueueImpl.cpp
+++ b/cpp/source/rocketmq/ProcessQueueImpl.cpp
@@ -41,11 +41,11 @@ ProcessQueueImpl::ProcessQueueImpl(rmq::MessageQueue message_queue, FilterExpres
       invisible_time_(MixAll::millisecondsOf(MixAll::DEFAULT_INVISIBLE_TIME_)),
       simple_name_(simpleNameOf(message_queue_)), consumer_(std::move(consumer)),
       client_manager_(std::move(client_instance)), cached_message_quantity_(0), cached_message_memory_(0) {
-  SPDLOG_DEBUG("Created ProcessQueue={}", simpleName());
+  SPDLOG_DEBUG("Created ProcessQueue={}", simple_name_);
 }
 
 ProcessQueueImpl::~ProcessQueueImpl() {
-  SPDLOG_INFO("ProcessQueue={} should have been re-balanced away, thus, is destructed", simpleName());
+  SPDLOG_INFO("ProcessQueue={} should have been re-balanced away, thus, is destructed", simple_name_);
 }
 
 void ProcessQueueImpl::callback(std::shared_ptr<AsyncReceiveMessageCallback> callback) {
@@ -120,7 +120,7 @@ void ProcessQueueImpl::popMessage(std::string& attempt_id) {
 
   std::weak_ptr<AsyncReceiveMessageCallback> cb{receive_callback_};
   auto callback =
-      [cb, &attempt_id](const std::error_code& ec, const ReceiveMessageResult& result) {
+      [cb, attempt_id](const std::error_code& ec, const ReceiveMessageResult& result) {
     std::shared_ptr<AsyncReceiveMessageCallback> receive_cb = cb.lock();
     if (receive_cb) {
       receive_cb->onCompletion(ec, attempt_id, result);

--- a/cpp/source/rocketmq/include/AsyncReceiveMessageCallback.h
+++ b/cpp/source/rocketmq/include/AsyncReceiveMessageCallback.h
@@ -29,11 +29,11 @@ class AsyncReceiveMessageCallback : public std::enable_shared_from_this<AsyncRec
 public:
   explicit AsyncReceiveMessageCallback(std::weak_ptr<ProcessQueue> process_queue);
 
-  void onCompletion(const std::error_code& ec, std::string& attempt_id, const ReceiveMessageResult& result);
+  void onCompletion(const std::error_code& ec, const std::string& attempt_id, const ReceiveMessageResult& result);
 
-  void receiveMessageLater(std::chrono::milliseconds delay, std::string& attempt_id);
+  void receiveMessageLater(std::chrono::milliseconds delay, const std::string& attempt_id);
 
-  void receiveMessageImmediately(std::string& attempt_id);
+  void receiveMessageImmediately(const std::string& attempt_id);
 
 private:
   /**
@@ -44,7 +44,7 @@ private:
 
   std::function<void(std::string)> receive_message_later_;
 
-  void checkThrottleThenReceive(std::string attempt_id);
+  void checkThrottleThenReceive(const std::string& attempt_id);
 
   static const char* RECEIVE_LATER_TASK_NAME;
 };


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1159

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
