### PR TITLE
[Java] feat(LitePushConsumer): enable Lite Push Consumer to suspend consumption

### DIFF
--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/ConsumeResult.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/ConsumeResult.java
@@ -17,16 +17,47 @@
 
 package org.apache.rocketmq.client.apis.consumer;
 
+import java.util.Objects;
+
 /**
  * Designed for push consumer specifically.
  */
-public enum ConsumeResult {
+public class ConsumeResult {
     /**
      * Consume message successfully.
      */
-    SUCCESS,
+    public static final ConsumeResult SUCCESS = new ConsumeResult("SUCCESS");
     /**
      * Failed to consume message.
      */
-    FAILURE
+    public static final ConsumeResult FAILURE = new ConsumeResult("FAILURE");
+
+    private final String name;
+
+    protected ConsumeResult(String name) {
+        this.name = name;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConsumeResult result = (ConsumeResult) o;
+        return Objects.equals(name, result.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name);
+    }
 }

--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/ConsumeResultSuspend.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/ConsumeResultSuspend.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.apis.consumer;
+
+import java.time.Duration;
+
+public class ConsumeResultSuspend extends ConsumeResult {
+
+    private static final Duration MIN_SUSPEND_TIME = Duration.ofMillis(50);
+
+    private final Duration suspendTime;
+
+    private ConsumeResultSuspend(Duration suspendTime) {
+        super("SUSPEND");
+        if (suspendTime.compareTo(MIN_SUSPEND_TIME) < 0) {
+            throw new IllegalArgumentException(String.format(
+                "suspend time cannot be less than %s, got %s", MIN_SUSPEND_TIME, suspendTime));
+        }
+        this.suspendTime = suspendTime;
+    }
+
+    public Duration getSuspendTime() {
+        return suspendTime;
+    }
+
+    public static ConsumeResultSuspend of(Duration suspendTime) {
+        return new ConsumeResultSuspend(suspendTime);
+    }
+
+    @Override
+    public String toString() {
+        return "SUSPEND(" + suspendTime + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!super.equals(o)) {
+            return false;
+        }
+        ConsumeResultSuspend suspend = (ConsumeResultSuspend) o;
+        return suspendTime.equals(suspend.suspendTime);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + suspendTime.hashCode();
+        return result;
+    }
+}

--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/LitePushConsumerBuilder.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/LitePushConsumerBuilder.java
@@ -81,6 +81,15 @@ public interface LitePushConsumerBuilder {
     LitePushConsumerBuilder setConsumptionThreadCount(int count);
 
     /**
+     * Set enable fifo consume accelerator. If enabled, the consumer will consume messages in parallel by liteTopic,
+     * it may increase the probability of repeatedly consuming the same message.
+     *
+     * @param enableFifoConsumeAccelerator  enable fifo parallel processing.
+     * @return the consumer builder instance.
+     */
+    LitePushConsumerBuilder setEnableFifoConsumeAccelerator(boolean enableFifoConsumeAccelerator);
+
+    /**
      * Finalize the build of {@link LitePushConsumer} and start.
      *
      * <p>This method will block until the push consumer starts successfully.

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumerImpl.java
@@ -152,7 +152,10 @@ public abstract class ConsumerImpl extends ClientImpl {
             .setInvisibleDuration(Durations.fromNanos(invisibleDuration.toNanos()))
             .setMessageId(messageView.getMessageId().toString());
         if (isLiteConsumer()) {
-            messageView.getLiteTopic().ifPresent(builder::setLiteTopic);
+            if (messageView.getLiteTopic().isPresent()) {
+                builder.setLiteTopic(messageView.getLiteTopic().get());
+                builder.setSuspend(true);
+            }
         }
         return builder.build();
     }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/FifoConsumeService.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/FifoConsumeService.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
@@ -36,7 +35,6 @@ import org.apache.rocketmq.client.java.misc.ClientId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings("UnstableApiUsage")
 class FifoConsumeService extends ConsumeService {
     private static final Logger log = LoggerFactory.getLogger(FifoConsumeService.class);
     private final boolean enableFifoConsumeAccelerator;
@@ -54,41 +52,58 @@ class FifoConsumeService extends ConsumeService {
             consumeIteratively(pq, messageViews.iterator());
             return;
         }
-        Map<String, List<MessageViewImpl>> messageViewsGroupByMessageGroup = new HashMap<>();
-        List<MessageViewImpl> messageViewsWithoutMessageGroup = new ArrayList<>();
+        Map<String, List<MessageViewImpl>> messageViewsGroupByGroupKey = new HashMap<>();
         for (MessageViewImpl messageView : messageViews) {
-            Optional<String> messageGroup = messageView.getMessageGroup();
-            if (messageGroup.isPresent()) {
-                messageViewsGroupByMessageGroup.computeIfAbsent(messageGroup.get(), k -> new ArrayList<>())
-                    .add(messageView);
-            } else {
-                messageViewsWithoutMessageGroup.add(messageView);
-            }
+            // Group messages by group key. Default to null-key group for unkeyed messages.
+            String groupKey = getMessageGroupKey(messageView);
+            messageViewsGroupByGroupKey.computeIfAbsent(groupKey, k -> new ArrayList<>()).add(messageView);
         }
-
         log.debug("FifoConsumeService parallel consume, messageViewsNum={}, groupNum={}", messageViews.size(),
-            messageViewsGroupByMessageGroup.size() + (messageViewsWithoutMessageGroup.isEmpty() ? 0 : 1));
+            messageViewsGroupByGroupKey.size());
 
-        messageViewsGroupByMessageGroup.values().forEach(list -> consumeIteratively(pq, list.iterator()));
-        consumeIteratively(pq, messageViewsWithoutMessageGroup.iterator());
+        messageViewsGroupByGroupKey.values().forEach(list -> consumeIteratively(pq, list.iterator()));
     }
 
-    public void consumeIteratively(ProcessQueue pq, Iterator<MessageViewImpl> iterator) {
-        if (!iterator.hasNext()) {
-            return;
-        }
-        final MessageViewImpl messageView = iterator.next();
-        if (messageView.isCorrupted()) {
-            // Discard corrupted message.
-            log.error("Message is corrupted for FIFO consumption, prepare to discard it, mq={}, messageId={}, "
-                + "clientId={}", pq.getMessageQueue(), messageView.getMessageId(), clientId);
-            pq.discardFifoMessage(messageView);
-            consumeIteratively(pq, iterator);
+    /**
+     * Get the group key for the given message view.
+     * Subclasses should override this method to provide different grouping logic.
+     */
+    protected String getMessageGroupKey(MessageViewImpl messageView) {
+        return messageView.getMessageGroup().orElse(null);
+    }
+
+    /**
+     * Consume messages iteratively using the provided iterator.
+     * This method handles corrupted messages and continues processing the next valid message.
+     */
+    protected void consumeIteratively(ProcessQueue pq, Iterator<MessageViewImpl> iterator) {
+        MessageViewImpl messageView = getNextValidMessage(pq, iterator);
+        if (messageView == null) {
             return;
         }
         final ListenableFuture<ConsumeResult> future0 = consume(messageView);
         ListenableFuture<Void> future = Futures.transformAsync(future0, result -> pq.eraseFifoMessage(messageView,
             result), MoreExecutors.directExecutor());
         future.addListener(() -> consumeIteratively(pq, iterator), MoreExecutors.directExecutor());
+    }
+
+    /**
+     * Get the next valid message from the iterator.
+     * Skip corrupted messages and return the first valid one.
+     * Returns null if there are no more messages.
+     */
+    protected MessageViewImpl getNextValidMessage(ProcessQueue pq, Iterator<MessageViewImpl> iterator) {
+        while (iterator.hasNext()) {
+            final MessageViewImpl messageView = iterator.next();
+            if (messageView.isCorrupted()) {
+                // Discard corrupted message.
+                log.error("Message is corrupted for FIFO consumption, prepare to discard it, mq={}, messageId={}, "
+                    + "clientId={}", pq.getMessageQueue(), messageView.getMessageId(), clientId);
+                pq.discardFifoMessage(messageView);
+                continue;
+            }
+            return messageView;
+        }
+        return null;
     }
 }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LiteFifoConsumeService.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LiteFifoConsumeService.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.java.impl.consumer;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
+import org.apache.rocketmq.client.apis.consumer.ConsumeResultSuspend;
+import org.apache.rocketmq.client.apis.consumer.MessageListener;
+import org.apache.rocketmq.client.java.hook.MessageInterceptor;
+import org.apache.rocketmq.client.java.message.MessageViewImpl;
+import org.apache.rocketmq.client.java.misc.ClientId;
+
+public class LiteFifoConsumeService extends FifoConsumeService {
+
+    public LiteFifoConsumeService(ClientId clientId, MessageListener messageListener,
+        ThreadPoolExecutor consumptionExecutor, MessageInterceptor messageInterceptor,
+        ScheduledExecutorService scheduler, boolean enableFifoConsumeAccelerator) {
+        super(clientId, messageListener, consumptionExecutor,
+            messageInterceptor, scheduler, enableFifoConsumeAccelerator);
+    }
+
+    @Override
+    protected String getMessageGroupKey(MessageViewImpl messageView) {
+        return messageView.getLiteTopic().orElse(null);
+    }
+
+    @Override
+    protected void consumeIteratively(ProcessQueue pq, Iterator<MessageViewImpl> iterator) {
+        MessageViewImpl messageView = getNextValidMessage(pq, iterator);
+        if (messageView == null) {
+            return;
+        }
+        final ListenableFuture<ConsumeResult> future0 = consume(messageView);
+
+        final AtomicReference<Iterator<MessageViewImpl>> iteratorRef = new AtomicReference<>(iterator);
+        ListenableFuture<Void> future = Futures.transformAsync(future0, result -> {
+            ListenableFuture<Void> returnFuture = pq.eraseFifoMessage(messageView, result);
+            if (result instanceof ConsumeResultSuspend) {
+                List<MessageViewImpl> newMsgList = new ArrayList<>();
+                iterator.forEachRemaining(msgView -> {
+                    boolean sameLiteTopic = messageView.getLiteTopic().equals(msgView.getLiteTopic());
+                    if (sameLiteTopic) {
+                        // Suspend all messages with the same liteTopic in this batch.
+                        pq.eraseFifoMessage(msgView, result);
+                    } else {
+                        newMsgList.add(msgView);
+                    }
+                });
+                iteratorRef.set(newMsgList.iterator());
+            }
+            return returnFuture;
+        }, MoreExecutors.directExecutor());
+        future.addListener(() -> consumeIteratively(pq, iteratorRef.get()), MoreExecutors.directExecutor());
+    }
+}

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LitePushConsumerBuilderImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LitePushConsumerBuilderImpl.java
@@ -42,6 +42,7 @@ public class LitePushConsumerBuilderImpl implements LitePushConsumerBuilder {
     protected int maxCacheMessageCount = 1024;
     protected int maxCacheMessageSizeInBytes = 64 * 1024 * 1024;
     protected int consumptionThreadCount = 20;
+    protected boolean enableFifoConsumeAccelerator = false;
 
     @Override
     public LitePushConsumerBuilder bindTopic(String bindTopic) {
@@ -91,6 +92,12 @@ public class LitePushConsumerBuilderImpl implements LitePushConsumerBuilder {
     public LitePushConsumerBuilder setConsumptionThreadCount(int consumptionThreadCount) {
         checkArgument(consumptionThreadCount > 0, "consumptionThreadCount should be positive");
         this.consumptionThreadCount = consumptionThreadCount;
+        return this;
+    }
+
+    @Override
+    public LitePushConsumerBuilder setEnableFifoConsumeAccelerator(boolean enableFifoConsumeAccelerator) {
+        this.enableFifoConsumeAccelerator = enableFifoConsumeAccelerator;
         return this;
     }
 

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LitePushConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LitePushConsumerImpl.java
@@ -35,7 +35,7 @@ public class LitePushConsumerImpl extends PushConsumerImpl implements LitePushCo
         super(builder.clientConfiguration, builder.consumerGroup,
             builder.subscriptionExpressions, builder.messageListener,
             builder.maxCacheMessageCount, builder.maxCacheMessageSizeInBytes,
-            builder.consumptionThreadCount, false);
+            builder.consumptionThreadCount, builder.enableFifoConsumeAccelerator);
         this.liteSubscriptionManager = new LiteSubscriptionManager(this,
             new Resource(builder.clientConfiguration.getNamespace(), builder.bindTopic),
             groupResource);

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LiteSubscriptionManager.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LiteSubscriptionManager.java
@@ -64,6 +64,7 @@ public class LiteSubscriptionManager {
     }
 
     public void startUp() {
+        syncAllLiteSubscription(); // syncAll after startup for subscribeLite("*")
         consumerImpl.getScheduler()
             .scheduleWithFixedDelay(this::syncAllLiteSubscription, 30, 30, TimeUnit.SECONDS);
     }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImpl.java
@@ -47,7 +47,9 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
+import org.apache.rocketmq.client.apis.consumer.ConsumeResultSuspend;
 import org.apache.rocketmq.client.apis.consumer.FilterExpression;
+import org.apache.rocketmq.client.apis.consumer.LitePushConsumer;
 import org.apache.rocketmq.client.apis.message.MessageId;
 import org.apache.rocketmq.client.apis.message.MessageView;
 import org.apache.rocketmq.client.java.exception.BadRequestException;
@@ -74,7 +76,7 @@ import org.slf4j.LoggerFactory;
  *
  * @see ProcessQueue
  */
-@SuppressWarnings({"NullableProblems", "UnstableApiUsage"})
+@SuppressWarnings({"NullableProblems"})
 class ProcessQueueImpl implements ProcessQueue {
     static final Duration FORWARD_FIFO_MESSAGE_TO_DLQ_FAILURE_BACKOFF_DELAY = Duration.ofSeconds(1);
     static final Duration ACK_MESSAGE_FAILURE_BACKOFF_DELAY = Duration.ofSeconds(1);
@@ -427,6 +429,7 @@ class ProcessQueueImpl implements ProcessQueue {
 
     @Override
     public void eraseMessage(MessageViewImpl messageView, ConsumeResult consumeResult) {
+        consumeResult = convertSuspendResultIfNeeded(consumeResult);
         statsConsumptionResult(consumeResult);
         ListenableFuture<Void> future = ConsumeResult.SUCCESS.equals(consumeResult) ? ackMessage(messageView) :
             nackMessage(messageView);
@@ -436,6 +439,12 @@ class ProcessQueueImpl implements ProcessQueue {
     private ListenableFuture<Void> nackMessage(final MessageViewImpl messageView) {
         final int deliveryAttempt = messageView.getDeliveryAttempt();
         final Duration duration = consumer.getRetryPolicy().getNextAttemptDelay(deliveryAttempt);
+        final SettableFuture<Void> future0 = SettableFuture.create();
+        changeInvisibleDuration(messageView, duration, 1, future0);
+        return future0;
+    }
+
+    private ListenableFuture<Void> changeInvisibleDuration(final MessageViewImpl messageView, final Duration duration) {
         final SettableFuture<Void> future0 = SettableFuture.create();
         changeInvisibleDuration(messageView, duration, 1, future0);
         return future0;
@@ -517,6 +526,7 @@ class ProcessQueueImpl implements ProcessQueue {
 
     @Override
     public ListenableFuture<Void> eraseFifoMessage(MessageViewImpl messageView, ConsumeResult consumeResult) {
+        consumeResult = convertSuspendResultIfNeeded(consumeResult);
         statsConsumptionResult(consumeResult);
         final RetryPolicy retryPolicy = consumer.getRetryPolicy();
         final int maxAttempts = retryPolicy.getMaxAttempts();
@@ -534,17 +544,23 @@ class ProcessQueueImpl implements ProcessQueue {
             return Futures.transformAsync(future, result -> eraseFifoMessage(messageView, result),
                 MoreExecutors.directExecutor());
         }
-        boolean ok = ConsumeResult.SUCCESS.equals(consumeResult);
-        if (!ok) {
+        ListenableFuture<Void> future;
+        if (ConsumeResult.SUCCESS.equals(consumeResult)) {
+            future = ackMessage(messageView);
+        } else if (consumeResult instanceof ConsumeResultSuspend) {
+            ConsumeResultSuspend consumeResultSuspend = (ConsumeResultSuspend) consumeResult;
+            log.info("Suspend consumption, consumerGroup={}, topic={}, liteTopic={}, messageId={}, result={}",
+                consumer.getConsumerGroup(), messageView.getTopic(), messageView.getLiteTopic().orElse(""),
+                messageView.getMessageId(), consumeResultSuspend);
+            future = changeInvisibleDuration(messageView, consumeResultSuspend.getSuspendTime());
+        } else {
             log.info("Failed to consume fifo message finally, run out of attempt times, maxAttempts={}, "
                 + "attempt={}, mq={}, messageId={}, clientId={}", maxAttempts, attempt, mq, messageId, clientId);
+            future = forwardToDeadLetterQueue(messageView);
         }
-        // Ack message or forward it to DLQ depends on consumption result.
-        ListenableFuture<Void> future = ok ? ackMessage(messageView) : forwardToDeadLetterQueue(messageView);
         future.addListener(() -> evictCache(messageView), consumer.getConsumptionExecutor());
         return future;
     }
-
 
     private ListenableFuture<Void> forwardToDeadLetterQueue(final MessageViewImpl messageView) {
         final SettableFuture<Void> future = SettableFuture.create();
@@ -718,4 +734,17 @@ class ProcessQueueImpl implements ProcessQueue {
             + "cachedMessageCount={}, cachedMessageBytes={}", consumer.getClientId(), mq, receptionTimes,
             receivedMessagesQuantity, this.getCachedMessageCount(), this.getCachedMessageBytes());
     }
+
+    private ConsumeResult convertSuspendResultIfNeeded(ConsumeResult consumeResult) {
+        if (consumeResult instanceof ConsumeResultSuspend) {
+            if (!(consumer instanceof LitePushConsumer)) {
+                log.warn("Only LitePushConsumer support ConsumeResultSuspend! " +
+                        "Convert to ConsumeResult.FAILURE, consumerGroup={}, consumerType={}",
+                    consumer.getConsumerGroup(), consumer.getClass().getSimpleName());
+                return ConsumeResult.FAILURE;
+            }
+        }
+        return consumeResult;
+    }
+
 }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
@@ -247,10 +247,15 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
     protected ConsumeService createConsumeService() {
         final ScheduledExecutorService scheduler = this.getClientManager().getScheduler();
         if (getSettings().isFifo()) {
-            log.info("Create FIFO consume service, consumerGroup={}, clientId={}, enableFifoConsumeAccelerator={}",
-                getConsumerGroup(), clientId, enableFifoConsumeAccelerator);
-            return new FifoConsumeService(clientId, messageListener, consumptionExecutor, this,
-                scheduler, enableFifoConsumeAccelerator);
+            log.info("Create {}FIFO consume service, consumerGroup={}, clientId={}, enableFifoConsumeAccelerator={}",
+                isLiteConsumer() ? "Lite " : "", getConsumerGroup(), clientId, enableFifoConsumeAccelerator);
+            if (isLiteConsumer()) {
+                return new LiteFifoConsumeService(clientId, messageListener, consumptionExecutor, this,
+                    scheduler, enableFifoConsumeAccelerator);
+            } else {
+                return new FifoConsumeService(clientId, messageListener, consumptionExecutor, this,
+                    scheduler, enableFifoConsumeAccelerator);
+            }
         }
         log.info("Create standard consume service, consumerGroup={}, clientId={}", getConsumerGroup(), clientId);
         return new StandardConsumeService(clientId, messageListener, consumptionExecutor, this, scheduler);


### PR DESCRIPTION
This commit enables Lite Push Consumer to handle suspended consumption results by:
1. Creating corresponding FIFO consume service based on whether it's a LiteConsumer in PushConsumerImpl
2. Converting ConsumeResult from enum to class to support custom result types including suspension
3. Adding LitePushConsumerBuilder configuration option to enable FIFO acceleration processing
4. Refactoring FifoConsumeService to improve flexibility in message grouping and iterative consumption
5. Supporting suspended consume result handling in LitePushConsumer
6. Synchronizing subscription manager to immediately sync all Lite subscriptions after startup
