### PR TITLE
[Java] feat(ClientImpl.java): broadcast SyncLiteSubscriptionRequest to all route endpoints

### DIFF
--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/ClientImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/ClientImpl.java
@@ -669,7 +669,7 @@ public abstract class ClientImpl extends AbstractIdleService implements Client, 
         }, MoreExecutors.directExecutor());
     }
 
-    protected Set<Endpoints> getTotalRouteEndpoints() {
+    public Set<Endpoints> getTotalRouteEndpoints() {
         Set<Endpoints> totalRouteEndpoints = new HashSet<>();
         for (TopicRouteData topicRouteData : topicRouteCache.values()) {
             totalRouteEndpoints.addAll(topicRouteData.getTotalEndpoints());

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LiteSubscriptionManager.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LiteSubscriptionManager.java
@@ -20,7 +20,6 @@ package org.apache.rocketmq.client.java.impl.consumer;
 import apache.rocketmq.v2.Code;
 import apache.rocketmq.v2.LiteSubscriptionAction;
 import apache.rocketmq.v2.NotifyUnsubscribeLiteCommand;
-import apache.rocketmq.v2.Status;
 import apache.rocketmq.v2.Subscription;
 import apache.rocketmq.v2.SyncLiteSubscriptionRequest;
 import apache.rocketmq.v2.SyncLiteSubscriptionResponse;
@@ -30,8 +29,10 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -42,6 +43,7 @@ import org.apache.rocketmq.client.java.exception.LiteSubscriptionQuotaExceededEx
 import org.apache.rocketmq.client.java.exception.StatusChecker;
 import org.apache.rocketmq.client.java.message.protocol.Resource;
 import org.apache.rocketmq.client.java.misc.ProtobufUtils;
+import org.apache.rocketmq.client.java.route.Endpoints;
 import org.apache.rocketmq.client.java.rpc.RpcFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -159,14 +161,19 @@ public class LiteSubscriptionManager {
             builder.setOffsetOption(ProtobufUtils.toProtobufOffsetOption(offsetOption));
         }
 
+        final SyncLiteSubscriptionRequest request = builder.build();
         final Duration requestTimeout = consumerImpl.getClientConfiguration().getRequestTimeout();
-        RpcFuture<SyncLiteSubscriptionRequest, SyncLiteSubscriptionResponse> future = consumerImpl.getClientManager()
-            .syncLiteSubscription(consumerImpl.getEndpoints(), builder.build(), requestTimeout);
-        return Futures.transformAsync(future, response -> {
-            final Status status = response.getStatus();
-            StatusChecker.check(status, future);
-            return Futures.immediateVoidFuture();
-        }, MoreExecutors.directExecutor());
+        final Set<Endpoints> totalRouteEndpoints = consumerImpl.getTotalRouteEndpoints();
+        List<ListenableFuture<Void>> futures = new ArrayList<>();
+        for (Endpoints endpoints : totalRouteEndpoints) {
+            final RpcFuture<SyncLiteSubscriptionRequest, SyncLiteSubscriptionResponse> rpcFuture =
+                consumerImpl.getClientManager().syncLiteSubscription(endpoints, request, requestTimeout);
+            futures.add(Futures.transformAsync(rpcFuture, response -> {
+                StatusChecker.check(response.getStatus(), rpcFuture);
+                return Futures.immediateVoidFuture();
+            }, MoreExecutors.directExecutor()));
+        }
+        return Futures.transform(Futures.allAsList(futures), input -> null, MoreExecutors.directExecutor());
     }
 
     void onNotifyUnsubscribeLiteCommand(NotifyUnsubscribeLiteCommand command) {

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/LiteSubscriptionManagerTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/LiteSubscriptionManagerTest.java
@@ -37,6 +37,7 @@ import apache.rocketmq.v2.SyncLiteSubscriptionRequest;
 import apache.rocketmq.v2.SyncLiteSubscriptionResponse;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
@@ -84,7 +85,8 @@ public class LiteSubscriptionManagerTest {
         when(consumerImpl.getClientConfiguration()).thenReturn(clientConfiguration);
         when(clientConfiguration.getRequestTimeout()).thenReturn(Duration.ofSeconds(30));
         when(consumerImpl.getClientManager()).thenReturn(clientManager);
-        when(consumerImpl.getEndpoints()).thenReturn(endpoints);
+        lenient().when(consumerImpl.getEndpoints()).thenReturn(endpoints);
+        when(consumerImpl.getTotalRouteEndpoints()).thenReturn(Collections.singleton(endpoints));
 
         // Mock successful response
         SyncLiteSubscriptionResponse successResponse = SyncLiteSubscriptionResponse.newBuilder()


### PR DESCRIPTION
LiteSubscriptionManager#syncLiteSubscription previously only sent the request to the client's initial endpoint, causing lite subscription state to be inconsistent across brokers in a multi-broker cluster. 
Broadcast the request to all route endpoints and aggregate the results. 
Widen ClientImpl#getTotalRouteEndpoints() visibility to public accordingly.