### PR TITLE
[Golang] fix(client.go): fix bug where NotifyClientTermination was never called

### DIFF
--- a/golang/client.go
+++ b/golang/client.go
@@ -610,17 +610,22 @@ func routeEqual(old, new []*v2.MessageQueue) bool {
 }
 
 func (cli *defaultClient) notifyClientTermination() {
-	cli.log.Info("start notifyClientTermination")
 	ctx := cli.Sign(context.Background())
 	request := &v2.NotifyClientTerminationRequest{}
 	targets := cli.getTotalTargets()
 	for _, target := range targets {
-		endpoints, err := utils.ParseTarget(target)
+		endpoints, _ := utils.ParseTarget(target)
+		if endpoints == nil {
+			continue
+		}
+		cli.log.Infof("start notifyClientTermination, endpoints=%s", utils.EndpointsToString(endpoints))
+		_, err := cli.clientManager.NotifyClientTermination(ctx, endpoints, request, cli.opts.timeout)
 		if err != nil {
-			cli.clientManager.NotifyClientTermination(ctx, endpoints, request, cli.opts.timeout)
+			cli.log.Errorf("failed to notify client termination, endpoints=%s, error=%v", utils.EndpointsToString(endpoints), err)
 		}
 	}
 }
+
 func (cli *defaultClient) GracefulStop() error {
 	if !cli.on.CAS(true, false) {
 		return fmt.Errorf("client has been closed")

--- a/golang/client.go
+++ b/golang/client.go
@@ -611,7 +611,12 @@ func routeEqual(old, new []*v2.MessageQueue) bool {
 
 func (cli *defaultClient) notifyClientTermination() {
 	ctx := cli.Sign(context.Background())
-	request := &v2.NotifyClientTerminationRequest{}
+	request := &v2.NotifyClientTerminationRequest{
+		Group: &v2.Resource{
+			ResourceNamespace: cli.config.NameSpace,
+			Name:              cli.config.ConsumerGroup,
+		},
+	}
 	targets := cli.getTotalTargets()
 	for _, target := range targets {
 		endpoints, _ := utils.ParseTarget(target)

--- a/golang/lite_push_consumer.go
+++ b/golang/lite_push_consumer.go
@@ -157,16 +157,29 @@ func (lpc *defaultLitePushConsumer) syncAllLiteSubscription() {
 }
 
 func (lpc *defaultLitePushConsumer) syncLiteSubscription(context context.Context, action v2.LiteSubscriptionAction, diff []string) error {
+	topic := lpc.litePushConsumerSettings.bindTopic
+	group := lpc.litePushConsumerSettings.groupName
+	clientId := lpc.litePushConsumerSettings.clientId
+
 	endpoints := lpc.cli.accessPoint
 	request := v2.SyncLiteSubscriptionRequest{
 		Action: action,
 		Topic: &v2.Resource{
-			Name:              lpc.litePushConsumerSettings.bindTopic,
+			Name:              topic,
 			ResourceNamespace: lpc.cli.config.NameSpace,
 		},
-		Group:        lpc.litePushConsumerSettings.groupName,
+		Group:        group,
 		LiteTopicSet: diff,
 	}
+
+	if action == v2.LiteSubscriptionAction_COMPLETE_ADD {
+		sugarBaseLogger.Infof("syncLiteSubscription action:%s, topic:%s, group:%s, clientId:%s, liteTopicCount:%d",
+			action, topic, group, clientId, len(diff))
+	} else {
+		sugarBaseLogger.Infof("syncLiteSubscription action:%s, topic:%s, group:%s, clientId:%s, liteTopics:%v",
+			action, topic, group, clientId, diff)
+	}
+
 	context = lpc.cli.Sign(context)
 	if v, err := lpc.defaultPushConsumer.cli.clientManager.SyncLiteSubscription(context, endpoints, &request, lpc.pcSettings.requestTimeout); err != nil {
 		return err

--- a/golang/process_queue.go
+++ b/golang/process_queue.go
@@ -461,12 +461,17 @@ func (dpq *defaultProcessQueue) receiveMessageImmediatelyWithAttemptId(attemptId
 			if status.Code(err) == codes.DeadlineExceeded {
 				nextAttemptId = request.GetAttemptId()
 			}
-			dpq.consumer.cli.doAfter(MessageHookPoints_RECEIVE, make([]*MessageCommon, 0), duration, MessageHookPointsStatus_ERROR)
-			// add some check to skip no message
-			dpq.consumer.cli.log.Errorf("Exception raised during message reception, mq=%s, endpoints=%v, attemptId=%d, "+
-				"nextAttemptId=%s, clientId=%s, err=%w", dpq.mqstr, endpoints, request.GetAttemptId(), nextAttemptId,
-				clientId, err)
-
+			rpcErr, isRpcErr := AsErrRpcStatus(err)
+			isNoNewMessage := isRpcErr && rpcErr.GetCode() == int32(v2.Code_MESSAGE_NOT_FOUND)
+			if isNoNewMessage {
+				dpq.consumer.cli.log.Debugf("No new message, mq=%s, endpoints=%v, clientId=%s",
+					dpq.mqstr, endpoints, clientId)
+			} else {
+				dpq.consumer.cli.doAfter(MessageHookPoints_RECEIVE, make([]*MessageCommon, 0), duration, MessageHookPointsStatus_ERROR)
+				dpq.consumer.cli.log.Errorf("Exception raised during message reception, mq=%s, endpoints=%v, attemptId=%d, "+
+					"nextAttemptId=%s, clientId=%s, err=%w", dpq.mqstr, endpoints, request.GetAttemptId(), nextAttemptId,
+					clientId, err)
+			}
 			dpq.onReceiveMessageException(err, nextAttemptId)
 		}
 	}()


### PR DESCRIPTION
Fixed logic error in `notifyClientTermination` method. The previous implementation incorrectly checked `err != nil` instead of `endpoints != nil`, which prevented `NotifyClientTermination` from being called. Added proper error handling with detailed logging for each notification attempt.