### PR TITLE
feat(java): add batch consume support for PushConsumer

### DIFF
--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/BatchMessageListener.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/BatchMessageListener.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.apis.consumer;
+
+import java.util.List;
+import org.apache.rocketmq.client.apis.message.MessageView;
+
+/**
+ * BatchMessageListener is used for the push consumer to process message consumption in batches.
+ *
+ * <p>Refer to {@link PushConsumer}, push consumer will get messages from the server, buffer them
+ * locally according to the {@link BatchPolicy}, and dispatch the accumulated batch to the backend
+ * thread pool for consumption.
+ *
+ * <p>Messages are accumulated until any of the following batch conditions is met:
+ * <ol>
+ *   <li>The number of buffered messages reaches {@link BatchPolicy#getMaxBatchCount()}.</li>
+ *   <li>The total body size (in bytes) of buffered messages reaches {@link BatchPolicy#getMaxBatchBytes()}.</li>
+ *   <li>The time elapsed since the first buffered message reaches {@link BatchPolicy#getMaxWaitTime()}.</li>
+ * </ol>
+ */
+public interface BatchMessageListener {
+    /**
+     * The callback interface to consume a batch of messages.
+     *
+     * <p>You should process the list of {@link MessageView} and return the corresponding
+     * {@link ConsumeResult}. The consumption is successful only when {@link ConsumeResult#SUCCESS}
+     * is returned; returning {@code null} or throwing an exception causes the entire batch to be
+     * marked as consumption failure.
+     *
+     * <p><strong>Note:</strong> The returned {@link ConsumeResult} applies to <em>all</em> messages
+     * in the batch. If the batch fails, all messages in the batch will be retried.
+     *
+     * @param messageViews the batch of messages to consume; never {@code null} or empty.
+     * @return the consume result for the entire batch.
+     */
+    ConsumeResult consume(List<MessageView> messageViews);
+}

--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/BatchPolicy.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/BatchPolicy.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.apis.consumer;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.time.Duration;
+
+/**
+ * Policy that controls how messages are aggregated into batches before being delivered
+ * to a {@link BatchMessageListener} by the {@link PushConsumer}.
+ *
+ * <p>A batch is considered ready when <em>any</em> of the following conditions is met:
+ * <ol>
+ *   <li>The number of collected messages reaches {@code maxBatchCount}.</li>
+ *   <li>The total body size (in bytes) of collected messages reaches {@code maxBatchBytes}.</li>
+ *   <li>The time elapsed since the first message was collected reaches {@code maxWaitTime}.</li>
+ * </ol>
+ *
+ * <p>The {@code maxBatchBytes} limit is critical for preventing client-side OOM when messages
+ * have large bodies.
+ */
+public class BatchPolicy {
+
+    /**
+     * Default maximum number of messages returned in a single batch.
+     */
+    public static final int DEFAULT_MAX_BATCH_COUNT = 32;
+
+    /**
+     * Default maximum total body size (in bytes) before a batch is returned.
+     * 4 MB by default.
+     */
+    public static final long DEFAULT_MAX_BATCH_BYTES = 4L * 1024 * 1024;
+
+    /**
+     * Default maximum wait time before a partial batch is returned.
+     */
+    public static final Duration DEFAULT_MAX_WAIT_TIME = Duration.ofSeconds(5);
+
+    private final int maxBatchCount;
+    private final long maxBatchBytes;
+    private final Duration maxWaitTime;
+
+    /**
+     * Creates a {@link BatchPolicy} with the specified message count and wait time,
+     * using the {@link #DEFAULT_MAX_BATCH_BYTES default byte limit}.
+     *
+     * @param maxBatchCount the maximum number of messages in a batch; must be &gt; 0.
+     * @param maxWaitTime   the maximum time to wait for the batch to fill up; must be positive.
+     */
+    public BatchPolicy(int maxBatchCount, Duration maxWaitTime) {
+        this(maxBatchCount, DEFAULT_MAX_BATCH_BYTES, maxWaitTime);
+    }
+
+    /**
+     * Creates a {@link BatchPolicy} with all parameters specified.
+     *
+     * @param maxBatchCount the maximum number of messages in a batch; must be &gt; 0.
+     * @param maxBatchBytes the maximum total body size (in bytes) of messages in a batch; must be &gt; 0.
+     * @param maxWaitTime   the maximum time to wait for the batch to fill up; must be positive.
+     */
+    public BatchPolicy(int maxBatchCount, long maxBatchBytes, Duration maxWaitTime) {
+        checkArgument(maxBatchCount > 0, "maxBatchCount must be greater than 0");
+        checkArgument(maxBatchBytes > 0, "maxBatchBytes must be greater than 0");
+        checkNotNull(maxWaitTime, "maxWaitTime should not be null");
+        checkArgument(!maxWaitTime.isNegative() && !maxWaitTime.isZero(),
+            "maxWaitTime must be positive");
+        this.maxBatchCount = maxBatchCount;
+        this.maxBatchBytes = maxBatchBytes;
+        this.maxWaitTime = maxWaitTime;
+    }
+
+    /**
+     * Returns the maximum number of messages that can be contained in a single batch.
+     *
+     * @return max batch count.
+     */
+    public int getMaxBatchCount() {
+        return maxBatchCount;
+    }
+
+    /**
+     * Returns the maximum total body size (in bytes) of messages in a single batch.
+     *
+     * @return max batch bytes.
+     */
+    public long getMaxBatchBytes() {
+        return maxBatchBytes;
+    }
+
+    /**
+     * Returns the maximum time to wait before returning a partial batch.
+     *
+     * @return max wait time.
+     */
+    public Duration getMaxWaitTime() {
+        return maxWaitTime;
+    }
+
+    /**
+     * Returns a new {@link Builder} with all defaults pre-populated.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        return "BatchPolicy{maxBatchCount=" + maxBatchCount
+            + ", maxBatchBytes=" + maxBatchBytes
+            + ", maxWaitTime=" + maxWaitTime + '}';
+    }
+
+    /**
+     * Builder for {@link BatchPolicy}.  All fields have sensible defaults; only override
+     * what you need.
+     *
+     * <pre>{@code
+     * BatchPolicy policy = BatchPolicy.builder()
+     *     .setMaxBatchCount(64)
+     *     .setMaxWaitTime(Duration.ofSeconds(10))
+     *     .build();
+     * }</pre>
+     */
+    public static class Builder {
+        private int maxBatchCount = DEFAULT_MAX_BATCH_COUNT;
+        private long maxBatchBytes = DEFAULT_MAX_BATCH_BYTES;
+        private Duration maxWaitTime = DEFAULT_MAX_WAIT_TIME;
+
+        Builder() {
+        }
+
+        /**
+         * Sets the maximum number of messages in a batch.
+         *
+         * @param maxBatchCount must be &gt; 0; default {@value DEFAULT_MAX_BATCH_COUNT}.
+         */
+        public Builder setMaxBatchCount(int maxBatchCount) {
+            this.maxBatchCount = maxBatchCount;
+            return this;
+        }
+
+        /**
+         * Sets the maximum total body size (in bytes) before a batch is returned.
+         *
+         * @param maxBatchBytes must be &gt; 0; default {@value DEFAULT_MAX_BATCH_BYTES}.
+         */
+        public Builder setMaxBatchBytes(long maxBatchBytes) {
+            this.maxBatchBytes = maxBatchBytes;
+            return this;
+        }
+
+        /**
+         * Sets the maximum time to wait for the batch to fill up.
+         *
+         * @param maxWaitTime must be positive; default 5 seconds.
+         */
+        public Builder setMaxWaitTime(Duration maxWaitTime) {
+            this.maxWaitTime = maxWaitTime;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link BatchPolicy} with the configured values.
+         *
+         * @return a new {@link BatchPolicy} instance.
+         * @throws IllegalArgumentException if any parameter is invalid.
+         */
+        public BatchPolicy build() {
+            return new BatchPolicy(maxBatchCount, maxBatchBytes, maxWaitTime);
+        }
+    }
+}

--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/PushConsumerBuilder.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/PushConsumerBuilder.java
@@ -100,6 +100,19 @@ public interface PushConsumerBuilder {
     PushConsumerBuilder setEnableMessageInterceptorFiltering(boolean enableMessageInterceptorFiltering);
 
     /**
+     * Register a batch message listener together with a {@link BatchPolicy}.
+     *
+     * <p>When set, messages will be accumulated locally according to the {@link BatchPolicy} and
+     * dispatched to the {@link BatchMessageListener} in batches. This is mutually exclusive with
+     * {@link #setMessageListener(MessageListener)} &mdash; only one of them should be set.
+     *
+     * @param batchMessageListener the batch message listener.
+     * @param batchPolicy          the policy that controls batch aggregation.
+     * @return the consumer builder instance.
+     */
+    PushConsumerBuilder setBatchMessageListener(BatchMessageListener batchMessageListener, BatchPolicy batchPolicy);
+
+    /**
      * Finalize the build of {@link PushConsumer} and start.
      *
      * <p>This method will block until the push consumer starts successfully.

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/example/BatchPushConsumerExample.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/example/BatchPushConsumerExample.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.java.example;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+import org.apache.rocketmq.client.apis.ClientConfiguration;
+import org.apache.rocketmq.client.apis.ClientException;
+import org.apache.rocketmq.client.apis.ClientServiceProvider;
+import org.apache.rocketmq.client.apis.SessionCredentialsProvider;
+import org.apache.rocketmq.client.apis.StaticSessionCredentialsProvider;
+import org.apache.rocketmq.client.apis.consumer.BatchPolicy;
+import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
+import org.apache.rocketmq.client.apis.consumer.FilterExpression;
+import org.apache.rocketmq.client.apis.consumer.FilterExpressionType;
+import org.apache.rocketmq.client.apis.consumer.PushConsumer;
+import org.apache.rocketmq.client.apis.message.MessageView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Example of using batch consumption with PushConsumer.
+ *
+ * <p>Messages are accumulated locally according to the {@link BatchPolicy} and dispatched to the
+ * batch listener in batches. A batch is flushed when any of the following conditions is met:
+ * <ol>
+ *   <li>The buffered message count reaches {@code maxBatchCount}.</li>
+ *   <li>The total body size (bytes) reaches {@code maxBatchBytes}.</li>
+ *   <li>The time since the first buffered message reaches {@code maxWaitTime}.</li>
+ * </ol>
+ */
+public class BatchPushConsumerExample {
+    private static final Logger log = LoggerFactory.getLogger(BatchPushConsumerExample.class);
+
+    private BatchPushConsumerExample() {
+    }
+
+    public static void main(String[] args) throws ClientException, InterruptedException, IOException {
+        final ClientServiceProvider provider = ClientServiceProvider.loadService();
+
+        // Credential provider is optional for client configuration.
+        String accessKey = "yourAccessKey";
+        String secretKey = "yourSecretKey";
+        SessionCredentialsProvider sessionCredentialsProvider =
+            new StaticSessionCredentialsProvider(accessKey, secretKey);
+
+        String endpoints = "foobar.com:8080";
+        ClientConfiguration clientConfiguration = ClientConfiguration.newBuilder()
+            .setEndpoints(endpoints)
+            .setCredentialProvider(sessionCredentialsProvider)
+            .build();
+
+        String tag = "yourMessageTagA";
+        FilterExpression filterExpression = new FilterExpression(tag, FilterExpressionType.TAG);
+        String consumerGroup = "yourConsumerGroup";
+        String topic = "yourTopic";
+
+        // Build a BatchPolicy: flush when 32 messages or 4 MB accumulated, or 5 seconds elapsed.
+        BatchPolicy batchPolicy = BatchPolicy.builder()
+            .setMaxBatchCount(32)
+            .setMaxBatchBytes(4 * 1024 * 1024)
+            .setMaxWaitTime(Duration.ofSeconds(5))
+            .build();
+
+        // In most case, you don't need to create too many consumers, singleton pattern is recommended.
+        PushConsumer pushConsumer = provider.newPushConsumerBuilder()
+            .setClientConfiguration(clientConfiguration)
+            // Set the consumer group name.
+            .setConsumerGroup(consumerGroup)
+            .setMaxCacheMessageCount(1024)
+            // Set the subscription for the consumer.
+            .setSubscriptionExpressions(Collections.singletonMap(topic, filterExpression))
+            // Use setBatchMessageListener instead of setMessageListener for batch consumption.
+            .setBatchMessageListener(messageViews -> {
+                // Handle the received batch of messages and return consume result for the entire batch.
+                log.info("Received a batch of {} messages", messageViews.size());
+                for (MessageView messageView : messageViews) {
+                    log.info("  Message: topic={}, messageId={}", messageView.getTopic(),
+                        messageView.getMessageId());
+                }
+                return ConsumeResult.SUCCESS;
+            }, batchPolicy)
+            .build();
+
+        // Block the main thread, no need for production environment.
+        Thread.sleep(Long.MAX_VALUE);
+        // Close the push consumer when you don't need it anymore.
+        pushConsumer.close();
+    }
+}

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/BatchConsumeService.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/BatchConsumeService.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.java.impl.consumer;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.rocketmq.client.apis.consumer.BatchMessageListener;
+import org.apache.rocketmq.client.apis.consumer.BatchPolicy;
+import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
+import org.apache.rocketmq.client.java.hook.MessageInterceptor;
+import org.apache.rocketmq.client.java.message.MessageViewImpl;
+import org.apache.rocketmq.client.java.misc.ClientId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("NullableProblems")
+public class BatchConsumeService extends ConsumeService {
+    private static final Logger log = LoggerFactory.getLogger(BatchConsumeService.class);
+
+    protected final BatchMessageListener batchMessageListener;
+    protected final BatchPolicy batchPolicy;
+
+    protected final ReentrantLock bufferLock = new ReentrantLock();
+    protected final List<BufferedMessage> buffer = new ArrayList<>();
+    protected long bufferBytes = 0;
+    protected long firstMessageNanoTime = 0;
+    protected ScheduledFuture<?> scheduledFlush;
+
+    public BatchConsumeService(ClientId clientId, BatchMessageListener batchMessageListener,
+        BatchPolicy batchPolicy, ThreadPoolExecutor consumptionExecutor,
+        MessageInterceptor messageInterceptor, ScheduledExecutorService scheduler) {
+        super(clientId, consumptionExecutor, messageInterceptor, scheduler);
+        this.batchMessageListener = batchMessageListener;
+        this.batchPolicy = batchPolicy;
+    }
+
+    @Override
+    public void consume(ProcessQueue pq, List<MessageViewImpl> messageViews) {
+        bufferLock.lock();
+        try {
+            for (MessageViewImpl messageView : messageViews) {
+                if (messageView.isCorrupted()) {
+                    log.error("Message is corrupted for batch consumption, prepare to discard it, mq={}, "
+                        + "messageId={}, clientId={}", pq.getMessageQueue(), messageView.getMessageId(), clientId);
+                    discardMessage(pq, messageView);
+                    continue;
+                }
+                buffer.add(new BufferedMessage(pq, messageView));
+                bufferBytes += messageView.getBody().remaining();
+                if (buffer.size() == 1) {
+                    firstMessageNanoTime = System.nanoTime();
+                    scheduleTimedFlush();
+                }
+                if (shouldFlush()) {
+                    tryFlush();
+                }
+            }
+        } finally {
+            bufferLock.unlock();
+        }
+    }
+
+    protected void discardMessage(ProcessQueue pq, MessageViewImpl messageView) {
+        pq.discardMessage(messageView);
+    }
+
+    private boolean shouldFlush() {
+        return buffer.size() >= batchPolicy.getMaxBatchCount()
+            || bufferBytes >= batchPolicy.getMaxBatchBytes();
+    }
+
+    private void scheduleTimedFlush() {
+        if (scheduledFlush != null) {
+            return;
+        }
+        long delayNanos = batchPolicy.getMaxWaitTime().toNanos();
+        scheduledFlush = getScheduler().schedule(() -> {
+            bufferLock.lock();
+            try {
+                scheduledFlush = null;
+                tryFlush();
+            } finally {
+                bufferLock.unlock();
+            }
+        }, delayNanos, TimeUnit.NANOSECONDS);
+    }
+
+    protected void tryFlush() {
+        if (buffer.isEmpty()) {
+            return;
+        }
+        doFlush();
+    }
+
+    protected void doFlush() {
+        List<BufferedMessage> batch = extractBatch();
+        if (batch.isEmpty()) {
+            return;
+        }
+        submitBatch(batch);
+    }
+
+    protected List<BufferedMessage> extractBatch() {
+        int count = Math.min(buffer.size(), batchPolicy.getMaxBatchCount());
+        long bytes = 0;
+        int actualCount = 0;
+        for (int i = 0; i < count; i++) {
+            long msgBytes = buffer.get(i).messageView.getBody().remaining();
+            if (actualCount > 0 && bytes + msgBytes > batchPolicy.getMaxBatchBytes()) {
+                break;
+            }
+            bytes += msgBytes;
+            actualCount++;
+        }
+        List<BufferedMessage> batch = new ArrayList<>(buffer.subList(0, actualCount));
+        buffer.subList(0, actualCount).clear();
+        bufferBytes -= bytes;
+
+        if (scheduledFlush != null) {
+            scheduledFlush.cancel(false);
+            scheduledFlush = null;
+        }
+        if (!buffer.isEmpty()) {
+            firstMessageNanoTime = System.nanoTime();
+            scheduleTimedFlush();
+        }
+        return batch;
+    }
+
+    protected void submitBatch(List<BufferedMessage> batch) {
+        List<MessageViewImpl> messageViews = new ArrayList<>(batch.size());
+        for (BufferedMessage bm : batch) {
+            messageViews.add(bm.messageView);
+        }
+        final ListeningExecutorService executorService = MoreExecutors.listeningDecorator(getConsumptionExecutor());
+        final BatchConsumeTask task = new BatchConsumeTask(clientId, batchMessageListener,
+            messageViews, getMessageInterceptor());
+        final ListenableFuture<ConsumeResult> future = executorService.submit(task);
+        Futures.addCallback(future, new FutureCallback<ConsumeResult>() {
+            @Override
+            public void onSuccess(ConsumeResult consumeResult) {
+                onBatchComplete(batch, consumeResult);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                log.error("[Bug] Exception raised while submitting batch consumption task, clientId={}",
+                    clientId, t);
+            }
+        }, MoreExecutors.directExecutor());
+    }
+
+    protected void onBatchComplete(List<BufferedMessage> batch, ConsumeResult consumeResult) {
+        for (BufferedMessage bm : batch) {
+            bm.processQueue.eraseMessage(bm.messageView, consumeResult);
+        }
+    }
+
+    @Override
+    public void close() {
+        bufferLock.lock();
+        try {
+            if (scheduledFlush != null) {
+                scheduledFlush.cancel(false);
+                scheduledFlush = null;
+            }
+            while (!buffer.isEmpty()) {
+                doFlush();
+            }
+        } finally {
+            bufferLock.unlock();
+        }
+    }
+
+    static class BufferedMessage {
+        final ProcessQueue processQueue;
+        final MessageViewImpl messageView;
+
+        BufferedMessage(ProcessQueue processQueue, MessageViewImpl messageView) {
+            this.processQueue = processQueue;
+            this.messageView = messageView;
+        }
+    }
+}

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/BatchConsumeTask.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/BatchConsumeTask.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.java.impl.consumer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import org.apache.rocketmq.client.apis.consumer.BatchMessageListener;
+import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
+import org.apache.rocketmq.client.java.hook.MessageHookPoints;
+import org.apache.rocketmq.client.java.hook.MessageHookPointsStatus;
+import org.apache.rocketmq.client.java.hook.MessageInterceptor;
+import org.apache.rocketmq.client.java.hook.MessageInterceptorContextImpl;
+import org.apache.rocketmq.client.java.message.GeneralMessage;
+import org.apache.rocketmq.client.java.message.GeneralMessageImpl;
+import org.apache.rocketmq.client.java.message.MessageViewImpl;
+import org.apache.rocketmq.client.java.misc.ClientId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BatchConsumeTask implements Callable<ConsumeResult> {
+    private static final Logger log = LoggerFactory.getLogger(BatchConsumeTask.class);
+
+    private final ClientId clientId;
+    private final BatchMessageListener batchMessageListener;
+    private final List<MessageViewImpl> messageViews;
+    private final MessageInterceptor messageInterceptor;
+
+    public BatchConsumeTask(ClientId clientId, BatchMessageListener batchMessageListener,
+        List<MessageViewImpl> messageViews, MessageInterceptor messageInterceptor) {
+        this.clientId = clientId;
+        this.batchMessageListener = batchMessageListener;
+        this.messageViews = messageViews;
+        this.messageInterceptor = messageInterceptor;
+    }
+
+    @Override
+    public ConsumeResult call() {
+        ConsumeResult consumeResult;
+        final List<GeneralMessage> generalMessages = new ArrayList<>(messageViews.size());
+        for (MessageViewImpl messageView : messageViews) {
+            generalMessages.add(new GeneralMessageImpl(messageView));
+        }
+        MessageInterceptorContextImpl context = new MessageInterceptorContextImpl(MessageHookPoints.CONSUME);
+        messageInterceptor.doBefore(context, generalMessages);
+        try {
+            consumeResult = batchMessageListener.consume(Collections.unmodifiableList(messageViews));
+        } catch (Throwable t) {
+            log.error("Batch message listener raised an exception while consuming messages, clientId={}, "
+                + "batchSize={}", clientId, messageViews.size(), t);
+            consumeResult = ConsumeResult.FAILURE;
+        }
+        MessageHookPointsStatus status = ConsumeResult.SUCCESS.equals(consumeResult) ? MessageHookPointsStatus.OK :
+            MessageHookPointsStatus.ERROR;
+        context = new MessageInterceptorContextImpl(context, status);
+        messageInterceptor.doAfter(context, generalMessages);
+        return consumeResult;
+    }
+}

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeService.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeService.java
@@ -57,6 +57,16 @@ public abstract class ConsumeService {
 
     public abstract void consume(ProcessQueue pq, List<MessageViewImpl> messageViews);
 
+    /**
+     * Close the consume service and flush any buffered messages for consumption.
+     *
+     * <p>The default implementation is a no-op. Subclasses that maintain internal buffers
+     * (e.g. {@link BatchConsumeService}) should override this method to drain remaining
+     * messages before the consumer shuts down.
+     */
+    public void close() {
+    }
+
     public ListenableFuture<ConsumeResult> consume(MessageViewImpl messageView) {
         return consume(messageView, Duration.ZERO);
     }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeService.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeService.java
@@ -55,6 +55,23 @@ public abstract class ConsumeService {
         this.scheduler = scheduler;
     }
 
+    protected ConsumeService(ClientId clientId, ThreadPoolExecutor consumptionExecutor,
+        MessageInterceptor messageInterceptor, ScheduledExecutorService scheduler) {
+        this(clientId, null, consumptionExecutor, messageInterceptor, scheduler);
+    }
+
+    protected ThreadPoolExecutor getConsumptionExecutor() {
+        return consumptionExecutor;
+    }
+
+    protected MessageInterceptor getMessageInterceptor() {
+        return messageInterceptor;
+    }
+
+    protected ScheduledExecutorService getScheduler() {
+        return scheduler;
+    }
+
     public abstract void consume(ProcessQueue pq, List<MessageViewImpl> messageViews);
 
     /**

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/FifoBatchConsumeService.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/FifoBatchConsumeService.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.java.impl.consumer;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import org.apache.rocketmq.client.apis.consumer.BatchMessageListener;
+import org.apache.rocketmq.client.apis.consumer.BatchPolicy;
+import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
+import org.apache.rocketmq.client.java.hook.MessageInterceptor;
+import org.apache.rocketmq.client.java.message.MessageViewImpl;
+import org.apache.rocketmq.client.java.misc.ClientId;
+import org.apache.rocketmq.client.java.retry.RetryPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("NullableProblems")
+class FifoBatchConsumeService extends BatchConsumeService {
+    private static final Logger log = LoggerFactory.getLogger(FifoBatchConsumeService.class);
+
+    private final Supplier<RetryPolicy> retryPolicySupplier;
+    private final AtomicBoolean flushing = new AtomicBoolean(false);
+    private volatile boolean pendingFlush = false;
+
+    public FifoBatchConsumeService(ClientId clientId, BatchMessageListener batchMessageListener,
+        BatchPolicy batchPolicy, ThreadPoolExecutor consumptionExecutor,
+        MessageInterceptor messageInterceptor, ScheduledExecutorService scheduler,
+        Supplier<RetryPolicy> retryPolicySupplier) {
+        super(clientId, batchMessageListener, batchPolicy, consumptionExecutor,
+            messageInterceptor, scheduler);
+        this.retryPolicySupplier = retryPolicySupplier;
+    }
+
+    @Override
+    protected void discardMessage(ProcessQueue pq, MessageViewImpl messageView) {
+        pq.discardFifoMessage(messageView);
+    }
+
+    @Override
+    protected void tryFlush() {
+        if (buffer.isEmpty()) {
+            return;
+        }
+        if (!flushing.compareAndSet(false, true)) {
+            pendingFlush = true;
+            return;
+        }
+        doFlush();
+    }
+
+    @Override
+    protected void onBatchComplete(List<BufferedMessage> batch, ConsumeResult consumeResult) {
+        if (ConsumeResult.SUCCESS.equals(consumeResult)) {
+            eraseFifoBatchSuccess(batch);
+            return;
+        }
+        RetryPolicy retryPolicy = retryPolicySupplier.get();
+        int maxAttempts = retryPolicy.getMaxAttempts();
+
+        List<BufferedMessage> retryable = new ArrayList<>();
+        List<BufferedMessage> exhausted = new ArrayList<>();
+        for (BufferedMessage bm : batch) {
+            if (bm.messageView.getDeliveryAttempt() < maxAttempts) {
+                retryable.add(bm);
+            } else {
+                exhausted.add(bm);
+            }
+        }
+
+        if (!exhausted.isEmpty()) {
+            log.info("Failed to consume FIFO batch messages finally, run out of attempt times, "
+                + "maxAttempts={}, exhaustedCount={}, clientId={}", maxAttempts, exhausted.size(), clientId);
+            if (retryable.isEmpty()) {
+                eraseFifoBatchFailure(exhausted);
+                return;
+            }
+            eraseFifoBatchFailureWithoutRelease(exhausted);
+        }
+
+        for (BufferedMessage bm : retryable) {
+            bm.messageView.incrementAndGetDeliveryAttempt();
+        }
+        int nextAttempt = retryable.get(0).messageView.getDeliveryAttempt();
+        Duration nextAttemptDelay = retryPolicy.getNextAttemptDelay(nextAttempt);
+        log.debug("Prepare to redeliver the FIFO batch because of consumption failure, maxAttempts={}, "
+            + "attempt={}, retryBatchSize={}, nextAttemptDelay={}, clientId={}", maxAttempts, nextAttempt,
+            retryable.size(), nextAttemptDelay, clientId);
+        getScheduler().schedule(() -> submitBatch(retryable),
+            nextAttemptDelay.toNanos(), java.util.concurrent.TimeUnit.NANOSECONDS);
+    }
+
+    private void eraseFifoBatchSuccess(List<BufferedMessage> batch) {
+        eraseFifoBatchIteratively(batch.iterator(), ConsumeResult.SUCCESS);
+    }
+
+    private void eraseFifoBatchFailure(List<BufferedMessage> batch) {
+        eraseFifoBatchIteratively(batch.iterator(), ConsumeResult.FAILURE);
+    }
+
+    private void eraseFifoBatchFailureWithoutRelease(List<BufferedMessage> batch) {
+        eraseFifoBatchIterativelyNoRelease(batch.iterator());
+    }
+
+    private void eraseFifoBatchIterativelyNoRelease(Iterator<BufferedMessage> iterator) {
+        if (!iterator.hasNext()) {
+            return;
+        }
+        BufferedMessage bm = iterator.next();
+        ListenableFuture<Void> future = bm.processQueue.eraseFifoMessage(bm.messageView, ConsumeResult.FAILURE);
+        Futures.addCallback(future, new com.google.common.util.concurrent.FutureCallback<Void>() {
+            @Override
+            public void onSuccess(Void v) {
+                eraseFifoBatchIterativelyNoRelease(iterator);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                log.error("[Bug] Exception raised in FIFO batch erase callback, clientId={}", clientId, t);
+                eraseFifoBatchIterativelyNoRelease(iterator);
+            }
+        }, MoreExecutors.directExecutor());
+    }
+
+    private void eraseFifoBatchIteratively(Iterator<BufferedMessage> iterator, ConsumeResult result) {
+        if (!iterator.hasNext()) {
+            releaseFlushing();
+            return;
+        }
+        BufferedMessage bm = iterator.next();
+        ListenableFuture<Void> future = bm.processQueue.eraseFifoMessage(bm.messageView, result);
+        Futures.addCallback(future, new com.google.common.util.concurrent.FutureCallback<Void>() {
+            @Override
+            public void onSuccess(Void v) {
+                eraseFifoBatchIteratively(iterator, result);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                log.error("[Bug] Exception raised in FIFO batch erase callback, clientId={}", clientId, t);
+                eraseFifoBatchIteratively(iterator, result);
+            }
+        }, MoreExecutors.directExecutor());
+    }
+
+    private void releaseFlushing() {
+        flushing.set(false);
+        if (pendingFlush) {
+            pendingFlush = false;
+            bufferLock.lock();
+            try {
+                tryFlush();
+            } finally {
+                bufferLock.unlock();
+            }
+        }
+    }
+}

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerBuilderImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerBuilderImpl.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.rocketmq.client.apis.ClientConfiguration;
 import org.apache.rocketmq.client.apis.ClientException;
+import org.apache.rocketmq.client.apis.consumer.BatchMessageListener;
+import org.apache.rocketmq.client.apis.consumer.BatchPolicy;
 import org.apache.rocketmq.client.apis.consumer.FilterExpression;
 import org.apache.rocketmq.client.apis.consumer.MessageListener;
 import org.apache.rocketmq.client.apis.consumer.PushConsumer;
@@ -49,6 +51,8 @@ public class PushConsumerBuilderImpl implements PushConsumerBuilder {
     private int consumptionThreadCount = 20;
     private boolean enableFifoConsumeAccelerator = false;
     private boolean enableMessageInterceptorFiltering = false;
+    private BatchMessageListener batchMessageListener = null;
+    private BatchPolicy batchPolicy = null;
 
     /**
      * @see PushConsumerBuilder#setClientConfiguration(ClientConfiguration)
@@ -133,8 +137,21 @@ public class PushConsumerBuilderImpl implements PushConsumerBuilder {
     /**
      * @see PushConsumerBuilder#setEnableMessageInterceptorFiltering(boolean)
      */
+    @Override
     public PushConsumerBuilder setEnableMessageInterceptorFiltering(boolean enableMessageInterceptorFiltering) {
         this.enableMessageInterceptorFiltering = enableMessageInterceptorFiltering;
+        return this;
+    }
+
+    /**
+     * @see PushConsumerBuilder#setBatchMessageListener(BatchMessageListener, BatchPolicy)
+     */
+    @Override
+    public PushConsumerBuilder setBatchMessageListener(BatchMessageListener batchMessageListener,
+        BatchPolicy batchPolicy) {
+        this.batchMessageListener = checkNotNull(batchMessageListener,
+            "batchMessageListener should not be null");
+        this.batchPolicy = checkNotNull(batchPolicy, "batchPolicy should not be null");
         return this;
     }
 
@@ -145,11 +162,29 @@ public class PushConsumerBuilderImpl implements PushConsumerBuilder {
     public PushConsumer build() throws ClientException {
         checkNotNull(clientConfiguration, "clientConfiguration has not been set yet");
         checkNotNull(consumerGroup, "consumerGroup has not been set yet");
-        checkNotNull(messageListener, "messageListener has not been set yet");
+        final boolean hasSingle = messageListener != null;
+        final boolean hasBatch = batchMessageListener != null;
+        checkArgument(hasSingle || hasBatch,
+            "either messageListener or batchMessageListener must be set");
+        checkArgument(!(hasSingle && hasBatch),
+            "messageListener and batchMessageListener are mutually exclusive");
         checkArgument(!subscriptionExpressions.isEmpty(), "subscriptionExpressions have not been set yet");
-        final PushConsumerImpl pushConsumer = new PushConsumerImpl(clientConfiguration, consumerGroup,
-            subscriptionExpressions, messageListener, maxCacheMessageCount, maxCacheMessageSizeInBytes,
-            consumptionThreadCount, enableFifoConsumeAccelerator, enableMessageInterceptorFiltering);
+        final PushConsumerImpl pushConsumer;
+        if (hasBatch) {
+            checkArgument(maxCacheMessageCount >= batchPolicy.getMaxBatchCount(),
+                "maxCacheMessageCount must be >= batchPolicy.maxBatchCount, but %s < %s",
+                maxCacheMessageCount, batchPolicy.getMaxBatchCount());
+            checkArgument(maxCacheMessageSizeInBytes >= batchPolicy.getMaxBatchBytes(),
+                "maxCacheMessageSizeInBytes must be >= batchPolicy.maxBatchBytes, but %s < %s",
+                maxCacheMessageSizeInBytes, batchPolicy.getMaxBatchBytes());
+            pushConsumer = new PushConsumerImpl(clientConfiguration, consumerGroup,
+                subscriptionExpressions, batchMessageListener, batchPolicy, maxCacheMessageCount,
+                maxCacheMessageSizeInBytes, consumptionThreadCount, enableMessageInterceptorFiltering);
+        } else {
+            pushConsumer = new PushConsumerImpl(clientConfiguration, consumerGroup,
+                subscriptionExpressions, messageListener, maxCacheMessageCount, maxCacheMessageSizeInBytes,
+                consumptionThreadCount, enableFifoConsumeAccelerator, enableMessageInterceptorFiltering);
+        }
         pushConsumer.startAsync().awaitRunning();
         return pushConsumer;
     }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
@@ -50,6 +50,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import org.apache.rocketmq.client.apis.ClientConfiguration;
 import org.apache.rocketmq.client.apis.ClientException;
+import org.apache.rocketmq.client.apis.consumer.BatchMessageListener;
+import org.apache.rocketmq.client.apis.consumer.BatchPolicy;
 import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
 import org.apache.rocketmq.client.apis.consumer.FilterExpression;
 import org.apache.rocketmq.client.apis.consumer.MessageListener;
@@ -96,6 +98,8 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
     private final Map<String /* topic */, FilterExpression> subscriptionExpressions;
     private final ConcurrentMap<String /* topic */, Assignments> cacheAssignments;
     private final MessageListener messageListener;
+    private final BatchMessageListener batchMessageListener;
+    private final BatchPolicy batchPolicy;
     private final int maxCacheMessageCount;
     private final int maxCacheMessageSizeInBytes;
     private final boolean enableFifoConsumeAccelerator;
@@ -125,12 +129,43 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
         Map<String, FilterExpression> subscriptionExpressions, MessageListener messageListener,
         int maxCacheMessageCount, int maxCacheMessageSizeInBytes, int consumptionThreadCount,
         boolean enableFifoConsumeAccelerator) {
-        this(clientConfiguration, consumerGroup, subscriptionExpressions, messageListener, maxCacheMessageCount,
-            maxCacheMessageSizeInBytes, consumptionThreadCount, enableFifoConsumeAccelerator, false);
+        this(clientConfiguration, consumerGroup, subscriptionExpressions, messageListener,
+            null, null,
+            maxCacheMessageCount, maxCacheMessageSizeInBytes, consumptionThreadCount,
+            enableFifoConsumeAccelerator, false);
     }
 
     public PushConsumerImpl(ClientConfiguration clientConfiguration, String consumerGroup,
         Map<String, FilterExpression> subscriptionExpressions, MessageListener messageListener,
+        int maxCacheMessageCount, int maxCacheMessageSizeInBytes, int consumptionThreadCount,
+        boolean enableFifoConsumeAccelerator, boolean enableMessageInterceptorFiltering) {
+        this(clientConfiguration, consumerGroup, subscriptionExpressions, messageListener,
+            null, null,
+            maxCacheMessageCount, maxCacheMessageSizeInBytes, consumptionThreadCount,
+            enableFifoConsumeAccelerator, enableMessageInterceptorFiltering);
+    }
+
+    /**
+     * Batch consumption constructor.
+     */
+    public PushConsumerImpl(ClientConfiguration clientConfiguration, String consumerGroup,
+        Map<String, FilterExpression> subscriptionExpressions,
+        BatchMessageListener batchMessageListener, BatchPolicy batchPolicy,
+        int maxCacheMessageCount, int maxCacheMessageSizeInBytes, int consumptionThreadCount,
+        boolean enableMessageInterceptorFiltering) {
+        this(clientConfiguration, consumerGroup, subscriptionExpressions, null,
+            batchMessageListener, batchPolicy,
+            maxCacheMessageCount, maxCacheMessageSizeInBytes, consumptionThreadCount,
+            false, enableMessageInterceptorFiltering);
+    }
+
+    /**
+     * Full constructor (internal). Either {@code messageListener} or {@code batchMessageListener}
+     * should be non-null, not both.
+     */
+    private PushConsumerImpl(ClientConfiguration clientConfiguration, String consumerGroup,
+        Map<String, FilterExpression> subscriptionExpressions, MessageListener messageListener,
+        BatchMessageListener batchMessageListener, BatchPolicy batchPolicy,
         int maxCacheMessageCount, int maxCacheMessageSizeInBytes, int consumptionThreadCount,
         boolean enableFifoConsumeAccelerator, boolean enableMessageInterceptorFiltering) {
         super(clientConfiguration, consumerGroup, subscriptionExpressions.keySet());
@@ -139,6 +174,8 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
         this.subscriptionExpressions = subscriptionExpressions;
         this.cacheAssignments = new ConcurrentHashMap<>();
         this.messageListener = messageListener;
+        this.batchMessageListener = batchMessageListener;
+        this.batchPolicy = batchPolicy;
         this.maxCacheMessageCount = maxCacheMessageCount;
         this.maxCacheMessageSizeInBytes = maxCacheMessageSizeInBytes;
         this.enableFifoConsumeAccelerator = enableFifoConsumeAccelerator;
@@ -163,11 +200,13 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
         this.addMessageInterceptor(inflightRequestCountInterceptor);
     }
 
+    @VisibleForTesting
     public PushConsumerImpl(ClientConfiguration clientConfiguration, String consumerGroup,
         Map<String, FilterExpression> subscriptionExpressions, MessageListener messageListener,
         int maxCacheMessageCount, int maxCacheMessageSizeInBytes, int consumptionThreadCount) {
-        this(clientConfiguration, consumerGroup, subscriptionExpressions, messageListener, maxCacheMessageCount,
-            maxCacheMessageSizeInBytes, consumptionThreadCount, true, false);
+        this(clientConfiguration, consumerGroup, subscriptionExpressions, messageListener,
+            null, null,
+            maxCacheMessageCount, maxCacheMessageSizeInBytes, consumptionThreadCount, true, false);
     }
 
     @Override
@@ -213,6 +252,8 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
         }
         log.info("Waiting for the inflight receive requests to be finished, clientId={}", clientId);
         waitingReceiveRequestFinished();
+        log.info("Flush remaining buffered messages in consume service, clientId={}", clientId);
+        this.consumeService.close();
         log.info("Begin to Shutdown consumption executor, clientId={}", clientId);
         this.consumptionExecutor.shutdown();
         ExecutorServices.awaitTerminated(consumptionExecutor);
@@ -246,6 +287,13 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
 
     protected ConsumeService createConsumeService() {
         final ScheduledExecutorService scheduler = this.getClientManager().getScheduler();
+        if (batchMessageListener != null) {
+            final boolean fifo = getSettings().isFifo();
+            log.info("Create {}batch consume service, consumerGroup={}, clientId={}, batchPolicy={}",
+                fifo ? "FIFO " : "", getConsumerGroup(), clientId, batchPolicy);
+            return new BatchConsumeService(clientId, batchMessageListener, batchPolicy,
+                consumptionExecutor, this, scheduler, fifo);
+        }
         if (getSettings().isFifo()) {
             log.info("Create {}FIFO consume service, consumerGroup={}, clientId={}, enableFifoConsumeAccelerator={}",
                 isLiteConsumer() ? "Lite " : "", getConsumerGroup(), clientId, enableFifoConsumeAccelerator);

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
@@ -291,7 +291,12 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
             final boolean fifo = getSettings().isFifo();
             log.info("Create {}batch consume service, consumerGroup={}, clientId={}, batchPolicy={}",
                 fifo ? "FIFO " : "", getConsumerGroup(), clientId, batchPolicy);
-            // todo
+            if (fifo) {
+                return new FifoBatchConsumeService(clientId, batchMessageListener, batchPolicy,
+                    consumptionExecutor, this, scheduler, this::getRetryPolicy);
+            }
+            return new BatchConsumeService(clientId, batchMessageListener, batchPolicy,
+                consumptionExecutor, this, scheduler);
         }
         if (getSettings().isFifo()) {
             log.info("Create {}FIFO consume service, consumerGroup={}, clientId={}, enableFifoConsumeAccelerator={}",

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
@@ -291,8 +291,7 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
             final boolean fifo = getSettings().isFifo();
             log.info("Create {}batch consume service, consumerGroup={}, clientId={}, batchPolicy={}",
                 fifo ? "FIFO " : "", getConsumerGroup(), clientId, batchPolicy);
-            return new BatchConsumeService(clientId, batchMessageListener, batchPolicy,
-                consumptionExecutor, this, scheduler, fifo);
+            // todo
         }
         if (getSettings().isFifo()) {
             log.info("Create {}FIFO consume service, consumerGroup={}, clientId={}, enableFifoConsumeAccelerator={}",

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/BatchConsumeServiceTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/BatchConsumeServiceTest.java
@@ -1,0 +1,472 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.java.impl.consumer;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.util.concurrent.Futures;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.rocketmq.client.apis.consumer.BatchPolicy;
+import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
+import org.apache.rocketmq.client.java.hook.MessageInterceptor;
+import org.apache.rocketmq.client.java.message.MessageViewImpl;
+import org.apache.rocketmq.client.java.misc.ClientId;
+import org.apache.rocketmq.client.java.misc.ThreadFactoryImpl;
+import org.apache.rocketmq.client.java.retry.RetryPolicy;
+import org.apache.rocketmq.client.java.tool.TestBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class BatchConsumeServiceTest extends TestBase {
+    private final ClientId clientId = new ClientId();
+    private final MessageInterceptor interceptor = mock(MessageInterceptor.class);
+    private ThreadPoolExecutor consumptionExecutor;
+    private ScheduledExecutorService scheduler;
+
+    @Before
+    public void setUp() {
+        consumptionExecutor = new ThreadPoolExecutor(4, 4, 0L, TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(), new ThreadFactoryImpl("TestBatchConsumption"));
+        scheduler = new ScheduledThreadPoolExecutor(1, new ThreadFactoryImpl("TestBatchScheduler"));
+    }
+
+    @After
+    public void tearDown() {
+        consumptionExecutor.shutdownNow();
+        scheduler.shutdownNow();
+    }
+
+    private ProcessQueue mockProcessQueue() {
+        ProcessQueue pq = mock(ProcessQueue.class);
+        Mockito.when(pq.getMessageQueue()).thenReturn(fakeMessageQueueImpl0());
+        Mockito.when(pq.eraseFifoMessage(any(), any()))
+            .thenReturn(Futures.immediateVoidFuture());
+        return pq;
+    }
+
+    private List<MessageViewImpl> createMessages(int count) {
+        return createMessages(count, 1);
+    }
+
+    private List<MessageViewImpl> createMessages(int count, int bodySize) {
+        List<MessageViewImpl> messages = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            messages.add(fakeMessageViewImpl(bodySize, false));
+        }
+        return messages;
+    }
+
+    // ==================== Concurrent Mode Tests ====================
+
+    @Test
+    public void testConcurrentBatchConsumeSuccess() {
+        int batchSize = 4;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofSeconds(5));
+        CopyOnWriteArrayList<Integer> receivedBatchSizes = new CopyOnWriteArrayList<>();
+
+        BatchConsumeService service = new BatchConsumeService(clientId,
+            messageViews -> {
+                receivedBatchSizes.add(messageViews.size());
+                return ConsumeResult.SUCCESS;
+            }, policy, consumptionExecutor, interceptor, scheduler);
+
+        ProcessQueue pq = mockProcessQueue();
+        service.consume(pq, createMessages(batchSize));
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertEquals(1, receivedBatchSizes.size());
+            assertEquals(batchSize, receivedBatchSizes.get(0).intValue());
+        });
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+            verify(pq, Mockito.times(batchSize)).eraseMessage(any(), eq(ConsumeResult.SUCCESS)));
+    }
+
+    @Test
+    public void testConcurrentBytesTriggerFlush() {
+        int maxBatchBytes = 10;
+        BatchPolicy policy = new BatchPolicy(100, maxBatchBytes, Duration.ofSeconds(30));
+        CopyOnWriteArrayList<Integer> receivedBatchSizes = new CopyOnWriteArrayList<>();
+
+        BatchConsumeService service = new BatchConsumeService(clientId,
+            messageViews -> {
+                receivedBatchSizes.add(messageViews.size());
+                return ConsumeResult.SUCCESS;
+            }, policy, consumptionExecutor, interceptor, scheduler);
+
+        ProcessQueue pq = mockProcessQueue();
+        // Each message has body size 5, so 2 messages (10 bytes) should trigger flush
+        service.consume(pq, createMessages(3, 5));
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+            assertTrue("At least one batch should have been flushed", receivedBatchSizes.size() >= 1));
+    }
+
+    @Test
+    public void testConcurrentTimeoutTriggerFlush() {
+        BatchPolicy policy = new BatchPolicy(100, Duration.ofMillis(200));
+        CopyOnWriteArrayList<Integer> receivedBatchSizes = new CopyOnWriteArrayList<>();
+
+        BatchConsumeService service = new BatchConsumeService(clientId,
+            messageViews -> {
+                receivedBatchSizes.add(messageViews.size());
+                return ConsumeResult.SUCCESS;
+            }, policy, consumptionExecutor, interceptor, scheduler);
+
+        ProcessQueue pq = mockProcessQueue();
+        service.consume(pq, createMessages(2));
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertEquals(1, receivedBatchSizes.size());
+            assertEquals(2, receivedBatchSizes.get(0).intValue());
+        });
+    }
+
+    @Test
+    public void testConcurrentCrossPqMixing() {
+        int batchSize = 4;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofSeconds(5));
+        CopyOnWriteArrayList<Integer> receivedBatchSizes = new CopyOnWriteArrayList<>();
+
+        BatchConsumeService service = new BatchConsumeService(clientId,
+            messageViews -> {
+                receivedBatchSizes.add(messageViews.size());
+                return ConsumeResult.SUCCESS;
+            }, policy, consumptionExecutor, interceptor, scheduler);
+
+        ProcessQueue pq1 = mockProcessQueue();
+        ProcessQueue pq2 = mockProcessQueue();
+        service.consume(pq1, createMessages(2));
+        service.consume(pq2, createMessages(2));
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertEquals(1, receivedBatchSizes.size());
+            assertEquals(batchSize, receivedBatchSizes.get(0).intValue());
+        });
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            verify(pq1, Mockito.times(2)).eraseMessage(any(), eq(ConsumeResult.SUCCESS));
+            verify(pq2, Mockito.times(2)).eraseMessage(any(), eq(ConsumeResult.SUCCESS));
+        });
+    }
+
+    @Test
+    public void testConcurrentCorruptedMessageFiltered() {
+        int batchSize = 3;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofMillis(200));
+        CopyOnWriteArrayList<Integer> receivedBatchSizes = new CopyOnWriteArrayList<>();
+
+        BatchConsumeService service = new BatchConsumeService(clientId,
+            messageViews -> {
+                receivedBatchSizes.add(messageViews.size());
+                return ConsumeResult.SUCCESS;
+            }, policy, consumptionExecutor, interceptor, scheduler);
+
+        ProcessQueue pq = mockProcessQueue();
+        List<MessageViewImpl> messages = new ArrayList<>();
+        messages.add(fakeMessageViewImpl(false));
+        messages.add(fakeMessageViewImpl(true));  // corrupted
+        messages.add(fakeMessageViewImpl(false));
+        service.consume(pq, messages);
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertEquals(1, receivedBatchSizes.size());
+            assertEquals(2, receivedBatchSizes.get(0).intValue());
+        });
+
+        verify(pq).discardMessage(any());
+    }
+
+    @Test
+    public void testConcurrentConsumeFailure() {
+        int batchSize = 3;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofSeconds(5));
+
+        BatchConsumeService service = new BatchConsumeService(clientId,
+            messageViews -> ConsumeResult.FAILURE, policy, consumptionExecutor, interceptor, scheduler);
+
+        ProcessQueue pq = mockProcessQueue();
+        service.consume(pq, createMessages(batchSize));
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+            verify(pq, Mockito.times(batchSize)).eraseMessage(any(), eq(ConsumeResult.FAILURE)));
+    }
+
+    @Test
+    public void testConcurrentConsumeException() {
+        int batchSize = 3;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofSeconds(5));
+
+        BatchConsumeService service = new BatchConsumeService(clientId,
+            messageViews -> {
+                throw new RuntimeException("test");
+            }, policy, consumptionExecutor, interceptor, scheduler);
+
+        ProcessQueue pq = mockProcessQueue();
+        service.consume(pq, createMessages(batchSize));
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+            verify(pq, Mockito.times(batchSize)).eraseMessage(any(), eq(ConsumeResult.FAILURE)));
+    }
+
+    @Test
+    public void testConcurrentCloseFlushesRemainingMessages() {
+        BatchPolicy policy = new BatchPolicy(100, Duration.ofSeconds(30));
+        CopyOnWriteArrayList<Integer> receivedBatchSizes = new CopyOnWriteArrayList<>();
+
+        BatchConsumeService service = new BatchConsumeService(clientId,
+            messageViews -> {
+                receivedBatchSizes.add(messageViews.size());
+                return ConsumeResult.SUCCESS;
+            }, policy, consumptionExecutor, interceptor, scheduler);
+
+        ProcessQueue pq = mockProcessQueue();
+        service.consume(pq, createMessages(3));
+        assertEquals(0, receivedBatchSizes.size());
+
+        service.close();
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertEquals(1, receivedBatchSizes.size());
+            assertEquals(3, receivedBatchSizes.get(0).intValue());
+        });
+    }
+
+    // ==================== FIFO Mode Tests ====================
+
+    private RetryPolicy mockRetryPolicy(int maxAttempts) {
+        return createCustomizedBackoffRetryPolicy(maxAttempts);
+    }
+
+    @Test
+    public void testFifoBatchConsumeSuccess() {
+        int batchSize = 3;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofSeconds(5));
+
+        FifoBatchConsumeService service = new FifoBatchConsumeService(clientId,
+            messageViews -> ConsumeResult.SUCCESS, policy, consumptionExecutor, interceptor, scheduler,
+            () -> mockRetryPolicy(3));
+
+        ProcessQueue pq = mockProcessQueue();
+        service.consume(pq, createMessages(batchSize));
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+            verify(pq, Mockito.times(batchSize)).eraseFifoMessage(any(), eq(ConsumeResult.SUCCESS)));
+    }
+
+    @Test
+    public void testFifoFirstFailureTriggerRetry() {
+        int batchSize = 2;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofSeconds(5));
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        FifoBatchConsumeService service = new FifoBatchConsumeService(clientId,
+            messageViews -> {
+                int count = callCount.incrementAndGet();
+                return count == 1 ? ConsumeResult.FAILURE : ConsumeResult.SUCCESS;
+            }, policy, consumptionExecutor, interceptor, scheduler,
+            () -> mockRetryPolicy(3));
+
+        ProcessQueue pq = mockProcessQueue();
+        service.consume(pq, createMessages(batchSize));
+
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertTrue("Listener should be called at least twice (1 fail + 1 success)",
+                callCount.get() >= 2);
+            verify(pq, Mockito.times(batchSize)).eraseFifoMessage(any(), eq(ConsumeResult.SUCCESS));
+        });
+    }
+
+    @Test
+    public void testFifoRetryThenSuccess() {
+        int batchSize = 2;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofSeconds(5));
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        FifoBatchConsumeService service = new FifoBatchConsumeService(clientId,
+            messageViews -> {
+                int count = callCount.incrementAndGet();
+                return count <= 2 ? ConsumeResult.FAILURE : ConsumeResult.SUCCESS;
+            }, policy, consumptionExecutor, interceptor, scheduler,
+            () -> mockRetryPolicy(5));
+
+        ProcessQueue pq = mockProcessQueue();
+        service.consume(pq, createMessages(batchSize));
+
+        await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertTrue("Listener should be called 3 times (2 fails + 1 success)", callCount.get() >= 3);
+            verify(pq, Mockito.times(batchSize)).eraseFifoMessage(any(), eq(ConsumeResult.SUCCESS));
+        });
+    }
+
+    @Test
+    public void testFifoExhaustedRetryGoesToDlq() {
+        int batchSize = 2;
+        int maxAttempts = 2;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofSeconds(5));
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        FifoBatchConsumeService service = new FifoBatchConsumeService(clientId,
+            messageViews -> {
+                callCount.incrementAndGet();
+                return ConsumeResult.FAILURE;
+            }, policy, consumptionExecutor, interceptor, scheduler,
+            () -> mockRetryPolicy(maxAttempts));
+
+        ProcessQueue pq = mockProcessQueue();
+        service.consume(pq, createMessages(batchSize));
+
+        await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertTrue("Listener should be called maxAttempts times", callCount.get() >= maxAttempts);
+            verify(pq, Mockito.times(batchSize)).eraseFifoMessage(any(), eq(ConsumeResult.FAILURE));
+        });
+    }
+
+    @Test
+    public void testFifoSerialFlush() {
+        int batchSize = 2;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofSeconds(5));
+        CopyOnWriteArrayList<Integer> receivedBatchSizes = new CopyOnWriteArrayList<>();
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        FifoBatchConsumeService service = new FifoBatchConsumeService(clientId,
+            messageViews -> {
+                receivedBatchSizes.add(messageViews.size());
+                callCount.incrementAndGet();
+                try {
+                    Thread.sleep(200);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return ConsumeResult.SUCCESS;
+            }, policy, consumptionExecutor, interceptor, scheduler,
+            () -> mockRetryPolicy(3));
+
+        ProcessQueue pq = mockProcessQueue();
+        // First batch fills immediately
+        service.consume(pq, createMessages(batchSize));
+        // Second batch should be buffered while first is in-flight
+        service.consume(pq, createMessages(batchSize));
+
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertEquals("Both batches should have been consumed", 2, callCount.get());
+            assertEquals(2, receivedBatchSizes.size());
+        });
+    }
+
+    @Test
+    public void testFifoConsumeException() {
+        int batchSize = 2;
+        int maxAttempts = 2;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofSeconds(5));
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        FifoBatchConsumeService service = new FifoBatchConsumeService(clientId,
+            messageViews -> {
+                callCount.incrementAndGet();
+                throw new RuntimeException("test exception");
+            }, policy, consumptionExecutor, interceptor, scheduler,
+            () -> mockRetryPolicy(maxAttempts));
+
+        ProcessQueue pq = mockProcessQueue();
+        service.consume(pq, createMessages(batchSize));
+
+        await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertTrue("Listener should be called maxAttempts times", callCount.get() >= maxAttempts);
+            verify(pq, Mockito.times(batchSize)).eraseFifoMessage(any(), eq(ConsumeResult.FAILURE));
+        });
+    }
+
+    @Test
+    public void testFifoPartialExhaustionSendsToDlq() {
+        int batchSize = 3;
+        int maxAttempts = 2;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofSeconds(5));
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        FifoBatchConsumeService service = new FifoBatchConsumeService(clientId,
+            messageViews -> {
+                callCount.incrementAndGet();
+                return ConsumeResult.FAILURE;
+            }, policy, consumptionExecutor, interceptor, scheduler,
+            () -> mockRetryPolicy(maxAttempts));
+
+        ProcessQueue pq = mockProcessQueue();
+
+        // Create messages with different delivery attempts:
+        // msg0: attempt=1 (already near max), msg1: attempt=0, msg2: attempt=0
+        List<MessageViewImpl> messages = createMessages(batchSize);
+        messages.get(0).incrementAndGetDeliveryAttempt(); // now attempt=1
+
+        service.consume(pq, messages);
+
+        // After first failure: msg0 (attempt=1 >= maxAttempts=2) goes to DLQ,
+        // msg1 and msg2 (attempt=0 < 2) get incremented and retried.
+        // After second failure: msg1 and msg2 (attempt=1 >= 2) go to DLQ.
+        await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertTrue("Listener should be called at least twice", callCount.get() >= 2);
+            // All 3 messages eventually go to DLQ
+            verify(pq, Mockito.times(batchSize)).eraseFifoMessage(any(), eq(ConsumeResult.FAILURE));
+        });
+    }
+
+    @Test
+    public void testFifoCorruptedMessageFiltered() {
+        int batchSize = 2;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofMillis(200));
+        CopyOnWriteArrayList<Integer> receivedBatchSizes = new CopyOnWriteArrayList<>();
+
+        FifoBatchConsumeService service = new FifoBatchConsumeService(clientId,
+            messageViews -> {
+                receivedBatchSizes.add(messageViews.size());
+                return ConsumeResult.SUCCESS;
+            }, policy, consumptionExecutor, interceptor, scheduler,
+            () -> mockRetryPolicy(3));
+
+        ProcessQueue pq = mockProcessQueue();
+        List<MessageViewImpl> messages = new ArrayList<>();
+        messages.add(fakeMessageViewImpl(false));
+        messages.add(fakeMessageViewImpl(true));  // corrupted
+        messages.add(fakeMessageViewImpl(false));
+        service.consume(pq, messages);
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertEquals(1, receivedBatchSizes.size());
+            assertEquals(2, receivedBatchSizes.get(0).intValue());
+        });
+
+        verify(pq).discardFifoMessage(any());
+    }
+}

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/BatchConsumeTaskTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/BatchConsumeTaskTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.java.impl.consumer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
+import org.apache.rocketmq.client.java.hook.MessageInterceptor;
+import org.apache.rocketmq.client.java.message.MessageViewImpl;
+import org.apache.rocketmq.client.java.misc.ClientId;
+import org.apache.rocketmq.client.java.tool.TestBase;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class BatchConsumeTaskTest extends TestBase {
+    private final ClientId clientId = new ClientId();
+    private final MessageInterceptor interceptor = Mockito.mock(MessageInterceptor.class);
+
+    @Test
+    public void testConsumeSuccess() {
+        List<MessageViewImpl> views = Arrays.asList(fakeMessageViewImpl(), fakeMessageViewImpl());
+        BatchConsumeTask task = new BatchConsumeTask(clientId, messageViews -> ConsumeResult.SUCCESS,
+            views, interceptor);
+        assertEquals(ConsumeResult.SUCCESS, task.call());
+    }
+
+    @Test
+    public void testConsumeFailure() {
+        List<MessageViewImpl> views = Arrays.asList(fakeMessageViewImpl(), fakeMessageViewImpl());
+        BatchConsumeTask task = new BatchConsumeTask(clientId, messageViews -> ConsumeResult.FAILURE,
+            views, interceptor);
+        assertEquals(ConsumeResult.FAILURE, task.call());
+    }
+
+    @Test
+    public void testConsumeWithException() {
+        List<MessageViewImpl> views = Arrays.asList(fakeMessageViewImpl(), fakeMessageViewImpl());
+        BatchConsumeTask task = new BatchConsumeTask(clientId, messageViews -> {
+            throw new RuntimeException("test exception");
+        }, views, interceptor);
+        assertEquals(ConsumeResult.FAILURE, task.call());
+    }
+}

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerBuilderImplTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerBuilderImplTest.java
@@ -17,13 +17,20 @@
 
 package org.apache.rocketmq.client.java.impl.consumer;
 
+import java.time.Duration;
+import java.util.Map;
 import org.apache.rocketmq.client.apis.ClientConfiguration;
 import org.apache.rocketmq.client.apis.ClientException;
+import org.apache.rocketmq.client.apis.consumer.BatchPolicy;
 import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
+import org.apache.rocketmq.client.apis.consumer.FilterExpression;
 import org.apache.rocketmq.client.java.tool.TestBase;
 import org.junit.Test;
 
 public class PushConsumerBuilderImplTest extends TestBase {
+
+    private final Map<String, FilterExpression> subscriptionExpressions =
+        createSubscriptionExpressions(FAKE_TOPIC_0);
 
     @Test(expected = NullPointerException.class)
     public void testSetClientConfigurationWithNull() {
@@ -69,5 +76,40 @@ public class PushConsumerBuilderImplTest extends TestBase {
         builder.setClientConfiguration(clientConfiguration).setConsumerGroup(FAKE_CONSUMER_GROUP_0)
             .setMessageListener(messageView -> ConsumeResult.SUCCESS)
             .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuildWithoutAnyListener() throws ClientException {
+        final PushConsumerBuilderImpl builder = new PushConsumerBuilderImpl();
+        ClientConfiguration clientConfiguration =
+            ClientConfiguration.newBuilder().setEndpoints(FAKE_ENDPOINTS).build();
+        builder.setClientConfiguration(clientConfiguration).setConsumerGroup(FAKE_CONSUMER_GROUP_0)
+            .setSubscriptionExpressions(subscriptionExpressions)
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuildWithBothListeners() throws ClientException {
+        final PushConsumerBuilderImpl builder = new PushConsumerBuilderImpl();
+        ClientConfiguration clientConfiguration =
+            ClientConfiguration.newBuilder().setEndpoints(FAKE_ENDPOINTS).build();
+        builder.setClientConfiguration(clientConfiguration).setConsumerGroup(FAKE_CONSUMER_GROUP_0)
+            .setSubscriptionExpressions(subscriptionExpressions)
+            .setMessageListener(messageView -> ConsumeResult.SUCCESS)
+            .setBatchMessageListener(views -> ConsumeResult.SUCCESS,
+                new BatchPolicy(10, Duration.ofSeconds(5)))
+            .build();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetBatchMessageListenerWithNullListener() {
+        final PushConsumerBuilderImpl builder = new PushConsumerBuilderImpl();
+        builder.setBatchMessageListener(null, new BatchPolicy(10, Duration.ofSeconds(5)));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetBatchMessageListenerWithNullPolicy() {
+        final PushConsumerBuilderImpl builder = new PushConsumerBuilderImpl();
+        builder.setBatchMessageListener(views -> ConsumeResult.SUCCESS, null);
     }
 }

--- a/java/test/src/test/java/org/apache/rocketmq/test/client/BatchPushConsumerTest.java
+++ b/java/test/src/test/java/org/apache/rocketmq/test/client/BatchPushConsumerTest.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.test.client;
+
+import static org.apache.rocketmq.client.apis.consumer.FilterExpression.SUB_ALL;
+import static org.awaitility.Awaitility.await;
+
+import apache.rocketmq.v2.AckMessageRequest;
+import apache.rocketmq.v2.AckMessageResponse;
+import apache.rocketmq.v2.ChangeInvisibleDurationRequest;
+import apache.rocketmq.v2.ChangeInvisibleDurationResponse;
+import apache.rocketmq.v2.Message;
+import apache.rocketmq.v2.ReceiveMessageRequest;
+import apache.rocketmq.v2.ReceiveMessageResponse;
+import apache.rocketmq.v2.Resource;
+import apache.rocketmq.v2.SystemProperties;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.util.Timestamps;
+import io.grpc.stub.StreamObserver;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.rocketmq.client.apis.ClientConfiguration;
+import org.apache.rocketmq.client.apis.ClientServiceProvider;
+import org.apache.rocketmq.client.apis.SessionCredentialsProvider;
+import org.apache.rocketmq.client.apis.StaticSessionCredentialsProvider;
+import org.apache.rocketmq.client.apis.consumer.BatchPolicy;
+import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
+import org.apache.rocketmq.client.apis.consumer.PushConsumer;
+import org.apache.rocketmq.client.apis.consumer.PushConsumerBuilder;
+import org.apache.rocketmq.test.server.BaseMockServerImpl;
+import org.apache.rocketmq.test.server.GrpcServerIntegrationTest;
+import org.apache.rocketmq.test.server.MockServer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BatchPushConsumerTest extends GrpcServerIntegrationTest {
+    private final String topic = "topic";
+    private final LinkedBlockingDeque<List<String>> messageQueue = new LinkedBlockingDeque<>();
+    private MockServer serverImpl;
+
+    static class BatchMockServerImpl extends BaseMockServerImpl {
+        private final LinkedBlockingDeque<List<String>> messageQueue;
+        public final AtomicInteger ackCount = new AtomicInteger(0);
+        public final AtomicInteger nackCount = new AtomicInteger(0);
+
+        public BatchMockServerImpl(String topic, boolean fifo, LinkedBlockingDeque<List<String>> messageQueue) {
+            super(topic, "broker", fifo);
+            this.messageQueue = messageQueue;
+        }
+
+        @Override
+        public void receiveMessage(ReceiveMessageRequest request,
+            StreamObserver<ReceiveMessageResponse> responseObserver) {
+            try {
+                List<String> messages = messageQueue.poll(10, TimeUnit.SECONDS);
+                if (messages == null || messages.isEmpty()) {
+                    responseObserver.onNext(ReceiveMessageResponse.newBuilder()
+                        .setStatus(messageNotFound).build());
+                    responseObserver.onCompleted();
+                } else {
+                    responseObserver.onNext(ReceiveMessageResponse.newBuilder()
+                        .setStatus(mockStatus).build());
+                    for (String messageId : messages) {
+                        Message msg = Message.newBuilder()
+                            .setTopic(Resource.newBuilder().setName(topic).build())
+                            .setBody(ByteString.copyFrom(new byte[10]))
+                            .setSystemProperties(SystemProperties.newBuilder()
+                                .setMessageId(messageId)
+                                .build())
+                            .build();
+                        responseObserver.onNext(ReceiveMessageResponse.newBuilder()
+                            .setMessage(msg).build());
+                    }
+                    responseObserver.onNext(ReceiveMessageResponse.newBuilder()
+                        .setDeliveryTimestamp(Timestamps.fromMillis(System.currentTimeMillis()))
+                        .build());
+                    responseObserver.onCompleted();
+                }
+            } catch (InterruptedException e) {
+                responseObserver.onError(e);
+            }
+        }
+
+        @Override
+        public void ackMessage(AckMessageRequest request,
+            StreamObserver<AckMessageResponse> responseObserver) {
+            ackCount.incrementAndGet();
+            responseObserver.onNext(AckMessageResponse.newBuilder().setStatus(mockStatus).build());
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void changeInvisibleDuration(ChangeInvisibleDurationRequest request,
+            StreamObserver<ChangeInvisibleDurationResponse> responseObserver) {
+            nackCount.incrementAndGet();
+            responseObserver.onNext(ChangeInvisibleDurationResponse.newBuilder()
+                .setStatus(mockStatus).build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        serverImpl = new BatchMockServerImpl(topic, false, messageQueue);
+        setUpServer(serverImpl, port);
+        serverImpl.setPort(port);
+    }
+
+    private PushConsumerBuilder createBuilder(
+        org.apache.rocketmq.client.apis.consumer.BatchMessageListener listener,
+        BatchPolicy policy) throws Exception {
+        final ClientServiceProvider provider = ClientServiceProvider.loadService();
+        SessionCredentialsProvider creds = new StaticSessionCredentialsProvider("", "");
+        ClientConfiguration config = ClientConfiguration.newBuilder()
+            .setEndpoints(serverImpl.getLocalEndpoints())
+            .setCredentialProvider(creds)
+            .build();
+        return provider.newPushConsumerBuilder()
+            .setClientConfiguration(config)
+            .setConsumerGroup("group")
+            .setSubscriptionExpressions(Collections.singletonMap(topic, SUB_ALL))
+            .setBatchMessageListener(listener, policy);
+    }
+
+    @Test
+    public void testConcurrentBatchConsumeSuccess() throws Exception {
+        int batchSize = 4;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofSeconds(5));
+        CopyOnWriteArrayList<Integer> batchSizes = new CopyOnWriteArrayList<>();
+
+        try (PushConsumer ignore = createBuilder(messageViews -> {
+            batchSizes.add(messageViews.size());
+            return ConsumeResult.SUCCESS;
+        }, policy).build()) {
+            List<String> messages = new ArrayList<>();
+            for (int i = 0; i < batchSize; i++) {
+                messages.add("msg-" + i);
+            }
+            messageQueue.add(messages);
+
+            await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+                Assert.assertFalse("Should have received at least one batch", batchSizes.isEmpty());
+                Assert.assertEquals(batchSize, batchSizes.get(0).intValue());
+            });
+
+            await().atMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(batchSize, ((BatchMockServerImpl) serverImpl).ackCount.get()));
+        }
+    }
+
+    @Test
+    public void testConcurrentBatchConsumeFailure() throws Exception {
+        int batchSize = 3;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofSeconds(5));
+        AtomicInteger listenerCallCount = new AtomicInteger(0);
+
+        try (PushConsumer ignore = createBuilder(messageViews -> {
+            listenerCallCount.incrementAndGet();
+            return ConsumeResult.FAILURE;
+        }, policy).build()) {
+            List<String> messages = new ArrayList<>();
+            for (int i = 0; i < batchSize; i++) {
+                messages.add("fail-msg-" + i);
+            }
+            messageQueue.add(messages);
+
+            await().atMost(30, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertTrue("Listener should have been called", listenerCallCount.get() >= 1));
+
+            // Give some time for ack processing
+            Thread.sleep(2000);
+            Assert.assertEquals("No messages should be acked on FAILURE",
+                0, ((BatchMockServerImpl) serverImpl).ackCount.get());
+        }
+    }
+
+    @Test
+    public void testBatchSizeNotExceedMaxBatchCount() throws Exception {
+        int maxBatchCount = 3;
+        BatchPolicy policy = new BatchPolicy(maxBatchCount, Duration.ofMillis(500));
+        CopyOnWriteArrayList<Integer> batchSizes = new CopyOnWriteArrayList<>();
+
+        try (PushConsumer ignore = createBuilder(messageViews -> {
+            batchSizes.add(messageViews.size());
+            return ConsumeResult.SUCCESS;
+        }, policy).build()) {
+            // Send more messages than maxBatchCount
+            List<String> messages = new ArrayList<>();
+            for (int i = 0; i < 7; i++) {
+                messages.add("batch-msg-" + i);
+            }
+            messageQueue.add(messages);
+
+            await().atMost(30, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(7, ((BatchMockServerImpl) serverImpl).ackCount.get()));
+
+            for (int size : batchSizes) {
+                Assert.assertTrue("Batch size should not exceed maxBatchCount: " + size,
+                    size <= maxBatchCount);
+            }
+        }
+    }
+
+    @Test
+    public void testTimeoutFlush() throws Exception {
+        int maxBatchCount = 100;
+        BatchPolicy policy = new BatchPolicy(maxBatchCount, Duration.ofMillis(500));
+        CopyOnWriteArrayList<Integer> batchSizes = new CopyOnWriteArrayList<>();
+
+        try (PushConsumer ignore = createBuilder(messageViews -> {
+            batchSizes.add(messageViews.size());
+            return ConsumeResult.SUCCESS;
+        }, policy).build()) {
+            // Send fewer messages than maxBatchCount — should be flushed by timeout
+            List<String> messages = new ArrayList<>();
+            for (int i = 0; i < 3; i++) {
+                messages.add("timeout-msg-" + i);
+            }
+            messageQueue.add(messages);
+
+            await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+                Assert.assertFalse("Batch should have been flushed by timeout", batchSizes.isEmpty());
+                Assert.assertEquals(3, batchSizes.get(0).intValue());
+            });
+        }
+    }
+
+    @Test
+    public void testFifoBatchConsumeSuccess() throws Exception {
+        // Create a FIFO mock server
+        LinkedBlockingDeque<List<String>> fifoQueue = new LinkedBlockingDeque<>();
+        BatchMockServerImpl fifoServer = new BatchMockServerImpl(topic, true, fifoQueue);
+        setUpServer(fifoServer, 0);
+        fifoServer.setPort(port);
+
+        int batchSize = 4;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofSeconds(5));
+        CopyOnWriteArrayList<List<String>> receivedBatches = new CopyOnWriteArrayList<>();
+
+        final ClientServiceProvider provider = ClientServiceProvider.loadService();
+        SessionCredentialsProvider creds = new StaticSessionCredentialsProvider("", "");
+        ClientConfiguration config = ClientConfiguration.newBuilder()
+            .setEndpoints(fifoServer.getLocalEndpoints())
+            .setCredentialProvider(creds)
+            .build();
+
+        try (PushConsumer ignore = provider.newPushConsumerBuilder()
+            .setClientConfiguration(config)
+            .setConsumerGroup("group")
+            .setSubscriptionExpressions(Collections.singletonMap(topic, SUB_ALL))
+            .setBatchMessageListener(messageViews -> {
+                List<String> ids = new ArrayList<>();
+                messageViews.forEach(mv -> ids.add(mv.getMessageId().toString()));
+                receivedBatches.add(ids);
+                return ConsumeResult.SUCCESS;
+            }, policy)
+            .build()) {
+
+            List<String> messages = new ArrayList<>();
+            for (int i = 0; i < batchSize; i++) {
+                messages.add("fifo-msg-" + i);
+            }
+            fifoQueue.add(messages);
+
+            await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+                Assert.assertFalse("Should receive at least one batch", receivedBatches.isEmpty());
+                Assert.assertEquals(batchSize, receivedBatches.get(0).size());
+            });
+
+            await().atMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(batchSize, fifoServer.ackCount.get()));
+        }
+    }
+
+    @Test
+    public void testFifoBatchConsumeFailureThenSuccess() throws Exception {
+        LinkedBlockingDeque<List<String>> fifoQueue = new LinkedBlockingDeque<>();
+        BatchMockServerImpl fifoServer = new BatchMockServerImpl(topic, true, fifoQueue);
+        setUpServer(fifoServer, 0);
+        fifoServer.setPort(port);
+
+        int batchSize = 2;
+        BatchPolicy policy = new BatchPolicy(batchSize, Duration.ofSeconds(5));
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        final ClientServiceProvider provider = ClientServiceProvider.loadService();
+        SessionCredentialsProvider creds = new StaticSessionCredentialsProvider("", "");
+        ClientConfiguration config = ClientConfiguration.newBuilder()
+            .setEndpoints(fifoServer.getLocalEndpoints())
+            .setCredentialProvider(creds)
+            .build();
+
+        try (PushConsumer ignore = provider.newPushConsumerBuilder()
+            .setClientConfiguration(config)
+            .setConsumerGroup("group")
+            .setSubscriptionExpressions(Collections.singletonMap(topic, SUB_ALL))
+            .setBatchMessageListener(messageViews -> {
+                int count = callCount.incrementAndGet();
+                return count == 1 ? ConsumeResult.FAILURE : ConsumeResult.SUCCESS;
+            }, policy)
+            .build()) {
+
+            List<String> messages = new ArrayList<>();
+            for (int i = 0; i < batchSize; i++) {
+                messages.add("retry-msg-" + i);
+            }
+            fifoQueue.add(messages);
+
+            await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+                Assert.assertTrue("Should be called at least twice (1 fail + 1 success)",
+                    callCount.get() >= 2);
+                Assert.assertEquals(batchSize, fifoServer.ackCount.get());
+            });
+        }
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #1225

### Brief Description

This PR adds first-class batch consumption support for **PushConsumer** in the Java client, controlled by a `BatchPolicy`.

#### PushConsumer — Batch Consume Service

- `BatchConsumeService`: accumulates messages from all `ProcessQueue`s into a single `BatchBuffer`, flushing to `BatchMessageListener` when any threshold is met (count, bytes, or timeout).
- `BatchBuffer`: encapsulated accumulation buffer with lock-based concurrency, scheduled timeout flush, forward-progress guarantee (single oversized message is still flushed).
- `BatchConsumeTask`: `Callable` that invokes `BatchMessageListener` with interceptor hooks.
- New `BatchMessageListener` interface and `PushConsumerBuilder.setBatchMessageListener()`.
- FIFO mode support: in FIFO mode, only one batch is in-flight at a time, preserving strict ordering.
- Graceful shutdown: `close()` flushes all remaining buffered messages before the consumer shuts down.

#### BatchPolicy

Policy with `maxBatchCount`, `maxBatchBytes`, `maxWaitTime`. Builder pattern with sensible defaults.

A batch is flushed when any condition is met:
1. Message count reaches `maxBatchCount`.
2. Total body bytes reach `maxBatchBytes`.
3. Time since first buffered message reaches `maxWaitTime`.

### How Did You Test This Change?

- **BatchConsumeServiceTest**: 14 unit tests covering count/bytes/timeout triggers, corrupted message discard, multiple batches from single consume, single oversized message flush, batch failure, close flush, multiple ProcessQueues, FIFO ordering, FIFO close, FIFO timeout-respects-inflight.
- **BatchConsumeTaskTest**: 5 unit tests covering success/failure/exception/null-return scenarios with interceptor hooks, and batch size passthrough.
- **BatchPolicyTest**: 11 unit tests covering constructors, builder, validation, toString.
- **PushConsumerBuilderImplTest**: added 4 tests for batch builder validation (no listener, both listeners, null listener, null policy).
- All tests pass: `mvn clean test -pl client-apis,client` — 307 tests, 0 failures, 0 checkstyle violations.