### PR TITLE
[Python] Fix PushConsumer not receiving messages

### DIFF
--- a/python/rocketmq/v5/client/connection/rpc_channel.py
+++ b/python/rocketmq/v5/client/connection/rpc_channel.py
@@ -133,11 +133,12 @@ class RpcStreamStreamCall:
                             logger.debug(
                                 f"{ self.__handler} sync setting success. response status code: {res.status.code}"
                             )
-                            if res.settings and res.settings.metric:
-                                # reset metrics if needed
-                                self.__handler.reset_metric(res.settings.metric)
-                                # sync setting
+                            if res.settings:
+                                # sync setting first to ensure consumer initialization
                                 self.__handler.reset_setting(res.settings)
+                                if res.settings.metric:
+                                    # reset metrics if needed
+                                    self.__handler.reset_metric(res.settings.metric)
                     elif res.HasField("recover_orphaned_transaction_command"):
                         # sever check for a transaction message
                         if self.__handler:


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #1168

### Brief Description

This PR fixes an issue where `PushConsumer` fails to receive messages while `SimpleConsumer` works correctly.

**Root Cause:**

In `rpc_channel.py`, `reset_setting()` was nested inside the metric check condition and placed after `reset_metric()`:

```python
# Before (problematic)
if res.settings and res.settings.metric:
    self.__handler.reset_metric(res.settings.metric)
    self.__handler.reset_setting(res.settings)
```

Two issues combined to cause this bug:
1. `reset_setting()` was only called when `res.settings.metric` was truthy
2. Even after fixing the nesting, `reset_metric()` could throw exceptions (e.g., `'NoneType' object has no attribute 'get_meter'` when metrics not initialized), preventing `reset_setting()` from being called

This caused `PushConsumer.__consumption` to remain `None`, making `__scan_assignment()` return early and never fetch messages.

**Fix:**

Move `reset_setting()` before `reset_metric()` to ensure consumer initialization completes regardless of metric state:

```python
# After (fixed)
if res.settings:
    self.__handler.reset_setting(res.settings)  # Call first
    if res.settings.metric:
        self.__handler.reset_metric(res.settings.metric)
```

### How Did You Test This Change?

Tested on RocketMQ 5.1.4 (NameServer + Broker + Proxy) with the reproduction script from #1168:

**Before fix:**
```
PushConsumer:   0 messages
SimpleConsumer: 5 messages
[FAILED]
```

**After fix:**
```
PushConsumer:   20 messages
[PASSED]
```
