### PR TITLE
[C#] Prepare SDK 5.2.1 release

### DIFF
--- a/csharp/rocketmq-client-csharp/rocketmq-client-csharp.csproj
+++ b/csharp/rocketmq-client-csharp/rocketmq-client-csharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <PackageId>RocketMQ.Client</PackageId>
-        <PackageVersion>5.2.0-rc1</PackageVersion>
+        <PackageVersion>5.2.1</PackageVersion>
         <Version>$(PackageVersion)</Version>
 
         <Authors>RocketMQ Authors</Authors>


### PR DESCRIPTION
## Summary

Prepare the RocketMQ C# SDK 5.2.1 release.

Changes:
- bump `RocketMQ.Client` package version to `5.2.1`

## Validation

- Not run locally: `dotnet` is not available in the current environment.
