### PR TITLE
fix(ci): join git diff output to single line for GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
               "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUMBER/files" | \
               jq -r '.[].filename' | tr '\n' ' ')
           else
-            CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
+            CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD | tr '\n' ' ')
           fi
           echo "files=$CHANGED_FILES" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- Join `git diff --name-only` output with `tr '\n' ' '` to produce a single-line value for `$GITHUB_OUTPUT`
- Fixes `Invalid format` error in `paths-filter` job on push events, where multi-line output broke the `key=value` format

## Test plan
- [x] Verify `paths-filter` job passes on push to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)