### PR TITLE
[Java] Build rocketmq-proto from submodule instead of depending on Maven Central

### DIFF
--- a/.github/workflows/java_build.yml
+++ b/.github/workflows/java_build.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Set up JDK ${{ matrix.jdk }}
         uses: actions/setup-java@v3
         with:
@@ -28,6 +30,8 @@ jobs:
     steps:
       - name: Checkout Current Repository
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
       # Use JDK 21.
       - name: Use JDK 21
         uses: actions/setup-java@v3

--- a/.github/workflows/java_coverage.yml
+++ b/.github/workflows/java_coverage.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          submodules: recursive
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/java/README-CN.md
+++ b/java/README-CN.md
@@ -13,6 +13,25 @@
 1. 准备 Java 环境。Java 8 是确保客户端运行的最小版本，Java 11 是确保客户端编译的最小版本；
 2. 部署 namesrv，broker 以及 [proxy](https://github.com/apache/rocketmq/tree/develop/proxy) 组件。
 
+## 从源码构建
+
+`rocketmq-proto` 模块从 `protos/` 子模块（[rocketmq-apis](https://github.com/apache/rocketmq-apis)）编译，而非从 Maven Central 下载。构建前需要先初始化子模块：
+
+```bash
+git submodule update --init protos
+```
+
+然后使用 Maven 构建：
+
+```bash
+cd java
+mvn -B package -DskipTests
+```
+
+构建顺序为：`proto`（从子模块编译）→ `client-apis` → `client` → `client-shade` → `test`。
+
+Proto 的版本号定义在 `protos/java/VERSION` 中，需要与 `java/proto/pom.xml` 的 `<version>` 保持一致。更新 proto 时，推进子模块并同步更新这两个文件。
+
 ## 快速开始
 
 根据构建系统增加对应的客户端依赖，并将 `${rocketmq.version}` 替换成中央仓库中[最新的版本](https://search.maven.org/search?q=g:org.apache.rocketmq%20AND%20a:rocketmq-client-java)。

--- a/java/README.md
+++ b/java/README.md
@@ -14,6 +14,25 @@ to [quick start](https://rocketmq.apache.org/docs/quickStart/02quickstart/)).
 1. Java 8+ for runtime, Java 11+ for the build;
 2. Setup namesrv, broker, and [proxy](https://github.com/apache/rocketmq/tree/develop/proxy).
 
+## Build from Source
+
+The `rocketmq-proto` module is compiled from the `protos/` submodule ([rocketmq-apis](https://github.com/apache/rocketmq-apis)) rather than downloaded from Maven Central. Before building, initialize the submodule:
+
+```bash
+git submodule update --init protos
+```
+
+Then build with Maven:
+
+```bash
+cd java
+mvn -B package -DskipTests
+```
+
+The build order is: `proto` (from submodule) → `client-apis` → `client` → `client-shade` → `test`.
+
+The proto version is defined in `protos/java/VERSION` and must match the `<version>` in `java/proto/pom.xml`. When updating proto, advance the submodule and update both files accordingly.
+
 ## Getting Started
 
 Dependencies must be included in accordance with your build automation tools, and replace the `${rocketmq.version}` with the [latest version](https://search.maven.org/search?q=g:org.apache.rocketmq%20AND%20a:rocketmq-client-java).

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -28,6 +28,7 @@
     <packaging>pom</packaging>
     <version>5.2.1</version>
     <modules>
+        <module>proto</module>
         <module>client-apis</module>
         <module>client</module>
         <module>client-shade</module>
@@ -48,7 +49,6 @@
            ~  1. Whether it is essential, because the current shaded jar is fat enough.
            ~  2. Make sure that it is compatible with Java 8.
          -->
-        <rocketmq-proto.version>2.1.2</rocketmq-proto.version>
         <annotations-api.version>1.3.5</annotations-api.version>
         <protobuf.version>3.24.4</protobuf.version>
         <grpc.version>1.50.0</grpc.version>
@@ -110,7 +110,7 @@
             <dependency>
                 <groupId>org.apache.rocketmq</groupId>
                 <artifactId>rocketmq-proto</artifactId>
-                <version>${rocketmq-proto.version}</version>
+                <version>2.2.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/java/proto/pom.xml
+++ b/java/proto/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.rocketmq</groupId>
+        <artifactId>rocketmq-client-java-parent</artifactId>
+        <version>5.2.1</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>rocketmq-proto</artifactId>
+    <!--
+      ~ This version is independent of the client version (${project.version}).
+      ~ It MUST match protos/java/VERSION in the rocketmq-apis submodule, which is the
+      ~ authoritative source used by the Bazel-based release process (assemble_maven).
+      ~
+      ~ When updating:
+      ~   1. Advance the protos/ submodule to the target commit.
+      ~   2. Set this version to match protos/java/VERSION.
+      ~   3. Update the corresponding version in the parent POM's dependencyManagement.
+      -->
+    <version>2.2.0</version>
+    <packaging>jar</packaging>
+    <name>Apache RocketMQ Proto (compiled from submodule)</name>
+    <description>
+        Compiles rocketmq-apis proto definitions from the protos/ submodule
+        into a Java JAR, removing the dependency on a pre-published Maven artifact.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                    <protoSourceRoot>${project.basedir}/../../protos</protoSourceRoot>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Skip checkstyle for generated proto code -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <!-- Skip spotbugs for generated proto code -->
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <!-- Skip jacoco for proto module -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
## Summary

Add a `proto` module to the Java Maven reactor that compiles `.proto` files from the `protos/` submodule (rocketmq-apis) into a `rocketmq-proto` JAR, replacing the dependency on a pre-published Maven Central artifact.

Closes #1286

## Changes

1. **Update `protos/` submodule** to latest `main` (`bc8e184`), which includes the `client_properties` field from [rocketmq-apis#108](https://github.com/apache/rocketmq-apis/issues/108).
2. **Add `java/proto/pom.xml`** using `protobuf-maven-plugin` to compile the 3 `.proto` files (`definition.proto`, `service.proto`, `admin.proto`) and generate gRPC stubs.
3. **Add `proto` as the first module** in the parent POM reactor build order, so downstream modules (`client-apis`, `client`, `client-shade`) resolve `rocketmq-proto` from the reactor instead of Maven Central.
4. **Update CI workflows** (`java_build.yml`, `java_coverage.yml`) to checkout submodules with `submodules: recursive`.

## Why

- PR #1237 bumped `rocketmq-proto` to `2.2.0`, but that version is not yet published to Maven Central, causing all Java CI jobs to fail.
- Other language clients (C++, Rust, C#, Node.js) already compile proto from the submodule. Java should follow the same pattern.
- This decouples Java client development from proto release cycles.

## Build Order

```
proto (compile .proto from protos/ submodule)
  → client-apis
    → client (noshade)
      → client-shade
        → test
```