### PR TITLE
[Rust] Support namespace header in gRPC metadata and namespace fallback in SimpleConsumer

### DIFF
--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -245,7 +245,11 @@ impl Session {
             "x-mq-protocol-version",
             AsciiMetadataValue::from_static(PROTOCOL_VERSION),
         );
-
+        // Add namespace header
+        if !self.option.namespace.is_empty() {
+            let _ = AsciiMetadataValue::try_from(&self.option.namespace)
+                .map(|v| metadata.insert("x-mq-namespace", v));
+        }
         let date_time_result = OffsetDateTime::now_local();
         let date_time = if let Ok(result) = date_time_result {
             result

--- a/rust/src/simple_consumer.rs
+++ b/rust/src/simple_consumer.rs
@@ -65,6 +65,15 @@ impl SimpleConsumer {
                 Self::OPERATION_NEW_SIMPLE_CONSUMER,
             ));
         }
+        // Use namespace from SimpleConsumerOption if set, otherwise fall back to ClientOption
+        let namespace = if option.namespace().is_empty() {
+            client_option.get_namespace().to_string()
+        } else {
+            option.namespace().to_string()
+        };
+        // Update option with resolved namespace for settings
+        let mut option = option;
+        option.set_namespace(&namespace);
 
         let client_option = ClientOption {
             client_type: ClientType::SimpleConsumer,


### PR DESCRIPTION
### Brief Description

This PR adds namespace support for the Rust client with two key changes:

1. Add x-mq-namespace header in session requests (rust/src/session.rs)
      - When the namespace is configured and not empty, the client now includes an x-mq-namespace header in the gRPC metadata
      - This ensures the server can properly route requests to the correct namespace

2. Propagate namespace from ClientOption to SimpleConsumerOption (rust/src/simple_consumer.rs)
      - If SimpleConsumerOption has a namespace set, use it directly
      - Otherwise, fall back to the namespace configured in ClientOption
      - This provides flexibility for users to configure namespace at either the client level or the consumer level

These changes align the Rust client behavior with other language clients (Java, Go, etc.) that already support namespace headers.

### How Did You Test This Change?

- Verified that when namespace is configured, the x-mq-namespace header is correctly added to gRPC requests
- Tested SimpleConsumer with namespace set at both SimpleConsumerOption level and ClientOption level to ensure proper fallback behavior
- Confirmed backward compatibility: when namespace is empty/not set, no header is added and behavior remains unchanged
