### PR TITLE
[Golang] fix(client.go): nil pointer exception during close

### DIFF
--- a/golang/client.go
+++ b/golang/client.go
@@ -647,7 +647,9 @@ func (cli *defaultClient) GracefulStop() error {
 		return fmt.Errorf("client has been closed")
 	}
 	cli.notifyClientTermination()
-	cli.clientManager.UnRegisterClient(cli)
+	if cli.clientManager != nil {
+		cli.clientManager.UnRegisterClient(cli)
+	}
 	cli.done <- struct{}{}
 	close(cli.done)
 	cli.clientMeterProvider.Reset(&v2.Metric{

--- a/golang/push_consumer.go
+++ b/golang/push_consumer.go
@@ -517,7 +517,9 @@ func (pc *defaultPushConsumer) GracefulStop() error {
 	pc.cli.log.Infof("Begin to Shutdown consumption executor, clientId=%s", pc.cli.clientID)
 
 	// step 4
-	pc.consumerService.Shutdown()
+	if pc.consumerService != nil {
+		pc.consumerService.Shutdown()
+	}
 
 	// step 5
 	time.Sleep(time.Second)


### PR DESCRIPTION
Add nil checks for `consumerService` and `clientManager` in the close flow to prevent nil pointer panics caused by uninitialized objects.