### PR TITLE
[Go] Fix double execution of telemetry command during recovery

### DIFF
--- a/golang/client.go
+++ b/golang/client.go
@@ -144,8 +144,7 @@ func (cs *defaultClientSession) startUp() {
 				// we assume that the list of the servers hasn't changed, so the server that sent the message is still present.
 				hearbeat_response, err := cs.cli.clientManager.HeartBeat(context.TODO(), cs.endpoints, &v2.HeartbeatRequest{}, 10*time.Second)
 				if err == nil && hearbeat_response.Status.Code == v2.Code_OK {
-					cs.cli.log.Info("Managed to recover, executing message")
-					cs._execute_server_telemetry_command(response)
+					cs.cli.log.Info("Managed to recover")
 				} else {
 					cs.cli.log.Errorf("Failed to recover, Some of the servers are unhealthy, Heartbeat err=%w", err)
 					cs.release()

--- a/golang/client_test.go
+++ b/golang/client_test.go
@@ -268,7 +268,7 @@ func TestRestoreDefaultClientSessionOneError(t *testing.T) {
 	sugarBaseLogger.Info(observedLogs.All())
 	commandExecutionLog := observedLogs.All()[:3]
 	assert.Equal(t, "Encountered error while receiving TelemetryCommand, trying to recover, err=EOF", commandExecutionLog[0].Message)
-	assert.Equal(t, "Managed to recover, executing message", commandExecutionLog[1].Message)
+	assert.Equal(t, "Managed to recover", commandExecutionLog[1].Message)
 	assert.Equal(t, "Executed command successfully", commandExecutionLog[2].Message)
 }
 


### PR DESCRIPTION
## Summary
- `_execute_server_telemetry_command` was executed twice during telemetry recovery: once inside the `if cs.recovering` block on successful heartbeat, and again unconditionally after the block
- Fix: remove the call inside the recovering block, since a successfully received response should be executed once regardless of recovery state
- Affected: `client.go` `startUp()`