### PR TITLE
[Go] Prepare SDK 5.1.4 release

### DIFF
--- a/golang/example/producer/delay_recall/main.go
+++ b/golang/example/producer/delay_recall/main.go
@@ -67,7 +67,8 @@ func main() {
 
 	// Send delay messages with recall capability
 	fmt.Println("Sending delay messages that can be recalled...")
-	fmt.Println("Messages will be delivered after 10 minutes if not recalled\n")
+	fmt.Println("Messages will be delivered after 10 minutes if not recalled")
+	fmt.Println()
 
 	var recallHandles []string
 

--- a/golang/example/producer/priority/main.go
+++ b/golang/example/producer/priority/main.go
@@ -67,7 +67,8 @@ func main() {
 
 	// Send priority messages with different levels
 	fmt.Println("Sending priority messages...")
-	fmt.Println("Note: Higher priority value = higher priority\n")
+	fmt.Println("Note: Higher priority value = higher priority")
+	fmt.Println()
 
 	// Low priority message (priority = 1)
 	lowPriorityMsg := &rmq_client.Message{

--- a/golang/metadata/metadata.go
+++ b/golang/metadata/metadata.go
@@ -31,7 +31,7 @@ const (
 const (
 	LanguageValue = "GO"
 	ProtocolValue = "v2"
-	VersionValue  = "5.0.1-rc1"
+	VersionValue  = "5.1.4"
 )
 
 const (

--- a/golang/user_agent.go
+++ b/golang/user_agent.go
@@ -29,7 +29,7 @@ type userAgent struct {
 }
 
 var globalUserAgent = &userAgent{
-	version:  "5.0.1-rc1",
+	version:  "5.1.4",
 	platform: utils.GetOsDescription(),
 	hostName: utils.HostName(),
 }


### PR DESCRIPTION
## Summary

Prepare the RocketMQ Go SDK 5.1.4 release.

Changes:
- bump Go client metadata version to `5.1.4`
- bump Go user-agent version to `5.1.4`
- adjust two Go producer examples so `go test ./...` passes vet without redundant newline warnings

## Validation

- `go test ./...` from `golang/`
