### PR TITLE
chore(.licenserc.yaml): add golang/*_mock.go to ignore list

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -35,6 +35,7 @@ header:
     - '.gitmodules'
     - 'golang/go.mod'
     - 'golang/go.sum'
+    - 'golang/*_mock.go'
     - 'java/client/src/main/resources/META-INF/services/org.apache.rocketmq.client.apis.ClientServiceProvider'
     - 'java/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker'
     - '**/*.csproj'


### PR DESCRIPTION
Update license check configuration to add generated Go mock files to the ignore list.

Change-Id: I40051848be303ad8c192c4b83d4f2b6864629c77

<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->
