### PR TITLE
[Golang] fix(log.go): improve log directory retrieval logic

### DIFF
--- a/golang/log.go
+++ b/golang/log.go
@@ -80,7 +80,11 @@ func getEncoder() zapcore.Encoder {
 }
 
 func getLogWriter() zapcore.WriteSyncer {
-	clientLogRoot := utils.GetenvWithDef(CLIENT_LOG_ROOT, os.Getenv("user.home")+"/logs/rocketmqlogs")
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		homeDir = "/tmp" // fallback to /tmp if home dir cannot be determined
+	}
+	clientLogRoot := utils.GetenvWithDef(CLIENT_LOG_ROOT, homeDir+"/logs/rocketmq")
 	clientLogMaxIndex := utils.GetenvWithDef(CLIENT_LOG_MAXINDEX, "10")
 	clientLogFileName := utils.GetenvWithDef(CLIENT_LOG_FILENAME, "rocketmq_client_go.log")
 	clientLogMaxFileSize := utils.GetenvWithDef(CLIENT_LOG_FILESIZE, "1073741824")


### PR DESCRIPTION
Fixed an issue where the user home directory could not be correctly retrieved in some cases. When `os.UserHomeDir()` fails, a safe fallback path to the `/tmp` directory is provided.