### PR TITLE
[Go] Fix inverted hook status in Ack/DLQ methods

### DIFF
--- a/golang/push_consumer.go
+++ b/golang/push_consumer.go
@@ -581,13 +581,14 @@ func (pc *defaultPushConsumer) Ack(ctx context.Context, messageView *MessageView
 	resp, err := pc.ack0(ctx, messageView)
 	duration := time.Since(watchTime)
 
-	messageHookPointsStatus := MessageHookPointsStatus_ERROR
+	messageHookPointsStatus := MessageHookPointsStatus_OK
 	if err != nil {
+		messageHookPointsStatus = MessageHookPointsStatus_ERROR
 		pc.cli.doAfter(MessageHookPoints_ACK, messageCommons, duration, messageHookPointsStatus)
 		return err
 	}
 	if resp.GetStatus().GetCode() != v2.Code_OK {
-		messageHookPointsStatus = MessageHookPointsStatus_OK
+		messageHookPointsStatus = MessageHookPointsStatus_ERROR
 	}
 	pc.cli.doAfter(MessageHookPoints_ACK, messageCommons, duration, messageHookPointsStatus)
 	return nil
@@ -632,13 +633,14 @@ func (pc *defaultPushConsumer) ForwardMessageToDeadLetterQueue(ctx context.Conte
 	resp, err := pc.forwardMessageToDeadLetterQueue0(ctx, messageView)
 	duration := time.Since(watchTime)
 
-	messageHookPointsStatus := MessageHookPointsStatus_ERROR
+	messageHookPointsStatus := MessageHookPointsStatus_OK
 	if err != nil {
+		messageHookPointsStatus = MessageHookPointsStatus_ERROR
 		pc.cli.doAfter(MessageHookPoints_FORWARD_TO_DLQ, messageCommons, duration, messageHookPointsStatus)
 		return err
 	}
 	if resp.GetStatus().GetCode() != v2.Code_OK {
-		messageHookPointsStatus = MessageHookPointsStatus_OK
+		messageHookPointsStatus = MessageHookPointsStatus_ERROR
 	}
 	pc.cli.doAfter(MessageHookPoints_FORWARD_TO_DLQ, messageCommons, duration, messageHookPointsStatus)
 	return nil

--- a/golang/simple_consumer.go
+++ b/golang/simple_consumer.go
@@ -449,14 +449,15 @@ func (sc *defaultSimpleConsumer) Ack(ctx context.Context, messageView *MessageVi
 	request := sc.wrapAckMessageRequest(messageView)
 	ctx = sc.cli.Sign(ctx)
 	resp, err := sc.cli.clientManager.AckMessage(ctx, endpoints, request, sc.cli.opts.timeout)
-	messageHookPointsStatus := MessageHookPointsStatus_ERROR
+	messageHookPointsStatus := MessageHookPointsStatus_OK
 	duration := time.Since(watchTime)
 	if err != nil {
+		messageHookPointsStatus = MessageHookPointsStatus_ERROR
 		sc.cli.doAfter(MessageHookPoints_ACK, messageCommons, duration, messageHookPointsStatus)
 		return err
 	}
 	if resp.GetStatus().GetCode() != v2.Code_OK {
-		messageHookPointsStatus = MessageHookPointsStatus_OK
+		messageHookPointsStatus = MessageHookPointsStatus_ERROR
 	}
 	sc.cli.doAfter(MessageHookPoints_ACK, messageCommons, duration, messageHookPointsStatus)
 	return nil


### PR DESCRIPTION
## Summary
- The `messageHookPointsStatus` in three Ack/DLQ hook locations was incorrectly initialized to `ERROR` and set to `OK` when the response code was not `Code_OK` — the exact opposite of the intended behavior.
- Fixed by initializing to `OK` and switching to `ERROR` on failure, consistent with the pattern used in `changeInvisibleDuration0`.
- Affected locations:
  - `push_consumer.go`: `Ack()` and `ForwardMessageToDeadLetterQueue()`
  - `simple_consumer.go`: `Ack()`