### PR TITLE
fix(golang): add missing return in SendAsync when producer is off

### DIFF
--- a/golang/producer.go
+++ b/golang/producer.go
@@ -345,6 +345,7 @@ func (p *defaultProducer) Send(ctx context.Context, msg *Message) ([]*SendReceip
 func (p *defaultProducer) SendAsync(ctx context.Context, msg *Message, f func(context.Context, []*SendReceipt, error)) {
 	if !p.isOn() {
 		f(ctx, nil, fmt.Errorf("producer is not running"))
+		return
 	}
 	go func() {
 		msgs := []*UnifiedMessage{{


### PR DESCRIPTION
 When the producer is not running, SendAsync invoked the callback with an error but did not return, causing the subsequent goroutine to also execute. This resulted in the callback being called twice and a goroutine leak.