### PR TITLE
[Java] Record consumegroup when consumeMessage

### DIFF
--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeService.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeService.java
@@ -41,14 +41,17 @@ public abstract class ConsumeService {
     private static final Logger log = LoggerFactory.getLogger(ConsumeService.class);
 
     protected final ClientId clientId;
+    protected final String consumerGroup;
     private final MessageListener messageListener;
     private final ThreadPoolExecutor consumptionExecutor;
     private final MessageInterceptor messageInterceptor;
     private final ScheduledExecutorService scheduler;
 
-    public ConsumeService(ClientId clientId, MessageListener messageListener, ThreadPoolExecutor consumptionExecutor,
+    public ConsumeService(ClientId clientId, String consumerGroup,
+                          MessageListener messageListener, ThreadPoolExecutor consumptionExecutor,
         MessageInterceptor messageInterceptor, ScheduledExecutorService scheduler) {
         this.clientId = clientId;
+        this.consumerGroup = consumerGroup;
         this.messageListener = messageListener;
         this.consumptionExecutor = consumptionExecutor;
         this.messageInterceptor = messageInterceptor;
@@ -63,7 +66,7 @@ public abstract class ConsumeService {
 
     public ListenableFuture<ConsumeResult> consume(MessageViewImpl messageView, Duration delay) {
         final ListeningExecutorService executorService = MoreExecutors.listeningDecorator(consumptionExecutor);
-        final ConsumeTask task = new ConsumeTask(clientId, messageListener, messageView, messageInterceptor);
+        final ConsumeTask task = new ConsumeTask(clientId, consumerGroup, messageListener, messageView, messageInterceptor);
         // Consume message with no delay.
         if (Duration.ZERO.compareTo(delay) >= 0) {
             return executorService.submit(task);

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeService.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeService.java
@@ -66,7 +66,8 @@ public abstract class ConsumeService {
 
     public ListenableFuture<ConsumeResult> consume(MessageViewImpl messageView, Duration delay) {
         final ListeningExecutorService executorService = MoreExecutors.listeningDecorator(consumptionExecutor);
-        final ConsumeTask task = new ConsumeTask(clientId, consumerGroup, messageListener, messageView, messageInterceptor);
+        final ConsumeTask task = new ConsumeTask(clientId, consumerGroup,
+                messageListener, messageView, messageInterceptor);
         // Consume message with no delay.
         if (Duration.ZERO.compareTo(delay) >= 0) {
             return executorService.submit(task);

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeTask.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeTask.java
@@ -40,17 +40,20 @@ public class ConsumeTask implements Callable<ConsumeResult> {
     static final AttributeKey<MessageViewImpl> MESSAGE_VIEW_CONTEXT_KEY = AttributeKey.create("messageView");
     static final AttributeKey<String> REMOTE_ADDR_CONTEXT_KEY = AttributeKey.create("remoteAddr");
     static final AttributeKey<Throwable> CONSUME_ERROR_CONTEXT_KEY = AttributeKey.create("consumeError");
+    static final AttributeKey<String> CONSUMER_GROUP_CONTEXT_KEY = AttributeKey.create("consumerGroup");
 
     private static final Logger log = LoggerFactory.getLogger(ConsumeTask.class);
 
     private final ClientId clientId;
+    private final String consumerGroup;
     private final MessageListener messageListener;
     private final MessageViewImpl messageView;
     private final MessageInterceptor messageInterceptor;
 
-    public ConsumeTask(ClientId clientId, MessageListener messageListener, MessageViewImpl messageView,
-        MessageInterceptor messageInterceptor) {
+    public ConsumeTask(ClientId clientId,  String consumerGroup, MessageListener messageListener,
+                       MessageViewImpl messageView, MessageInterceptor messageInterceptor) {
         this.clientId = clientId;
+        this.consumerGroup = consumerGroup;
         this.messageListener = messageListener;
         this.messageView = messageView;
         this.messageInterceptor = messageInterceptor;
@@ -72,6 +75,8 @@ public class ConsumeTask implements Callable<ConsumeResult> {
         context.putAttribute(REMOTE_ADDR_CONTEXT_KEY, Attribute.create(remoteAddr));
         // Add message view to context.
         context.putAttribute(MESSAGE_VIEW_CONTEXT_KEY, Attribute.create(messageView));
+        // Add consumer group to context.
+        context.putAttribute(CONSUMER_GROUP_CONTEXT_KEY, Attribute.create(consumerGroup));
 
         messageInterceptor.doBefore(context, generalMessages);
         Throwable throwable = null;

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/FifoConsumeService.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/FifoConsumeService.java
@@ -39,10 +39,10 @@ class FifoConsumeService extends ConsumeService {
     private static final Logger log = LoggerFactory.getLogger(FifoConsumeService.class);
     private final boolean enableFifoConsumeAccelerator;
 
-    public FifoConsumeService(ClientId clientId, MessageListener messageListener,
+    public FifoConsumeService(ClientId clientId, String consumerGroup, MessageListener messageListener,
         ThreadPoolExecutor consumptionExecutor, MessageInterceptor messageInterceptor,
         ScheduledExecutorService scheduler, boolean enableFifoConsumeAccelerator) {
-        super(clientId, messageListener, consumptionExecutor, messageInterceptor, scheduler);
+        super(clientId, consumerGroup, messageListener, consumptionExecutor, messageInterceptor, scheduler);
         this.enableFifoConsumeAccelerator = enableFifoConsumeAccelerator;
     }
 

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LiteFifoConsumeService.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LiteFifoConsumeService.java
@@ -35,10 +35,10 @@ import org.apache.rocketmq.client.java.misc.ClientId;
 
 public class LiteFifoConsumeService extends FifoConsumeService {
 
-    public LiteFifoConsumeService(ClientId clientId, MessageListener messageListener,
+    public LiteFifoConsumeService(ClientId clientId, String consumerGroup, MessageListener messageListener,
         ThreadPoolExecutor consumptionExecutor, MessageInterceptor messageInterceptor,
         ScheduledExecutorService scheduler, boolean enableFifoConsumeAccelerator) {
-        super(clientId, messageListener, consumptionExecutor,
+        super(clientId, consumerGroup, messageListener, consumptionExecutor,
             messageInterceptor, scheduler, enableFifoConsumeAccelerator);
     }
 

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LitePushConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LitePushConsumerImpl.java
@@ -97,7 +97,8 @@ public class LitePushConsumerImpl extends PushConsumerImpl implements LitePushCo
                 scheduler, enableFifoConsumeAccelerator);
         }
         log.info("Create Lite standard consume service, consumerGroup={}, clientId={}", getConsumerGroup(), clientId);
-        return new LiteStandardConsumeService(clientId, messageListener, consumptionExecutor, this, scheduler);
+        return new LiteStandardConsumeService(clientId, getConsumerGroup(),
+                messageListener, consumptionExecutor, this, scheduler);
     }
 
 }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LitePushConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LitePushConsumerImpl.java
@@ -93,8 +93,8 @@ public class LitePushConsumerImpl extends PushConsumerImpl implements LitePushCo
         if (getSettings().isFifo()) {
             log.info("Create Lite FIFO consume service, consumerGroup={}, clientId={}, enableFifoConsumeAccelerator={}",
                 getConsumerGroup(), clientId, enableFifoConsumeAccelerator);
-            return new LiteFifoConsumeService(clientId, messageListener, consumptionExecutor, this,
-                scheduler, enableFifoConsumeAccelerator);
+            return new LiteFifoConsumeService(clientId, getConsumerGroup(), messageListener,
+                    consumptionExecutor, this, scheduler, enableFifoConsumeAccelerator);
         }
         log.info("Create Lite standard consume service, consumerGroup={}, clientId={}", getConsumerGroup(), clientId);
         return new LiteStandardConsumeService(clientId, getConsumerGroup(),

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LiteStandardConsumeService.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/LiteStandardConsumeService.java
@@ -35,10 +35,10 @@ import org.slf4j.LoggerFactory;
 public class LiteStandardConsumeService extends ConsumeService {
     private static final Logger log = LoggerFactory.getLogger(LiteStandardConsumeService.class);
 
-    public LiteStandardConsumeService(ClientId clientId, MessageListener messageListener,
+    public LiteStandardConsumeService(ClientId clientId, String consumerGroup, MessageListener messageListener,
         ThreadPoolExecutor consumptionExecutor, MessageInterceptor messageInterceptor,
         ScheduledExecutorService scheduler) {
-        super(clientId, messageListener, consumptionExecutor, messageInterceptor, scheduler);
+        super(clientId, consumerGroup, messageListener, consumptionExecutor, messageInterceptor, scheduler);
     }
 
     @Override

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
@@ -250,11 +250,12 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
         if (getSettings().isFifo()) {
             log.info("Create FIFO consume service, consumerGroup={}, clientId={}, enableFifoConsumeAccelerator={}",
                 getConsumerGroup(), clientId, enableFifoConsumeAccelerator);
-            return new FifoConsumeService(clientId, messageListener, consumptionExecutor, this,
-                scheduler, enableFifoConsumeAccelerator);
+            return new FifoConsumeService(clientId, getConsumerGroup(), messageListener,
+                    consumptionExecutor, this, scheduler, enableFifoConsumeAccelerator);
         }
         log.info("Create standard consume service, consumerGroup={}, clientId={}", getConsumerGroup(), clientId);
-        return new StandardConsumeService(clientId, messageListener, consumptionExecutor, this, scheduler);
+        return new StandardConsumeService(clientId, getConsumerGroup(),
+                messageListener, consumptionExecutor, this, scheduler);
     }
 
     /**

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/StandardConsumeService.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/StandardConsumeService.java
@@ -36,10 +36,10 @@ import org.slf4j.LoggerFactory;
 public class StandardConsumeService extends ConsumeService {
     private static final Logger log = LoggerFactory.getLogger(StandardConsumeService.class);
 
-    public StandardConsumeService(ClientId clientId, MessageListener messageListener,
+    public StandardConsumeService(ClientId clientId, String consumerGroup, MessageListener messageListener,
         ThreadPoolExecutor consumptionExecutor, MessageInterceptor messageInterceptor,
         ScheduledExecutorService scheduler) {
-        super(clientId, messageListener, consumptionExecutor, messageInterceptor, scheduler);
+        super(clientId, consumerGroup, messageListener, consumptionExecutor, messageInterceptor, scheduler);
     }
 
     @Override

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeServiceTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeServiceTest.java
@@ -51,8 +51,8 @@ public class ConsumeServiceTest extends TestBase {
     @Test
     public void testConsumeSuccess() throws ExecutionException, InterruptedException, TimeoutException {
         final MessageListener messageListener = messageView -> ConsumeResult.SUCCESS;
-        final ConsumeService consumeService = new ConsumeService(clientId, messageListener,
-            consumptionExecutor, interceptor, scheduler) {
+        final ConsumeService consumeService = new ConsumeService(clientId, "testConsumerGroup",
+                messageListener, consumptionExecutor, interceptor, scheduler) {
             @Override
             public void consume(ProcessQueue pq, List<MessageViewImpl> messageViews) {
             }
@@ -66,8 +66,8 @@ public class ConsumeServiceTest extends TestBase {
     @Test
     public void testConsumeFailure() throws ExecutionException, InterruptedException, TimeoutException {
         final MessageListener messageListener = messageView -> ConsumeResult.FAILURE;
-        final ConsumeService consumeService = new ConsumeService(clientId, messageListener,
-            consumptionExecutor, interceptor, scheduler) {
+        final ConsumeService consumeService = new ConsumeService(clientId, "testConsumerGroup",
+                messageListener, consumptionExecutor, interceptor, scheduler) {
             @Override
             public void consume(ProcessQueue pq, List<MessageViewImpl> messageViews) {
             }
@@ -83,8 +83,8 @@ public class ConsumeServiceTest extends TestBase {
         final MessageListener messageListener = messageView -> {
             throw new RuntimeException();
         };
-        final ConsumeService consumeService = new ConsumeService(clientId, messageListener,
-            consumptionExecutor, interceptor, scheduler) {
+        final ConsumeService consumeService = new ConsumeService(clientId, "testConsumerGroup",
+                messageListener, consumptionExecutor, interceptor, scheduler) {
             @Override
             public void consume(ProcessQueue pq, List<MessageViewImpl> messageViews) {
 
@@ -99,8 +99,8 @@ public class ConsumeServiceTest extends TestBase {
     @Test
     public void testConsumeWithDelay() throws ExecutionException, InterruptedException {
         final MessageListener messageListener = messageView -> ConsumeResult.SUCCESS;
-        final ConsumeService consumeService = new ConsumeService(clientId, messageListener,
-            consumptionExecutor, interceptor, scheduler) {
+        final ConsumeService consumeService = new ConsumeService(clientId, "testConsumerGroup",
+                messageListener, consumptionExecutor, interceptor, scheduler) {
 
             @Override
             public void consume(ProcessQueue pq, List<MessageViewImpl> messageViews) {

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeTaskTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeTaskTest.java
@@ -21,12 +21,18 @@ import static org.junit.Assert.assertEquals;
 
 import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
 import org.apache.rocketmq.client.apis.consumer.MessageListener;
+import org.apache.rocketmq.client.java.hook.Attribute;
 import org.apache.rocketmq.client.java.hook.MessageInterceptor;
+import org.apache.rocketmq.client.java.hook.MessageInterceptorContext;
+import org.apache.rocketmq.client.java.message.GeneralMessage;
 import org.apache.rocketmq.client.java.message.MessageViewImpl;
 import org.apache.rocketmq.client.java.misc.ClientId;
 import org.apache.rocketmq.client.java.tool.TestBase;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class ConsumeTaskTest extends TestBase {
 
@@ -37,7 +43,8 @@ public class ConsumeTaskTest extends TestBase {
         final MessageListener messageListener = Mockito.mock(MessageListener.class);
         Mockito.when(messageListener.consume(messageView)).thenReturn(ConsumeResult.SUCCESS);
         final MessageInterceptor messageInterceptor = Mockito.mock(MessageInterceptor.class);
-        final ConsumeTask consumeTask = new ConsumeTask(clientId, messageListener, messageView, messageInterceptor);
+        final ConsumeTask consumeTask = new ConsumeTask(clientId, "testConsumerGroup",
+                messageListener, messageView, messageInterceptor);
         final ConsumeResult consumeResult = consumeTask.call();
         assertEquals(ConsumeResult.SUCCESS, consumeResult);
     }
@@ -49,8 +56,36 @@ public class ConsumeTaskTest extends TestBase {
         final MessageListener messageListener = Mockito.mock(MessageListener.class);
         Mockito.when(messageListener.consume(messageView)).thenThrow(new RuntimeException());
         final MessageInterceptor messageInterceptor = Mockito.mock(MessageInterceptor.class);
-        final ConsumeTask consumeTask = new ConsumeTask(clientId, messageListener, messageView, messageInterceptor);
+        final ConsumeTask consumeTask = new ConsumeTask(clientId, "testConsumerGroup",
+                messageListener, messageView, messageInterceptor);
         final ConsumeResult consumeResult = consumeTask.call();
         assertEquals(ConsumeResult.FAILURE, consumeResult);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testConsumerGroupInContext() {
+        final String expectedGroup = "myConsumerGroup";
+        ClientId clientId = new ClientId();
+        final MessageViewImpl messageView = fakeMessageViewImpl();
+        final MessageListener messageListener = Mockito.mock(MessageListener.class);
+        Mockito.when(messageListener.consume(messageView)).thenReturn(ConsumeResult.SUCCESS);
+        final AtomicReference<String> capturedGroup = new AtomicReference<>();
+        final MessageInterceptor messageInterceptor = new MessageInterceptor() {
+            @Override
+            public void doBefore(MessageInterceptorContext context, List<GeneralMessage> messages) {
+                Attribute<String> attr = context.getAttribute(ConsumeTask.CONSUMER_GROUP_CONTEXT_KEY);
+                if (attr != null) {
+                    capturedGroup.set(attr.get());
+                }
+            }
+            @Override
+            public void doAfter(MessageInterceptorContext context, List<GeneralMessage> messages) {
+            }
+        };
+        final ConsumeTask consumeTask = new ConsumeTask(clientId, expectedGroup, messageListener,
+                messageView, messageInterceptor);
+        consumeTask.call();
+        assertEquals(expectedGroup, capturedGroup.get());
     }
 }

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeTaskTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ConsumeTaskTest.java
@@ -19,6 +19,8 @@ package org.apache.rocketmq.client.java.impl.consumer;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
 import org.apache.rocketmq.client.apis.consumer.MessageListener;
 import org.apache.rocketmq.client.java.hook.Attribute;
@@ -30,9 +32,6 @@ import org.apache.rocketmq.client.java.misc.ClientId;
 import org.apache.rocketmq.client.java.tool.TestBase;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class ConsumeTaskTest extends TestBase {
 
@@ -79,6 +78,7 @@ public class ConsumeTaskTest extends TestBase {
                     capturedGroup.set(attr.get());
                 }
             }
+
             @Override
             public void doAfter(MessageInterceptorContext context, List<GeneralMessage> messages) {
             }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1289 

### Brief Description
Pass the consumer group in the hook context when consuming messages, enabling hooks to log more detailed information.


<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
