### PR TITLE
[ISSUE #1307] [C++] Support graceful shutdown for PushConsumer

### DIFF
--- a/cpp/source/base/ThreadPoolImpl.cpp
+++ b/cpp/source/base/ThreadPoolImpl.cpp
@@ -88,6 +88,21 @@ void ThreadPoolImpl::shutdown() {
   }
 }
 
+void ThreadPoolImpl::gracefulShutdown() {
+  State expected = State::STARTED;
+  if (state_.compare_exchange_strong(expected, State::STOPPING, std::memory_order_relaxed)) {
+    // Release work guard so io_context::run() returns once all pending handlers complete.
+    // Do NOT call context_.stop() — let queued tasks drain naturally.
+    work_guard_->reset();
+    for (auto& thread : threads_) {
+      if (thread.joinable()) {
+        thread.join();
+      }
+    }
+    state_.store(State::STOPPED, std::memory_order_relaxed);
+  }
+}
+
 void ThreadPoolImpl::submit(std::function<void()> task) {
   if (State::STARTED == state_.load(std::memory_order_relaxed)) {
     asio::post(context_, task);

--- a/cpp/source/base/include/ThreadPool.h
+++ b/cpp/source/base/include/ThreadPool.h
@@ -30,6 +30,13 @@ public:
 
   virtual void shutdown() = 0;
 
+  /**
+   * Gracefully shutdown: stop accepting new tasks, wait for all pending tasks
+   * to complete, then join worker threads. Unlike shutdown(), this does NOT
+   * forcefully stop the io_context.
+   */
+  virtual void gracefulShutdown() = 0;
+
   virtual void submit(std::function<void(void)> task) = 0;
 };
 

--- a/cpp/source/base/include/ThreadPoolImpl.h
+++ b/cpp/source/base/include/ThreadPoolImpl.h
@@ -42,6 +42,8 @@ public:
 
   void shutdown() override;
 
+  void gracefulShutdown() override;
+
   void submit(std::function<void(void)> task) override;
 
 private:

--- a/cpp/source/rocketmq/ConsumeMessageServiceImpl.cpp
+++ b/cpp/source/rocketmq/ConsumeMessageServiceImpl.cpp
@@ -54,6 +54,14 @@ void ConsumeMessageServiceImpl::shutdown() {
   }
 }
 
+void ConsumeMessageServiceImpl::gracefulShutdown() {
+  State expected = State::STARTED;
+  if (state_.compare_exchange_strong(expected, State::STOPPING, std::memory_order_relaxed)) {
+    pool_->gracefulShutdown();
+    state_.store(State::STOPPED, std::memory_order_relaxed);
+  }
+}
+
 State ConsumeMessageServiceImpl::state() const {
   return state_.load(std::memory_order_relaxed);
 }

--- a/cpp/source/rocketmq/ProcessQueueImpl.cpp
+++ b/cpp/source/rocketmq/ProcessQueueImpl.cpp
@@ -118,13 +118,24 @@ void ProcessQueueImpl::popMessage(std::string& attempt_id) {
   SPDLOG_DEBUG("Receive message from={}, attemptId={}", simpleNameOf(message_queue_), attempt_id);
 
   std::weak_ptr<AsyncReceiveMessageCallback> cb{receive_callback_};
+  std::weak_ptr<PushConsumerImpl> consumer_weak{consumer_client};
   auto callback =
-      [cb, attempt_id](const std::error_code& ec, const ReceiveMessageResult& result) {
+      [cb, attempt_id, consumer_weak](const std::error_code& ec, const ReceiveMessageResult& result) {
+    // Decrement inflight receive request count so PushConsumerImpl::shutdown()
+    // can drain in-flight receives during graceful shutdown.
+    auto consumer = consumer_weak.lock();
+    if (consumer) {
+      consumer->decrementInflightReceiveRequests();
+    }
+
     std::shared_ptr<AsyncReceiveMessageCallback> receive_cb = cb.lock();
     if (receive_cb) {
       receive_cb->onCompletion(ec, attempt_id, result);
     }
   };
+
+  // Increment inflight receive request count before sending the RPC.
+  consumer_client->incrementInflightReceiveRequests();
 
   auto timeout = absl::ToChronoMilliseconds(
       consumer_client->config().subscriber.polling_timeout + consumer_client->config().request_timeout);

--- a/cpp/source/rocketmq/PushConsumerImpl.cpp
+++ b/cpp/source/rocketmq/PushConsumerImpl.cpp
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <string>
 #include <system_error>
+#include <thread>
 
 #include "AsyncReceiveMessageCallback.h"
 #include "ConsumeMessageServiceImpl.h"
@@ -115,6 +116,9 @@ void PushConsumerImpl::shutdown() noexcept {
     return;
   }
 
+  SPDLOG_INFO("Begin to shutdown the rocketmq push consumer, clientId={}", client_config_.client_id);
+
+  // Step 1: Cancel periodic tasks so no new receive requests or process queues are created.
   if (scan_assignment_handle_) {
     client_manager_->getScheduler()->cancel(scan_assignment_handle_);
     SPDLOG_DEBUG("Scan assignment periodic task cancelled");
@@ -125,17 +129,77 @@ void PushConsumerImpl::shutdown() noexcept {
     SPDLOG_DEBUG("Collect cache stats periodic task cancelled");
   }
 
+  // Step 2: Wait for all in-flight receive requests to complete.
+  SPDLOG_INFO("Waiting for inflight receive requests to finish, clientId={}", client_config_.client_id);
+  awaitInflightReceiveRequests();
+
+  // Step 3: Wait for cached messages in process queues to be consumed.
+  SPDLOG_INFO("Waiting for cached messages to be consumed, clientId={}", client_config_.client_id);
+  awaitCachedMessagesDrained();
+
+  // Step 4: Gracefully shutdown the consume message service so queued tasks drain instead of being cancelled.
+  SPDLOG_INFO("Begin to shutdown consumption executor, clientId={}", client_config_.client_id);
+  if (consume_message_service_) {
+    consume_message_service_->gracefulShutdown();
+  }
+
+  // Step 5: Grace period for async ack/nack requests to complete before closing the connection.
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+
+  // Step 6: Clear process queues and shutdown client infrastructure.
   {
     absl::MutexLock lock(&process_queue_table_mtx_);
     process_queue_table_.clear();
   }
 
-  if (consume_message_service_) {
-    consume_message_service_->shutdown();
+  ClientImpl::shutdown();
+  SPDLOG_INFO("Shutdown the rocketmq push consumer successfully, clientId={}", client_config_.client_id);
+}
+
+void PushConsumerImpl::awaitInflightReceiveRequests() {
+  auto max_waiting_time = client_config_.request_timeout + client_config_.subscriber.polling_timeout;
+  auto deadline = std::chrono::steady_clock::now()
+      + std::chrono::milliseconds(absl::ToInt64Milliseconds(max_waiting_time));
+
+  while (inflight_receive_requests_.load(std::memory_order_acquire) > 0) {
+    if (std::chrono::steady_clock::now() > deadline) {
+      SPDLOG_WARN("Timeout waiting for inflight receive requests to finish. Remaining={}, clientId={}",
+                  inflight_receive_requests_.load(std::memory_order_relaxed), client_config_.client_id);
+      return;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 
-  ClientImpl::shutdown();
-  SPDLOG_INFO("PushConsumerImpl stopped");
+  SPDLOG_INFO("All inflight receive requests finished, clientId={}", client_config_.client_id);
+}
+
+void PushConsumerImpl::awaitCachedMessagesDrained() {
+  auto max_waiting_time = client_config_.request_timeout + client_config_.subscriber.polling_timeout;
+  auto deadline = std::chrono::steady_clock::now()
+      + std::chrono::milliseconds(absl::ToInt64Milliseconds(max_waiting_time));
+
+  while (true) {
+    uint64_t total_cached = 0;
+    {
+      absl::MutexLock lock(&process_queue_table_mtx_);
+      for (const auto& entry : process_queue_table_) {
+        total_cached += entry.second->cachedMessageQuantity();
+      }
+    }
+
+    if (total_cached == 0) {
+      SPDLOG_INFO("All cached messages have been consumed, clientId={}", client_config_.client_id);
+      return;
+    }
+
+    if (std::chrono::steady_clock::now() > deadline) {
+      SPDLOG_WARN("Timeout waiting for cached messages to drain. Remaining={}, clientId={}", total_cached,
+                  client_config_.client_id);
+      return;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
 }
 
 void PushConsumerImpl::subscribe(const std::string& topic, const std::string& expression,

--- a/cpp/source/rocketmq/include/ConsumeMessageService.h
+++ b/cpp/source/rocketmq/include/ConsumeMessageService.h
@@ -42,6 +42,12 @@ public:
    */
   virtual void shutdown() = 0;
 
+  /**
+   * Gracefully stop: wait for all dispatched consume tasks to finish before
+   * returning. Does not forcefully discard queued tasks.
+   */
+  virtual void gracefulShutdown() = 0;
+
   virtual void dispatch(std::shared_ptr<ProcessQueue> process_queue, std::vector<MessageConstSharedPtr> messages) = 0;
 
   virtual void submit(std::shared_ptr<ConsumeTask> task) = 0;

--- a/cpp/source/rocketmq/include/ConsumeMessageServiceImpl.h
+++ b/cpp/source/rocketmq/include/ConsumeMessageServiceImpl.h
@@ -50,6 +50,8 @@ public:
 
   void shutdown() override;
 
+  void gracefulShutdown() override;
+
   MessageListener &listener() override { return message_listener_; }
 
   bool preHandle(const Message &message) override;

--- a/cpp/source/rocketmq/include/PushConsumerImpl.h
+++ b/cpp/source/rocketmq/include/PushConsumerImpl.h
@@ -128,6 +128,22 @@ public:
   // only for test
   std::size_t getProcessQueueTableSize() LOCKS_EXCLUDED(process_queue_table_mtx_);
 
+  /**
+   * Number of in-flight receive message requests. Used during graceful
+   * shutdown to wait for all pending receives to complete.
+   */
+  int64_t inflightReceiveRequestCount() const {
+    return inflight_receive_requests_.load(std::memory_order_acquire);
+  }
+
+  void incrementInflightReceiveRequests() {
+    inflight_receive_requests_.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  void decrementInflightReceiveRequests() {
+    inflight_receive_requests_.fetch_sub(1, std::memory_order_relaxed);
+  }
+
   void setCustomExecutor(const Executor& executor) {
     custom_executor_ = executor;
   }
@@ -215,6 +231,23 @@ private:
   ConsumeStats stats_;
   std::uintptr_t collect_stats_handle_{0};
   static const char* COLLECT_STATS_TASK_NAME;
+
+  /**
+   * Tracks the number of in-flight receive message gRPC requests.
+   * Incremented before sending a receive request, decremented when the
+   * response callback fires.
+   */
+  std::atomic<int64_t> inflight_receive_requests_{0};
+
+  /**
+   * Wait until all in-flight receive requests complete or timeout.
+   */
+  void awaitInflightReceiveRequests();
+
+  /**
+   * Wait until all cached messages in process queues are consumed or timeout.
+   */
+  void awaitCachedMessagesDrained() LOCKS_EXCLUDED(process_queue_table_mtx_);
 
   void fetchRoutes() LOCKS_EXCLUDED(topic_filter_expression_table_mtx_);
 

--- a/cpp/source/rocketmq/mocks/include/ConsumeMessageServiceMock.h
+++ b/cpp/source/rocketmq/mocks/include/ConsumeMessageServiceMock.h
@@ -30,6 +30,8 @@ public:
 
   MOCK_METHOD(void, shutdown, (), (override));
 
+  MOCK_METHOD(void, gracefulShutdown, (), (override));
+
   MOCK_METHOD(void, submitConsumeTask, (const std::weak_ptr<ProcessQueue>&), (override));
 
   MOCK_METHOD(void, signalDispatcher, (), (override));

--- a/cpp/source/rocketmq/tests/BUILD.bazel
+++ b/cpp/source/rocketmq/tests/BUILD.bazel
@@ -145,3 +145,13 @@ cc_test(
         "//source/rocketmq/mocks:rocketmq_mocks",
     ],
 )
+
+cc_test(
+    name = "graceful_shutdown_test",
+    srcs = [
+        "GracefulShutdownTest.cpp",
+    ],
+    deps = base_deps + [
+        "//source/rocketmq/mocks:rocketmq_mocks",
+    ],
+)

--- a/cpp/source/rocketmq/tests/ConsumeTaskTest.cpp
+++ b/cpp/source/rocketmq/tests/ConsumeTaskTest.cpp
@@ -43,6 +43,7 @@ class ConsumeTaskServiceMock : public ConsumeMessageService {
 public:
   MOCK_METHOD(void, start, (), (override));
   MOCK_METHOD(void, shutdown, (), (override));
+  MOCK_METHOD(void, gracefulShutdown, (), (override));
   MOCK_METHOD(void, dispatch, (std::shared_ptr<ProcessQueue>, std::vector<MessageConstSharedPtr>), (override));
   MOCK_METHOD(void, submit, (std::shared_ptr<ConsumeTask>), (override));
   MOCK_METHOD(MessageListener&, listener, (), (override));

--- a/cpp/source/rocketmq/tests/GracefulShutdownTest.cpp
+++ b/cpp/source/rocketmq/tests/GracefulShutdownTest.cpp
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include "ClientManagerMock.h"
+#include "PushConsumerImpl.h"
+#include "ThreadPoolImpl.h"
+#include "absl/memory/memory.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "rocketmq/ConsumeResult.h"
+
+ROCKETMQ_NAMESPACE_BEGIN
+
+namespace {
+
+std::shared_ptr<PushConsumerImpl> createConsumer(const std::string& group = "test-group") {
+  auto consumer = std::make_shared<PushConsumerImpl>(group);
+  auto client_manager = std::make_shared<testing::NiceMock<ClientManagerMock>>();
+  consumer->clientManager(client_manager);
+  return consumer;
+}
+
+} // namespace
+
+TEST(GracefulShutdownTest, inflightCounterInitiallyZero) {
+  auto consumer = createConsumer();
+  EXPECT_EQ(0, consumer->inflightReceiveRequestCount());
+}
+
+TEST(GracefulShutdownTest, inflightCounterIncrementDecrement) {
+  auto consumer = createConsumer();
+  consumer->incrementInflightReceiveRequests();
+  consumer->incrementInflightReceiveRequests();
+  EXPECT_EQ(2, consumer->inflightReceiveRequestCount());
+
+  consumer->decrementInflightReceiveRequests();
+  EXPECT_EQ(1, consumer->inflightReceiveRequestCount());
+
+  consumer->decrementInflightReceiveRequests();
+  EXPECT_EQ(0, consumer->inflightReceiveRequestCount());
+}
+
+TEST(GracefulShutdownTest, threadPoolGracefulShutdownDrainsTasks) {
+  auto pool = absl::make_unique<ThreadPoolImpl>(2);
+  pool->start();
+
+  std::atomic<int> completed{0};
+  for (int i = 0; i < 10; i++) {
+    pool->submit([&completed]() {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      completed.fetch_add(1);
+    });
+  }
+
+  // Graceful shutdown should wait for all tasks to complete
+  pool->gracefulShutdown();
+  EXPECT_EQ(10, completed.load());
+}
+
+TEST(GracefulShutdownTest, threadPoolGracefulShutdownRejectsNewTasks) {
+  auto pool = absl::make_unique<ThreadPoolImpl>(1);
+  pool->start();
+
+  std::atomic<int> completed{0};
+  pool->submit([&completed]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    completed.fetch_add(1);
+  });
+
+  // Give time for the first task to start
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+  pool->gracefulShutdown();
+
+  // After graceful shutdown, new tasks should be rejected
+  pool->submit([&completed]() {
+    completed.fetch_add(1);
+  });
+
+  // Only the first task should have completed
+  EXPECT_EQ(1, completed.load());
+}
+
+TEST(GracefulShutdownTest, shutdownOnNonStartedConsumerIsNoOp) {
+  auto consumer = createConsumer();
+  // Consumer is in CREATED state, shutdown should be a no-op
+  consumer->shutdown();
+  EXPECT_EQ(0, consumer->inflightReceiveRequestCount());
+}
+
+ROCKETMQ_NAMESPACE_END


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `master`. -->

### Which Issue(s) This PR Fixes

Fixes #1307

### Brief Description

Port the Java graceful-shutdown fix (#992 for #816) to the C++ `PushConsumer` so that in-flight `ReceiveMessage` requests complete and cached messages are consumed / acked before the underlying gRPC sessions are torn down.

Previously `PushConsumerImpl::shutdown()` cleared `process_queue_table_` and force-stopped the consumption `io_context` before `ClientImpl::shutdown()`, which caused:
- **Latency spikes** — messages already in the local cache were dropped locally and only came back after the broker's invisible-duration expired.
- **Duplicate consumption** — messages that finished consumption during shutdown could not `Ack` because the gRPC channel was already gone.

**Approach (aligned with Java #992):**

1. `ThreadPool` gains `gracefulShutdown()` — releases the asio `executor_work_guard` and joins workers **without** calling `context_.stop()`, letting queued handlers drain naturally.
2. `ConsumeMessageService` gains `gracefulShutdown()` that forwards to the pool.
3. `PushConsumerImpl` tracks in-flight `ReceiveMessage` RPCs via `std::atomic<int64_t>` — incremented in `ProcessQueueImpl::popMessage()` before dispatching, decremented from the completion callback.
4. `PushConsumerImpl::shutdown()` is rewritten into six ordered phases:
   1. Cancel `scan_assignment_handle_` / `collect_stats_handle_`.
   2. `awaitInflightReceiveRequests()` — poll until the inflight counter hits 0 or `request_timeout + polling_timeout` elapses.
   3. `awaitCachedMessagesDrained()` — poll until every `ProcessQueue::cachedMessageQuantity()` is 0, bounded by the same deadline.
   4. `consume_message_service_->gracefulShutdown()`.
   5. Sleep 1s to let async `ack` / `nack` RPCs complete.
   6. Clear `process_queue_table_` and call `ClientImpl::shutdown()`.

All wait loops are strictly time-bounded so a stuck broker cannot hang `shutdown()`.

### How Did You Test This Change?

- New unit tests in `cpp/source/rocketmq/tests/GracefulShutdownTest.cpp`:
  - `inflightCounterInitiallyZero` — counter starts at 0.
  - `inflightCounterIncrementDecrement` — `increment` / `decrement` arithmetic is correct.
  - `threadPoolGracefulShutdownDrainsTasks` — 10 tasks posted with 10ms sleep all complete after `gracefulShutdown()`.
  - `threadPoolGracefulShutdownRejectsNewTasks` — tasks submitted after `gracefulShutdown()` are rejected.
  - `shutdownOnNonStartedConsumerIsNoOp` — CAS guard prevents shutdown side effects on unstarted consumers.
- Regression: `push_consumer_impl_test`, `process_queue_impl_test`, `consume_message_service_test`, `consume_task_test` all pass.

Local verification:

```bash
cd cpp
bazel build //source/rocketmq:rocketmq_library
bazel test //source/rocketmq/tests:graceful_shutdown_test \
           //source/rocketmq/tests:push_consumer_impl_test \
           //source/rocketmq/tests:process_queue_impl_test \
           //source/rocketmq/tests:consume_message_service_test \
           //source/rocketmq/tests:consume_task_test
```

All targets build and pass.
