### PR TITLE
fix: add CODECOV_ACTION_KEY token and upgrade actions in golang coverage workflow

### DIFF
--- a/.github/workflows/golang_coverage.yml
+++ b/.github/workflows/golang_coverage.yml
@@ -12,17 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Golang ${{ matrix.go }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
       - name: Generate coverage report
         working-directory: ./golang
         run: go test -coverprofile coverage.out
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_ACTION_KEY }}
           file: ./golang/coverage.out
           flags: golang
           fail_ci_if_error: true


### PR DESCRIPTION
## Problem

The [Golang Coverage CI job](https://github.com/apache/rocketmq-clients/actions/runs/29067603573/job/86282401552) failed at the `Upload to Codecov` step with:

```
429 - {"message":"Rate limit reached. Please upload with the Codecov repository upload token to resolve issue."}
```

The root cause is that the golang coverage workflow was the **only** coverage workflow missing the `CODECOV_ACTION_KEY` token, causing uploads to hit Codecov's anonymous rate limit.

Additionally, `actions/checkout@v2`, `actions/setup-go@v2`, and `codecov/codecov-action@v3` are all using deprecated Node.js 20.

## Changes

| Change | Before | After |
|--------|--------|-------|
| Codecov token | missing | `${{ secrets.CODECOV_ACTION_KEY }}` |
| `codecov/codecov-action` | v3 | v4 |
| `actions/checkout` | v2 | v4 |
| `actions/setup-go` | v2 | v5 |

These changes align the golang coverage workflow with the existing `java_coverage.yml`, `cpp_coverage.yml`, and `rust_coverage.yaml` workflows.
