### PR TITLE
[Enhancement#1178][GOLANG]: limit goroutines in SendAsync using internal async executor

### DIFF
--- a/golang/producer_options.go
+++ b/golang/producer_options.go
@@ -29,15 +29,19 @@ import (
 )
 
 type producerOptions struct {
-	clientFunc  NewClientFunc
-	maxAttempts int32
-	topics      []string
-	checker     *TransactionChecker
+	clientFunc     NewClientFunc
+	maxAttempts    int32
+	topics         []string
+	checker        *TransactionChecker
+	asyncWorkers   int
+	asyncQueueSize int
 }
 
 var defaultProducerOptions = producerOptions{
-	clientFunc:  NewClient,
-	maxAttempts: 3,
+	clientFunc:     NewClient,
+	maxAttempts:    3,
+	asyncWorkers:   10,
+	asyncQueueSize: 1000,
 }
 
 // A ProducerOption sets options such as tls.Config, etc.
@@ -84,6 +88,18 @@ func WithTopics(t ...string) ProducerOption {
 func WithTransactionChecker(checker *TransactionChecker) ProducerOption {
 	return newFuncProducerOption(func(o *producerOptions) {
 		o.checker = checker
+	})
+}
+
+func WithAsyncWorkers(asyncWorkers int) ProducerOption {
+	return newFuncProducerOption(func(o *producerOptions) {
+		o.asyncWorkers = asyncWorkers
+	})
+}
+
+func WithAsyncQueueSize(asyncQueueSize int) ProducerOption {
+	return newFuncProducerOption(func(o *producerOptions) {
+		o.asyncQueueSize = asyncQueueSize
 	})
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1178 

### Brief Description
Use existing internal task channel for SendAsync to bound concurrency and avoid goroutine leaks.

### How Did You Test This Change?
use unitest：Added comprehensive unit tests for SendAsync covering
Real-world Simulation：tested against a local RocketMQ cluster with artificial broker delay