### PR TITLE
[Go] Support LiteSimpleConsumer

### DIFF
--- a/golang/client.go
+++ b/golang/client.go
@@ -51,6 +51,9 @@ type isClient interface {
 	onRecoverOrphanedTransactionCommand(endpoints *v2.Endpoints, command *v2.RecoverOrphanedTransactionCommand) error
 	onVerifyMessageCommand(endpoints *v2.Endpoints, command *v2.VerifyMessageCommand) error
 	IsEndpointUpdated() bool
+	isRunning() bool
+	getClient() *defaultClient
+	getRequestTimeout() time.Duration
 }
 type defaultClientSession struct {
 	endpoints        *v2.Endpoints
@@ -581,14 +584,15 @@ func (cli *defaultClient) startUp() error {
 						impl.publishingRouteDataResultCache.Store(topic, existing.(PublishingLoadBalancer).CopyAndUpdate(newRoute))
 					}
 				case *defaultSimpleConsumer:
+					filteredRoute := impl.filterTopicRouteData(newRoute)
 					existing, ok := impl.subTopicRouteDataResultCache.Load(topic)
 					if !ok {
-						slb, err := NewSubscriptionLoadBalancer(newRoute)
+						slb, err := NewSubscriptionLoadBalancer(filteredRoute)
 						if err == nil {
 							impl.subTopicRouteDataResultCache.Store(topic, slb)
 						}
 					} else {
-						impl.subTopicRouteDataResultCache.Store(topic, existing.(SubscriptionLoadBalancer).CopyAndUpdate(newRoute))
+						impl.subTopicRouteDataResultCache.Store(topic, existing.(SubscriptionLoadBalancer).CopyAndUpdate(filteredRoute))
 					}
 				}
 			}

--- a/golang/example/consumer/lite_simple_consumer/main.go
+++ b/golang/example/consumer/lite_simple_consumer/main.go
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	rmq_client "github.com/apache/rocketmq-clients/golang/v5"
+	"github.com/apache/rocketmq-clients/golang/v5/credentials"
+)
+
+const (
+	ConsumerGroup = "xxxxxx"
+	BindTopic     = "xxxxxx"
+	LiteTopic     = "xxxxxx"
+	Endpoint      = "xxxxxx"
+	AccessKey     = "xxxxxx"
+	SecretKey     = "xxxxxx"
+	NameSpace     = ""
+)
+
+var (
+	// maximum waiting time for receive func
+	awaitDuration = time.Second * 5
+	// maximum number of messages received at one time
+	maxMessageNum int32 = 16
+	// invisibleDuration should > 20s
+	invisibleDuration = time.Second * 20
+)
+
+func main() {
+	// log to console
+	os.Setenv("mq.consoleAppender.enabled", "true")
+	rmq_client.ResetLogger()
+	// In most case, you don't need to create many consumers, singleton pattern is more recommended.
+	liteSimpleConsumer, err := rmq_client.NewLiteSimpleConsumer(&rmq_client.Config{
+		Endpoint:      Endpoint,
+		ConsumerGroup: ConsumerGroup,
+		Credentials: &credentials.SessionCredentials{
+			AccessKey:    AccessKey,
+			AccessSecret: SecretKey,
+		},
+		NameSpace: NameSpace,
+	},
+		rmq_client.NewLiteSimpleConsumerConfig(BindTopic),
+		rmq_client.WithSimpleAwaitDuration(awaitDuration),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// start liteSimpleConsumer
+	err = liteSimpleConsumer.Start()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// graceful stop liteSimpleConsumer
+	defer liteSimpleConsumer.GracefulStop()
+
+	// subscribe a lite topic
+	err = liteSimpleConsumer.SubscribeLite(LiteTopic)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	go func() {
+		for {
+			fmt.Println("start receive message")
+			mvs, err := liteSimpleConsumer.Receive(context.TODO(), maxMessageNum, invisibleDuration)
+			if err != nil {
+				fmt.Println(err)
+			}
+			// ack message
+			for _, mv := range mvs {
+				liteSimpleConsumer.Ack(context.TODO(), mv)
+				fmt.Println("received message:", mv.GetMessageId(), mv.GetTopic(), mv.GetLiteTopic(), mv.GetProperties())
+			}
+			fmt.Println("wait a moment")
+			fmt.Println()
+			time.Sleep(time.Second * 3)
+		}
+	}()
+	// run for a while
+	time.Sleep(time.Minute)
+}

--- a/golang/lite_push_consumer.go
+++ b/golang/lite_push_consumer.go
@@ -18,11 +18,9 @@
 package golang
 
 import (
-	"context"
 	"errors"
 	"time"
 
-	"github.com/apache/rocketmq-clients/golang/v5/pkg/ticker"
 	v2 "github.com/apache/rocketmq-clients/golang/v5/protocol/v2"
 )
 
@@ -30,6 +28,7 @@ type LitePushConsumer interface {
 	PushConsumer
 	SubscribeLite(liteTopic string, offsetOption ...OffsetOption) error
 	UnSubscribeLite(liteTopic string) error
+	GetLiteTopicSet() []string
 }
 
 var _ = LitePushConsumer(&defaultLitePushConsumer{})
@@ -37,6 +36,7 @@ var _ = LitePushConsumer(&defaultLitePushConsumer{})
 type defaultLitePushConsumer struct {
 	*defaultPushConsumer
 	litePushConsumerSettings *litePushConsumerSettings
+	liteSubscriptionManager  *liteSubscriptionManager
 }
 
 type LitePushConsumerConfig struct {
@@ -75,135 +75,36 @@ var NewLitePushConsumer = func(config *Config, liteConfig *LitePushConsumerConfi
 			defaultPushConsumer:      pushConsumer,
 			litePushConsumerSettings: lpcSetting,
 		}
-
+		lpc.liteSubscriptionManager = newLiteSubscriptionManager(lpc,
+			liteConfig.bindTopic, lpcSetting.groupName, pushConsumer.cli.config.NameSpace)
+		lpcSetting.liteSubscriptionManager = lpc.liteSubscriptionManager
 		pushConsumer.pushConsumerExtension = lpc
 		return lpc, nil
 	}
 }
 
 func (lpc *defaultLitePushConsumer) Start() error {
-	if err := lpc.startPushConsumer(); err != nil {
+	if err := lpc.defaultPushConsumer.Start(); err != nil {
 		return err
 	}
-	lpc.defaultPushConsumer.cli.notifyUnsubscribeLiteFunc = lpc.notifyUnsubscribeLite
-	//todo
-	lpc.syncAllLiteSubscription()
-	ticker.Tick(lpc.syncAllLiteSubscription, time.Second*30, lpc.defaultPushConsumer.cli.done)
+	lpc.defaultPushConsumer.cli.notifyUnsubscribeLiteFunc = lpc.liteSubscriptionManager.onNotifyUnsubscribeLiteCommand
+	lpc.liteSubscriptionManager.startUp()
 	return nil
-}
-
-func (lpc *defaultLitePushConsumer) startPushConsumer() error {
-	return lpc.defaultPushConsumer.Start()
-}
-
-func (lpc *defaultLitePushConsumer) notifyUnsubscribeLite(command *v2.NotifyUnsubscribeLiteCommand) {
-	liteTopic := command.LiteTopic
-	sugarBaseLogger.Infof("LitePushConsumer notifyUnsubscribeLite liteTopic:%s", liteTopic)
-	if liteTopic == "" {
-		return
-	}
-	lpc.litePushConsumerSettings.liteTopicSet.Delete(liteTopic)
 }
 
 func (lpc *defaultLitePushConsumer) SubscribeLite(liteTopic string, offsetOption ...OffsetOption) error {
-	if err := lpc.checkRunning(); err != nil {
-		return err
-	}
-	if len(offsetOption) > 1 {
-		return errors.New("only one offset option is supported")
-	}
-	var option *OffsetOption
-	if len(offsetOption) == 1 {
-		option = &offsetOption[0]
-	}
-	if err := lpc.syncLiteSubscription(context.TODO(), v2.LiteSubscriptionAction_PARTIAL_ADD, []string{liteTopic}, option); err != nil {
-		sugarBaseLogger.Errorf("LitePushConsumer SubscribeLite liteTopic:%s err:%v", liteTopic, err)
-		return err
-	}
-	lpc.litePushConsumerSettings.liteTopicSet.Store(liteTopic, struct{}{})
-	return nil
+	return lpc.liteSubscriptionManager.subscribeLite(liteTopic, offsetOption...)
 }
 
 func (lpc *defaultLitePushConsumer) UnSubscribeLite(liteTopic string) error {
-	if err := lpc.checkRunning(); err != nil {
-		return err
-	}
-	if err := lpc.syncLiteSubscription(context.TODO(), v2.LiteSubscriptionAction_PARTIAL_REMOVE, []string{liteTopic}, nil); err != nil {
-		sugarBaseLogger.Errorf("LitePushConsumer UnSubscribeLite liteTopic:%s err:%v", liteTopic, err)
-		return err
-	}
-	lpc.litePushConsumerSettings.liteTopicSet.Delete(liteTopic)
-	return nil
+	return lpc.liteSubscriptionManager.unsubscribeLite(liteTopic)
 }
 
-func (lpc *defaultLitePushConsumer) checkRunning() error {
-	if !lpc.defaultPushConsumer.isRunning() {
-		sugarBaseLogger.Errorf("[bug] LitePushConsumer not running. clientId: %s", lpc.litePushConsumerSettings.clientId)
-		return errors.New("consumer is not running")
-	}
-	return nil
-}
-
-func (lpc *defaultLitePushConsumer) syncAllLiteSubscription() {
-	liteTopicSet := make([]string, 0, lpc.litePushConsumerSettings.maxLiteTopicSize)
-	lpc.litePushConsumerSettings.liteTopicSet.Range(func(key, value interface{}) bool {
-		if liteTopic, ok := key.(string); ok {
-			liteTopicSet = append(liteTopicSet, liteTopic)
-		}
-		return true
-	})
-	// Sync subscription even when liteTopicSet is empty to keep server state consistent
-	//if len(liteTopicSet) == 0 {
-	//	return
-	//}
-	if err := lpc.syncLiteSubscription(context.TODO(), v2.LiteSubscriptionAction_COMPLETE_ADD, liteTopicSet, nil); err != nil {
-		sugarBaseLogger.Errorf("LitePushConsumer syncAllLiteSubscription:%v,  err:%v", liteTopicSet, err)
-	}
-}
-
-func (lpc *defaultLitePushConsumer) syncLiteSubscription(context context.Context, action v2.LiteSubscriptionAction, diff []string, offsetOption *OffsetOption) error {
-	topic := lpc.litePushConsumerSettings.bindTopic
-	group := lpc.litePushConsumerSettings.groupName
-	clientId := lpc.litePushConsumerSettings.clientId
-
-	endpoints := lpc.cli.accessPoint
-	request := v2.SyncLiteSubscriptionRequest{
-		Action: action,
-		Topic: &v2.Resource{
-			Name:              topic,
-			ResourceNamespace: lpc.cli.config.NameSpace,
-		},
-		Group:        group,
-		LiteTopicSet: diff,
-	}
-	if offsetOption != nil {
-		request.OffsetOption = offsetOption.toProtobuf()
-	}
-
-	if action == v2.LiteSubscriptionAction_COMPLETE_ADD {
-		sugarBaseLogger.Infof("syncLiteSubscription action:%s, topic:%s, group:%s, clientId:%s, liteTopicCount:%d",
-			action, topic, group, clientId, len(diff))
-	} else {
-		sugarBaseLogger.Infof("syncLiteSubscription action:%s, topic:%s, group:%s, clientId:%s, liteTopics:%v",
-			action, topic, group, clientId, diff)
-	}
-
-	context = lpc.cli.Sign(context)
-	if v, err := lpc.defaultPushConsumer.cli.clientManager.SyncLiteSubscription(context, endpoints, &request, lpc.pcSettings.requestTimeout); err != nil {
-		return err
-	} else {
-		if v.GetStatus().GetCode() != v2.Code_OK {
-			return &ErrRpcStatus{
-				Code:    int32(v.Status.GetCode()),
-				Message: v.GetStatus().GetMessage(),
-			}
-		}
-		return nil
-	}
+func (lpc *defaultLitePushConsumer) GetLiteTopicSet() []string {
+	return lpc.liteSubscriptionManager.getLiteTopicSet()
 }
 
 var _ = PushConsumerExtension(&defaultLitePushConsumer{})
-
 
 func (lpc *defaultLitePushConsumer) WrapHeartbeatRequest() *v2.HeartbeatRequest {
 	return &v2.HeartbeatRequest{

--- a/golang/lite_push_consumer_mock.go
+++ b/golang/lite_push_consumer_mock.go
@@ -66,6 +66,20 @@ func (mr *MockLitePushConsumerMockRecorder) UnSubscribeLite(liteTopic interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnSubscribeLite", reflect.TypeOf((*MockLitePushConsumer)(nil).UnSubscribeLite), liteTopic)
 }
 
+// GetLiteTopicSet mocks base method.
+func (m *MockLitePushConsumer) GetLiteTopicSet() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLiteTopicSet")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// GetLiteTopicSet indicates an expected call of GetLiteTopicSet.
+func (mr *MockLitePushConsumerMockRecorder) GetLiteTopicSet() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLiteTopicSet", reflect.TypeOf((*MockLitePushConsumer)(nil).GetLiteTopicSet))
+}
+
 // Start mocks base method.
 func (m *MockLitePushConsumer) Start() error {
 	m.ctrl.T.Helper()

--- a/golang/lite_push_consumer_options.go
+++ b/golang/lite_push_consumer_options.go
@@ -19,7 +19,6 @@ package golang
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	v2 "github.com/apache/rocketmq-clients/golang/v5/protocol/v2"
@@ -30,22 +29,16 @@ var _ = ClientSettings(&litePushConsumerSettings{})
 
 type litePushConsumerSettings struct {
 	*pushConsumerSettings
-	bindTopic             string
-	liteTopicSet          *sync.Map
-	liteSubscriptionQuota int32
-	maxLiteTopicSize      int32
-	invisibleDuration     time.Duration
+	bindTopic               string
+	invisibleDuration       time.Duration
+	liteSubscriptionManager *liteSubscriptionManager
 }
 
 func newLitePushConsumerSettings(settings *pushConsumerSettings, bindTopic string, invisibleDuration time.Duration) *litePushConsumerSettings {
 	return &litePushConsumerSettings{
 		pushConsumerSettings: settings,
 		bindTopic:            bindTopic,
-		liteTopicSet:         &sync.Map{},
 		invisibleDuration:    invisibleDuration,
-		// default value
-		liteSubscriptionQuota: 2000,
-		maxLiteTopicSize:      64,
 	}
 }
 
@@ -82,16 +75,9 @@ func (lpc *litePushConsumerSettings) applySettingsCommand(settings *v2.Settings)
 	}
 	// force fifo to true
 	lpc.pushConsumerSettings.isFifo = true
-	var subscription = settings.GetSubscription()
-	if subscription == nil {
-		sugarBaseLogger.Warnf("onSettingsCommand err = subscription is nil")
-		return fmt.Errorf("onSettingsCommand err = subscription is nil")
-	}
-	if subscription.LiteSubscriptionQuota != nil {
-		lpc.liteSubscriptionQuota = *subscription.LiteSubscriptionQuota
-	}
-	if subscription.MaxLiteTopicSize != nil {
-		lpc.maxLiteTopicSize = *subscription.MaxLiteTopicSize
+	// Delegate subscription settings (quota, max topic size) to the manager
+	if lpc.liteSubscriptionManager != nil {
+		lpc.liteSubscriptionManager.sync(settings.GetSubscription())
 	}
 	return nil
 }
@@ -126,11 +112,9 @@ func (lpc *litePushConsumerSettings) toProtobuf() *v2.Settings {
 	})
 	subSetting := &v2.Settings_Subscription{
 		Subscription: &v2.Subscription{
-			Group:                 lpc.groupName,
-			Subscriptions:         subscriptions,
-			LongPollingTimeout:    durationpb.New(lpc.longPollingTimeout),
-			LiteSubscriptionQuota: &lpc.liteSubscriptionQuota,
-			MaxLiteTopicSize:      &lpc.maxLiteTopicSize,
+			Group:              lpc.groupName,
+			Subscriptions:      subscriptions,
+			LongPollingTimeout: durationpb.New(lpc.longPollingTimeout),
 		},
 	}
 	settings := &v2.Settings{

--- a/golang/lite_push_consumer_test.go
+++ b/golang/lite_push_consumer_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -203,7 +204,7 @@ func TestLitePushConsumer_SubscribeLite(t *testing.T) {
 		t.Fatalf("expected no error for SubscribeLite, got %v", err)
 	}
 
-	if _, exists := dlpc.litePushConsumerSettings.liteTopicSet.Load("lite-topic-1"); !exists {
+	if _, exists := dlpc.liteSubscriptionManager.liteTopicSet.Load("lite-topic-1"); !exists {
 		t.Error("expected lite topic to be added to set")
 	}
 }
@@ -291,9 +292,9 @@ func TestLitePushConsumer_SubscribeLite_NotRunning(t *testing.T) {
 		t.Fatal("expected error when consumer not running")
 	}
 
-	expectedError := "consumer is not running"
-	if err.Error() != expectedError {
-		t.Errorf("expected error '%s', got '%s'", expectedError, err.Error())
+	expectedErrorPrefix := "client not running, clientId="
+	if !strings.HasPrefix(err.Error(), expectedErrorPrefix) {
+		t.Errorf("expected error prefix '%s', got '%s'", expectedErrorPrefix, err.Error())
 	}
 }
 
@@ -313,7 +314,7 @@ func TestLitePushConsumer_SubscribeLite_RpcError(t *testing.T) {
 		t.Fatal("expected rpc error")
 	}
 
-	if _, exists := dlpc.litePushConsumerSettings.liteTopicSet.Load("lite-topic-1"); exists {
+	if _, exists := dlpc.liteSubscriptionManager.liteTopicSet.Load("lite-topic-1"); exists {
 		t.Error("lite topic should not be added when rpc fails")
 	}
 }
@@ -327,7 +328,7 @@ func TestLitePushConsumer_UnSubscribeLite(t *testing.T) {
 		t.Fatalf("failed to create test lite push consumer: %v", err)
 	}
 
-	dlpc.litePushConsumerSettings.liteTopicSet.Store("lite-topic-1", struct{}{})
+	dlpc.liteSubscriptionManager.liteTopicSet.Store("lite-topic-1", struct{}{})
 
 	mockRpcClient.EXPECT().SyncLiteSubscription(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req *v2.SyncLiteSubscriptionRequest) (*v2.SyncLiteSubscriptionResponse, error) {
 		if req.Action != v2.LiteSubscriptionAction_PARTIAL_REMOVE {
@@ -344,7 +345,7 @@ func TestLitePushConsumer_UnSubscribeLite(t *testing.T) {
 		t.Fatalf("expected no error for UnSubscribeLite, got %v", err)
 	}
 
-	if _, exists := dlpc.litePushConsumerSettings.liteTopicSet.Load("lite-topic-1"); exists {
+	if _, exists := dlpc.liteSubscriptionManager.liteTopicSet.Load("lite-topic-1"); exists {
 		t.Error("expected lite topic to be removed from set")
 	}
 }
@@ -358,15 +359,15 @@ func TestLitePushConsumer_notifyUnsubscribeLite(t *testing.T) {
 		t.Fatalf("failed to create test lite push consumer: %v", err)
 	}
 
-	dlpc.litePushConsumerSettings.liteTopicSet.Store("lite-topic-notify", struct{}{})
+	dlpc.liteSubscriptionManager.liteTopicSet.Store("lite-topic-notify", struct{}{})
 
 	cmd := &v2.NotifyUnsubscribeLiteCommand{
 		LiteTopic: "lite-topic-notify",
 	}
 
-	dlpc.notifyUnsubscribeLite(cmd)
+	dlpc.liteSubscriptionManager.onNotifyUnsubscribeLiteCommand(cmd)
 
-	if _, exists := dlpc.litePushConsumerSettings.liteTopicSet.Load("lite-topic-notify"); exists {
+	if _, exists := dlpc.liteSubscriptionManager.liteTopicSet.Load("lite-topic-notify"); exists {
 		t.Error("expected lite topic to be removed from set after notify")
 	}
 }
@@ -380,15 +381,15 @@ func TestLitePushConsumer_notifyUnsubscribeLite_EmptyLiteTopic(t *testing.T) {
 		t.Fatalf("failed to create test lite push consumer: %v", err)
 	}
 
-	dlpc.litePushConsumerSettings.liteTopicSet.Store("lite-topic-keep", struct{}{})
+	dlpc.liteSubscriptionManager.liteTopicSet.Store("lite-topic-keep", struct{}{})
 
 	cmd := &v2.NotifyUnsubscribeLiteCommand{
 		LiteTopic: "",
 	}
 
-	dlpc.notifyUnsubscribeLite(cmd)
+	dlpc.liteSubscriptionManager.onNotifyUnsubscribeLiteCommand(cmd)
 
-	if _, exists := dlpc.litePushConsumerSettings.liteTopicSet.Load("lite-topic-keep"); !exists {
+	if _, exists := dlpc.liteSubscriptionManager.liteTopicSet.Load("lite-topic-keep"); !exists {
 		t.Error("lite topic should not be removed when command has empty lite topic")
 	}
 }
@@ -404,7 +405,7 @@ func TestLitePushConsumer_syncLiteSubscription_StatusError(t *testing.T) {
 
 	mockRpcClient.EXPECT().SyncLiteSubscription(gomock.Any(), gomock.Any()).Return(setupErrorResponse(v2.Code_INTERNAL_SERVER_ERROR, "internal error"), nil)
 
-	err = dlpc.syncLiteSubscription(context.TODO(), v2.LiteSubscriptionAction_PARTIAL_ADD, []string{"test"}, nil)
+	err = dlpc.liteSubscriptionManager.syncLiteSubscription(context.TODO(), v2.LiteSubscriptionAction_PARTIAL_ADD, []string{"test"}, nil)
 	if err == nil {
 		t.Fatal("expected error for non-OK status code")
 	}
@@ -422,7 +423,6 @@ func TestLitePushConsumer_syncLiteSubscription_StatusError(t *testing.T) {
 		t.Errorf("expected message 'internal error', got '%s'", rpcErr.Message)
 	}
 }
-
 
 func TestLitePushConsumer_WrapHeartbeatRequest(t *testing.T) {
 	setupTest(t)
@@ -488,12 +488,12 @@ func TestLitePushConsumerSettings_applySettingsCommand(t *testing.T) {
 		t.Fatalf("applySettingsCommand failed: %v", err)
 	}
 
-	if settings.liteSubscriptionQuota != liteQuota {
-		t.Errorf("expected lite subscription quota %d, got %d", liteQuota, settings.liteSubscriptionQuota)
+	if dlpc.liteSubscriptionManager.liteSubscriptionQuota != liteQuota {
+		t.Errorf("expected lite subscription quota %d, got %d", liteQuota, dlpc.liteSubscriptionManager.liteSubscriptionQuota)
 	}
 
-	if settings.maxLiteTopicSize != maxSize {
-		t.Errorf("expected max lite topic size %d, got %d", maxSize, settings.maxLiteTopicSize)
+	if dlpc.liteSubscriptionManager.maxLiteTopicSize != maxSize {
+		t.Errorf("expected max lite topic size %d, got %d", maxSize, dlpc.liteSubscriptionManager.maxLiteTopicSize)
 	}
 
 	if !settings.isFifo {
@@ -512,8 +512,8 @@ func TestLitePushConsumerSettings_toProtobuf(t *testing.T) {
 
 	settings := dlpc.litePushConsumerSettings
 
-	settings.liteSubscriptionQuota = 50
-	settings.maxLiteTopicSize = 512
+	dlpc.liteSubscriptionManager.liteSubscriptionQuota = 50
+	dlpc.liteSubscriptionManager.maxLiteTopicSize = 512
 
 	protobuf := settings.toProtobuf()
 
@@ -531,12 +531,13 @@ func TestLitePushConsumerSettings_toProtobuf(t *testing.T) {
 		t.Fatal("expected subscription to be set")
 	}
 
-	if subscription.Subscription.GetLiteSubscriptionQuota() != 50 {
-		t.Errorf("expected lite subscription quota 50, got %d", subscription.Subscription.GetLiteSubscriptionQuota())
+	// quota and maxLiteTopicSize are server-pushed only, never reported back
+	if subscription.Subscription.LiteSubscriptionQuota != nil {
+		t.Errorf("expected lite subscription quota to be unset, got %d", subscription.Subscription.GetLiteSubscriptionQuota())
 	}
 
-	if subscription.Subscription.GetMaxLiteTopicSize() != 512 {
-		t.Errorf("expected max lite topic size 512, got %d", subscription.Subscription.GetMaxLiteTopicSize())
+	if subscription.Subscription.MaxLiteTopicSize != nil {
+		t.Errorf("expected max lite topic size to be unset, got %d", subscription.Subscription.GetMaxLiteTopicSize())
 	}
 
 	entry := subscription.Subscription.GetSubscriptions()[0]

--- a/golang/lite_simple_consumer.go
+++ b/golang/lite_simple_consumer.go
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package golang
+
+import (
+	"errors"
+
+	v2 "github.com/apache/rocketmq-clients/golang/v5/protocol/v2"
+)
+
+// LiteSimpleConsumer is similar to SimpleConsumer, but for lite topic.
+type LiteSimpleConsumer interface {
+	SimpleConsumer
+	SubscribeLite(liteTopic string, offsetOption ...OffsetOption) error
+	UnSubscribeLite(liteTopic string) error
+	GetLiteTopicSet() []string
+}
+
+var _ = LiteSimpleConsumer(&defaultLiteSimpleConsumer{})
+
+type defaultLiteSimpleConsumer struct {
+	*defaultSimpleConsumer
+	liteSimpleConsumerSettings *liteSimpleConsumerSettings
+	liteSubscriptionManager    *liteSubscriptionManager
+}
+
+type LiteSimpleConsumerConfig struct {
+	bindTopic string
+}
+
+func NewLiteSimpleConsumerConfig(bindTopic string) *LiteSimpleConsumerConfig {
+	return &LiteSimpleConsumerConfig{
+		bindTopic: bindTopic,
+	}
+}
+
+var NewLiteSimpleConsumer = func(config *Config, liteConfig *LiteSimpleConsumerConfig, opts ...SimpleConsumerOption) (LiteSimpleConsumer, error) {
+	if liteConfig == nil {
+		return nil, errors.New("LiteSimpleConsumerConfig is required")
+	}
+	if liteConfig.bindTopic == "" {
+		return nil, errors.New("LiteSimpleConsumerConfig.bindTopic is required")
+	}
+	// Default subscription: (bindTopic, *) for code reuse.
+	filterExpressionMap := map[string]*FilterExpression{
+		liteConfig.bindTopic: SUB_ALL,
+	}
+	opts = append(opts, WithSimpleSubscriptionExpressions(filterExpressionMap))
+	if simpleConsumer, err := newSimpleConsumer(config, opts...); err != nil {
+		return nil, err
+	} else {
+		lscSettings := newLiteSimpleConsumerSettings(simpleConsumer.scSettings, liteConfig.bindTopic)
+		simpleConsumer.scSettings.clientType = v2.ClientType_LITE_SIMPLE_CONSUMER
+		simpleConsumer.cli.settings = lscSettings
+		lsc := &defaultLiteSimpleConsumer{
+			defaultSimpleConsumer:      simpleConsumer,
+			liteSimpleConsumerSettings: lscSettings,
+		}
+		lsc.liteSubscriptionManager = newLiteSubscriptionManager(lsc,
+			liteConfig.bindTopic, lscSettings.groupName, simpleConsumer.cli.config.NameSpace)
+		lscSettings.liteSubscriptionManager = lsc.liteSubscriptionManager
+		return lsc, nil
+	}
+}
+
+func (lsc *defaultLiteSimpleConsumer) Start() error {
+	if err := lsc.defaultSimpleConsumer.Start(); err != nil {
+		return err
+	}
+	lsc.defaultSimpleConsumer.cli.notifyUnsubscribeLiteFunc = lsc.liteSubscriptionManager.onNotifyUnsubscribeLiteCommand
+	lsc.liteSubscriptionManager.startUp()
+	return nil
+}
+
+func (lsc *defaultLiteSimpleConsumer) SubscribeLite(liteTopic string, offsetOption ...OffsetOption) error {
+	return lsc.liteSubscriptionManager.subscribeLite(liteTopic, offsetOption...)
+}
+
+func (lsc *defaultLiteSimpleConsumer) UnSubscribeLite(liteTopic string) error {
+	return lsc.liteSubscriptionManager.unsubscribeLite(liteTopic)
+}
+
+func (lsc *defaultLiteSimpleConsumer) GetLiteTopicSet() []string {
+	return lsc.liteSubscriptionManager.getLiteTopicSet()
+}

--- a/golang/lite_simple_consumer_options.go
+++ b/golang/lite_simple_consumer_options.go
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package golang
+
+import (
+	"fmt"
+	"time"
+
+	v2 "github.com/apache/rocketmq-clients/golang/v5/protocol/v2"
+)
+
+var _ = ClientSettings(&liteSimpleConsumerSettings{})
+
+type liteSimpleConsumerSettings struct {
+	*simpleConsumerSettings
+	bindTopic               string
+	liteSubscriptionManager *liteSubscriptionManager
+}
+
+func newLiteSimpleConsumerSettings(settings *simpleConsumerSettings, bindTopic string) *liteSimpleConsumerSettings {
+	return &liteSimpleConsumerSettings{
+		simpleConsumerSettings: settings,
+		bindTopic:              bindTopic,
+	}
+}
+
+// GetAccessPoint implements ClientSettings
+func (lsc *liteSimpleConsumerSettings) GetAccessPoint() *v2.Endpoints {
+	return lsc.simpleConsumerSettings.endpoints
+}
+
+// GetClientID implements ClientSettings
+func (lsc *liteSimpleConsumerSettings) GetClientID() string {
+	return lsc.simpleConsumerSettings.clientId
+}
+
+// GetClientType implements ClientSettings
+func (lsc *liteSimpleConsumerSettings) GetClientType() v2.ClientType {
+	return lsc.simpleConsumerSettings.clientType
+}
+
+// GetRequestTimeout implements ClientSettings
+func (lsc *liteSimpleConsumerSettings) GetRequestTimeout() time.Duration {
+	return lsc.simpleConsumerSettings.requestTimeout
+}
+
+// GetRetryPolicy implements ClientSettings
+func (lsc *liteSimpleConsumerSettings) GetRetryPolicy() *v2.RetryPolicy {
+	return lsc.simpleConsumerSettings.retryPolicy
+}
+
+// applySettingsCommand implements ClientSettings
+func (lsc *liteSimpleConsumerSettings) applySettingsCommand(settings *v2.Settings) error {
+	if lsc.simpleConsumerSettings.applySettingsCommand(settings) != nil {
+		sugarBaseLogger.Warnf("liteSimpleConsumerSettings applySettingsCommand failed")
+		return fmt.Errorf("liteSimpleConsumerSettings applySettingsCommand failed")
+	}
+	// Delegate subscription settings (quota, max topic size) to the manager
+	if lsc.liteSubscriptionManager != nil {
+		lsc.liteSubscriptionManager.sync(settings.GetSubscription())
+	}
+	return nil
+}
+
+// toProtobuf implements ClientSettings
+func (lsc *liteSimpleConsumerSettings) toProtobuf() *v2.Settings {
+	return lsc.simpleConsumerSettings.toProtobuf()
+}

--- a/golang/lite_simple_consumer_test.go
+++ b/golang/lite_simple_consumer_test.go
@@ -1,0 +1,646 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package golang
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	v2 "github.com/apache/rocketmq-clients/golang/v5/protocol/v2"
+	"github.com/golang/mock/gomock"
+)
+
+func createTestLiteSimpleConsumer(t *testing.T) (*defaultLiteSimpleConsumer, error) {
+	config := &Config{Endpoint: fakeAddress, NameSpace: "test-namespace", ConsumerGroup: "test-group"}
+	liteConfig := &LiteSimpleConsumerConfig{bindTopic: "bind-topic"}
+
+	lsc, err := NewLiteSimpleConsumer(config, liteConfig, WithSimpleAwaitDuration(time.Second*5))
+	if err != nil {
+		return nil, err
+	}
+
+	dlsc := lsc.(*defaultLiteSimpleConsumer)
+
+	dlsc.cli.on.Store(true)
+
+	mockedClientManager := &mockedClientManager{
+		mockRpcClient: mockRpcClient,
+	}
+
+	dlsc.cli.clientManager = mockedClientManager
+
+	if dlsc.cli != dlsc.defaultSimpleConsumer.cli {
+		t.Errorf("Expected dlsc.cli and dlsc.defaultSimpleConsumer.cli to be the same instance")
+	}
+
+	return dlsc, nil
+}
+
+func TestNewLiteSimpleConsumer(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	config := &Config{Endpoint: fakeAddress, NameSpace: "test-namespace", ConsumerGroup: "test-group"}
+
+	liteConfig := NewLiteSimpleConsumerConfig("bind-topic")
+	lsc, err := NewLiteSimpleConsumer(config, liteConfig)
+	if err != nil {
+		t.Fatalf("failed to create lite simple consumer: %v", err)
+	}
+
+	dlsc := lsc.(*defaultLiteSimpleConsumer)
+	if dlsc.liteSimpleConsumerSettings.bindTopic != "bind-topic" {
+		t.Errorf("expected bind topic 'bind-topic', got %s", dlsc.liteSimpleConsumerSettings.bindTopic)
+	}
+
+	if int32(dlsc.scSettings.clientType) != int32(v2.ClientType_LITE_SIMPLE_CONSUMER) {
+		t.Errorf("expected client type LITE_SIMPLE_CONSUMER, got %v", dlsc.scSettings.clientType)
+	}
+
+	// Default subscription: (bindTopic, *) for code reuse.
+	fe, ok := (*dlsc.subscriptionExpressions)["bind-topic"]
+	if !ok {
+		t.Fatal("expected default subscription for bind topic")
+	}
+	if fe.expression != SUB_ALL.expression || fe.expressionType != SUB_ALL.expressionType {
+		t.Errorf("expected default subscription SUB_ALL, got %+v", fe)
+	}
+
+	if _, ok := dlsc.cli.settings.(*liteSimpleConsumerSettings); !ok {
+		t.Errorf("expected client settings to be liteSimpleConsumerSettings, got %T", dlsc.cli.settings)
+	}
+
+	if dlsc.liteSimpleConsumerSettings.liteSubscriptionManager != dlsc.liteSubscriptionManager {
+		t.Error("expected settings and consumer to share the same liteSubscriptionManager")
+	}
+}
+
+func TestNewLiteSimpleConsumer_NilLiteConfig(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	config := &Config{Endpoint: fakeAddress, NameSpace: "test-namespace", ConsumerGroup: "test-group"}
+
+	_, err := NewLiteSimpleConsumer(config, nil)
+	if err == nil {
+		t.Fatal("expected error for nil lite config, got nil")
+	}
+
+	expectedError := "LiteSimpleConsumerConfig is required"
+	if err.Error() != expectedError {
+		t.Errorf("expected error '%s', got '%s'", expectedError, err.Error())
+	}
+}
+
+func TestNewLiteSimpleConsumer_EmptyBindTopic(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	config := &Config{Endpoint: fakeAddress, NameSpace: "test-namespace", ConsumerGroup: "test-group"}
+
+	liteConfig := &LiteSimpleConsumerConfig{bindTopic: ""}
+	_, err := NewLiteSimpleConsumer(config, liteConfig)
+	if err == nil {
+		t.Fatal("expected error for empty bind topic, got nil")
+	}
+
+	expectedError := "LiteSimpleConsumerConfig.bindTopic is required"
+	if err.Error() != expectedError {
+		t.Errorf("expected error '%s', got '%s'", expectedError, err.Error())
+	}
+}
+
+func TestLiteSimpleConsumer_SubscribeLite(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlsc, err := createTestLiteSimpleConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite simple consumer: %v", err)
+	}
+
+	mockRpcClient.EXPECT().SyncLiteSubscription(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req *v2.SyncLiteSubscriptionRequest) (*v2.SyncLiteSubscriptionResponse, error) {
+		if req.GetAction() != v2.LiteSubscriptionAction_PARTIAL_ADD {
+			t.Errorf("expected action PARTIAL_ADD, got %v", req.GetAction())
+		}
+		if req.GetTopic().GetName() != "bind-topic" {
+			t.Errorf("expected topic 'bind-topic', got %s", req.GetTopic().GetName())
+		}
+		if req.GetGroup().GetName() != "test-group" {
+			t.Errorf("expected group 'test-group', got %s", req.GetGroup().GetName())
+		}
+		if len(req.GetLiteTopicSet()) != 1 || req.GetLiteTopicSet()[0] != "lite-topic-1" {
+			t.Errorf("expected lite topic set ['lite-topic-1'], got %v", req.GetLiteTopicSet())
+		}
+		return setupSuccessResponse(), nil
+	}).Times(1)
+
+	err = dlsc.SubscribeLite("lite-topic-1")
+	if err != nil {
+		t.Fatalf("expected no error for SubscribeLite, got %v", err)
+	}
+
+	if _, exists := dlsc.liteSubscriptionManager.liteTopicSet.Load("lite-topic-1"); !exists {
+		t.Error("expected lite topic to be added to set")
+	}
+}
+
+func TestLiteSimpleConsumer_SubscribeLite_WithOffset(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlsc, err := createTestLiteSimpleConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite simple consumer: %v", err)
+	}
+
+	offsetOption, err := NewOffsetOptionWithOffset(100)
+	if err != nil {
+		t.Fatalf("failed to create offset option: %v", err)
+	}
+
+	mockRpcClient.EXPECT().SyncLiteSubscription(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req *v2.SyncLiteSubscriptionRequest) (*v2.SyncLiteSubscriptionResponse, error) {
+		if req.GetOffsetOption() == nil {
+			t.Fatal("expected offset option to be set")
+		}
+		if req.GetOffsetOption().GetOffset() != 100 {
+			t.Errorf("expected offset 100, got %d", req.GetOffsetOption().GetOffset())
+		}
+		return setupSuccessResponse(), nil
+	}).Times(1)
+
+	err = dlsc.SubscribeLite("lite-topic-1", offsetOption)
+	if err != nil {
+		t.Fatalf("expected no error for SubscribeLite with offset, got %v", err)
+	}
+}
+
+func TestLiteSimpleConsumer_SubscribeLite_NotRunning(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlsc, err := createTestLiteSimpleConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite simple consumer: %v", err)
+	}
+
+	dlsc.cli.on.Store(false)
+
+	err = dlsc.SubscribeLite("lite-topic-1")
+	if err == nil {
+		t.Fatal("expected error when consumer not running")
+	}
+
+	expectedErrorPrefix := "client not running, clientId="
+	if !strings.HasPrefix(err.Error(), expectedErrorPrefix) {
+		t.Errorf("expected error prefix '%s', got '%s'", expectedErrorPrefix, err.Error())
+	}
+}
+
+func TestLiteSimpleConsumer_SubscribeLite_RpcError(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlsc, err := createTestLiteSimpleConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite simple consumer: %v", err)
+	}
+
+	mockRpcClient.EXPECT().SyncLiteSubscription(gomock.Any(), gomock.Any()).Return(nil, errors.New("rpc error"))
+
+	err = dlsc.SubscribeLite("lite-topic-1")
+	if err == nil {
+		t.Fatal("expected rpc error")
+	}
+
+	if _, exists := dlsc.liteSubscriptionManager.liteTopicSet.Load("lite-topic-1"); exists {
+		t.Error("lite topic should not be added when rpc fails")
+	}
+}
+
+func TestLiteSimpleConsumer_UnSubscribeLite(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlsc, err := createTestLiteSimpleConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite simple consumer: %v", err)
+	}
+
+	dlsc.liteSubscriptionManager.liteTopicSet.Store("lite-topic-1", struct{}{})
+
+	mockRpcClient.EXPECT().SyncLiteSubscription(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req *v2.SyncLiteSubscriptionRequest) (*v2.SyncLiteSubscriptionResponse, error) {
+		if req.GetAction() != v2.LiteSubscriptionAction_PARTIAL_REMOVE {
+			t.Errorf("expected action PARTIAL_REMOVE, got %v", req.GetAction())
+		}
+		if len(req.GetLiteTopicSet()) != 1 || req.GetLiteTopicSet()[0] != "lite-topic-1" {
+			t.Errorf("expected lite topic set ['lite-topic-1'], got %v", req.GetLiteTopicSet())
+		}
+		return setupSuccessResponse(), nil
+	})
+
+	err = dlsc.UnSubscribeLite("lite-topic-1")
+	if err != nil {
+		t.Fatalf("expected no error for UnSubscribeLite, got %v", err)
+	}
+
+	if _, exists := dlsc.liteSubscriptionManager.liteTopicSet.Load("lite-topic-1"); exists {
+		t.Error("expected lite topic to be removed from set")
+	}
+}
+
+func TestLiteSimpleConsumer_GetLiteTopicSet(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlsc, err := createTestLiteSimpleConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite simple consumer: %v", err)
+	}
+
+	dlsc.liteSubscriptionManager.liteTopicSet.Store("lite-topic-1", struct{}{})
+	dlsc.liteSubscriptionManager.liteTopicSet.Store("lite-topic-2", struct{}{})
+
+	topics := dlsc.GetLiteTopicSet()
+	if len(topics) != 2 {
+		t.Errorf("expected 2 lite topics, got %d", len(topics))
+	}
+}
+
+func TestLiteSimpleConsumer_notifyUnsubscribeLite(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlsc, err := createTestLiteSimpleConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite simple consumer: %v", err)
+	}
+
+	dlsc.liteSubscriptionManager.liteTopicSet.Store("lite-topic-notify", struct{}{})
+
+	cmd := &v2.NotifyUnsubscribeLiteCommand{
+		LiteTopic: "lite-topic-notify",
+	}
+
+	dlsc.liteSubscriptionManager.onNotifyUnsubscribeLiteCommand(cmd)
+
+	if _, exists := dlsc.liteSubscriptionManager.liteTopicSet.Load("lite-topic-notify"); exists {
+		t.Error("expected lite topic to be removed from set after notify")
+	}
+}
+
+func TestLiteSimpleConsumer_wrapHeartbeatRequest(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlsc, err := createTestLiteSimpleConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite simple consumer: %v", err)
+	}
+
+	req := dlsc.wrapHeartbeatRequest()
+
+	if req.GetGroup().GetName() != "test-group" {
+		t.Errorf("expected group name 'test-group', got %s", req.GetGroup().GetName())
+	}
+
+	if req.GetGroup().GetResourceNamespace() != "test-namespace" {
+		t.Errorf("expected namespace 'test-namespace', got %s", req.GetGroup().GetResourceNamespace())
+	}
+
+	if int32(req.GetClientType()) != int32(v2.ClientType_LITE_SIMPLE_CONSUMER) {
+		t.Errorf("expected client type LITE_SIMPLE_CONSUMER, got %v", req.GetClientType())
+	}
+}
+
+func TestLiteSimpleConsumerSettings_applySettingsCommand(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlsc, err := createTestLiteSimpleConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite simple consumer: %v", err)
+	}
+
+	settings := dlsc.liteSimpleConsumerSettings
+
+	liteQuota := int32(100)
+	maxSize := int32(1024)
+
+	testSettings := &v2.Settings{
+		PubSub: &v2.Settings_Subscription{
+			Subscription: &v2.Subscription{
+				LiteSubscriptionQuota: &liteQuota,
+				MaxLiteTopicSize:      &maxSize,
+			},
+		},
+	}
+
+	err = settings.applySettingsCommand(testSettings)
+	if err != nil {
+		t.Fatalf("applySettingsCommand failed: %v", err)
+	}
+
+	if dlsc.liteSubscriptionManager.liteSubscriptionQuota != liteQuota {
+		t.Errorf("expected lite subscription quota %d, got %d", liteQuota, dlsc.liteSubscriptionManager.liteSubscriptionQuota)
+	}
+
+	if dlsc.liteSubscriptionManager.maxLiteTopicSize != maxSize {
+		t.Errorf("expected max lite topic size %d, got %d", maxSize, dlsc.liteSubscriptionManager.maxLiteTopicSize)
+	}
+}
+
+func TestLiteSimpleConsumerSettings_applySettingsCommand_InvalidPubSub(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlsc, err := createTestLiteSimpleConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite simple consumer: %v", err)
+	}
+
+	err = dlsc.liteSimpleConsumerSettings.applySettingsCommand(&v2.Settings{})
+	if err == nil {
+		t.Fatal("expected error for settings without subscription pubsub")
+	}
+}
+
+func TestLiteSimpleConsumerSettings_toProtobuf(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlsc, err := createTestLiteSimpleConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite simple consumer: %v", err)
+	}
+
+	protobuf := dlsc.liteSimpleConsumerSettings.toProtobuf()
+
+	if int32(protobuf.GetClientType()) != int32(v2.ClientType_LITE_SIMPLE_CONSUMER) {
+		t.Errorf("expected client type LITE_SIMPLE_CONSUMER, got %v", protobuf.GetClientType())
+	}
+
+	subscription, ok := protobuf.GetPubSub().(*v2.Settings_Subscription)
+	if !ok || subscription == nil {
+		t.Fatal("expected subscription to be set")
+	}
+
+	// quota and maxLiteTopicSize are server-pushed only, never reported back
+	if subscription.Subscription.LiteSubscriptionQuota != nil {
+		t.Errorf("expected lite subscription quota to be unset, got %d", subscription.Subscription.GetLiteSubscriptionQuota())
+	}
+
+	if subscription.Subscription.MaxLiteTopicSize != nil {
+		t.Errorf("expected max lite topic size to be unset, got %d", subscription.Subscription.GetMaxLiteTopicSize())
+	}
+
+	entry := subscription.Subscription.GetSubscriptions()[0]
+
+	if entry.GetTopic().GetName() != "bind-topic" {
+		t.Errorf("expected topic name 'bind-topic', got %s", entry.GetTopic().GetName())
+	}
+
+	if entry.GetTopic().GetResourceNamespace() != "test-namespace" {
+		t.Errorf("expected namespace 'test-namespace', got %s", entry.GetTopic().GetResourceNamespace())
+	}
+}
+
+func TestLiteSimpleConsumerSettings_Getters(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlsc, err := createTestLiteSimpleConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite simple consumer: %v", err)
+	}
+
+	settings := dlsc.liteSimpleConsumerSettings
+
+	if settings.GetClientID() != dlsc.cli.GetClientID() {
+		t.Errorf("expected client id %s, got %s", dlsc.cli.GetClientID(), settings.GetClientID())
+	}
+	if int32(settings.GetClientType()) != int32(v2.ClientType_LITE_SIMPLE_CONSUMER) {
+		t.Errorf("expected client type LITE_SIMPLE_CONSUMER, got %v", settings.GetClientType())
+	}
+	if settings.GetAccessPoint() != dlsc.scSettings.endpoints {
+		t.Error("expected access point to delegate to simple consumer settings")
+	}
+	if settings.GetRequestTimeout() != dlsc.scSettings.requestTimeout {
+		t.Errorf("expected request timeout %v, got %v", dlsc.scSettings.requestTimeout, settings.GetRequestTimeout())
+	}
+	if settings.GetRetryPolicy() != dlsc.scSettings.retryPolicy {
+		t.Error("expected retry policy to delegate to simple consumer settings")
+	}
+}
+
+func TestLiteSimpleConsumer_wrapAckMessageRequest_WithLiteTopic(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlsc, err := createTestLiteSimpleConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite simple consumer: %v", err)
+	}
+
+	mv := &MessageView{
+		messageId:     "msg-1",
+		topic:         "bind-topic",
+		liteTopic:     "lite-topic-1",
+		ReceiptHandle: "handle-1",
+	}
+
+	request := dlsc.wrapAckMessageRequest(mv)
+
+	entry := request.GetEntries()[0]
+	if entry.GetLiteTopic() != "lite-topic-1" {
+		t.Errorf("expected lite topic 'lite-topic-1' in ack entry, got %s", entry.GetLiteTopic())
+	}
+	if entry.GetMessageId() != "msg-1" {
+		t.Errorf("expected message id 'msg-1', got %s", entry.GetMessageId())
+	}
+	if entry.GetReceiptHandle() != "handle-1" {
+		t.Errorf("expected receipt handle 'handle-1', got %s", entry.GetReceiptHandle())
+	}
+}
+
+func TestSimpleConsumer_wrapAckMessageRequest_NoLiteTopic(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	config := &Config{Endpoint: fakeAddress, NameSpace: "test-namespace", ConsumerGroup: "test-group"}
+	sc, err := newSimpleConsumer(config)
+	if err != nil {
+		t.Fatalf("failed to create simple consumer: %v", err)
+	}
+
+	mv := &MessageView{
+		messageId:     "msg-1",
+		topic:         "normal-topic",
+		liteTopic:     "lite-topic-1",
+		ReceiptHandle: "handle-1",
+	}
+
+	request := sc.wrapAckMessageRequest(mv)
+
+	// normal simple consumer never carries lite topic even if the message has one
+	if request.GetEntries()[0].LiteTopic != nil {
+		t.Errorf("expected lite topic to be unset for simple consumer, got %s", request.GetEntries()[0].GetLiteTopic())
+	}
+}
+
+type captureChangeInvisibleClientManager struct {
+	*mockedClientManager
+	capturedRequest *v2.ChangeInvisibleDurationRequest
+}
+
+func (m *captureChangeInvisibleClientManager) ChangeInvisibleDuration(ctx context.Context, endpoints *v2.Endpoints, request *v2.ChangeInvisibleDurationRequest, duration time.Duration) (*v2.ChangeInvisibleDurationResponse, error) {
+	m.capturedRequest = request
+	return &v2.ChangeInvisibleDurationResponse{
+		Status:        &v2.Status{Code: v2.Code_OK},
+		ReceiptHandle: "new-handle",
+	}, nil
+}
+
+func TestLiteSimpleConsumer_ChangeInvisibleDuration_WithLiteTopic(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlsc, err := createTestLiteSimpleConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite simple consumer: %v", err)
+	}
+
+	captureManager := &captureChangeInvisibleClientManager{
+		mockedClientManager: &mockedClientManager{mockRpcClient: mockRpcClient},
+	}
+	dlsc.cli.clientManager = captureManager
+
+	mv := &MessageView{
+		messageId:     "msg-1",
+		topic:         "bind-topic",
+		liteTopic:     "lite-topic-1",
+		ReceiptHandle: "handle-1",
+		endpoints:     &v2.Endpoints{Scheme: v2.AddressScheme_IPv4},
+	}
+
+	err = dlsc.ChangeInvisibleDuration(mv, time.Second*30)
+	if err != nil {
+		t.Fatalf("expected no error for ChangeInvisibleDuration, got %v", err)
+	}
+
+	request := captureManager.capturedRequest
+	if request == nil {
+		t.Fatal("expected ChangeInvisibleDuration request to be captured")
+	}
+	if request.GetLiteTopic() != "lite-topic-1" {
+		t.Errorf("expected lite topic 'lite-topic-1', got %s", request.GetLiteTopic())
+	}
+	if !request.GetSuspend() {
+		t.Error("expected suspend to be true for lite consumer")
+	}
+	if mv.ReceiptHandle != "new-handle" {
+		t.Errorf("expected receipt handle updated to 'new-handle', got %s", mv.ReceiptHandle)
+	}
+}
+
+func buildTestMessageQueue(brokerId int32, permission v2.Permission) *v2.MessageQueue {
+	return &v2.MessageQueue{
+		Permission: permission,
+		Broker: &v2.Broker{
+			Name: "broker-test",
+			Id:   brokerId,
+		},
+	}
+}
+
+func TestLiteSimpleConsumer_filterTopicRouteData(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlsc, err := createTestLiteSimpleConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite simple consumer: %v", err)
+	}
+
+	writeOnlyMaster := buildTestMessageQueue(0, v2.Permission_WRITE)
+	readableSlave := buildTestMessageQueue(1, v2.Permission_READ_WRITE)
+	readableMaster := buildTestMessageQueue(0, v2.Permission_READ)
+	anotherReadableMaster := buildTestMessageQueue(0, v2.Permission_READ_WRITE)
+
+	queues := []*v2.MessageQueue{writeOnlyMaster, readableSlave, readableMaster, anotherReadableMaster}
+
+	// lite consumer keeps only the first readable master queue
+	filtered := dlsc.filterTopicRouteData(queues)
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 queue after filtering, got %d", len(filtered))
+	}
+	if filtered[0] != readableMaster {
+		t.Error("expected the first readable master queue to be kept")
+	}
+
+	// no readable master queue results in an empty route
+	filtered = dlsc.filterTopicRouteData([]*v2.MessageQueue{writeOnlyMaster, readableSlave})
+	if len(filtered) != 0 {
+		t.Errorf("expected empty route when no readable master queue, got %d", len(filtered))
+	}
+}
+
+func TestSimpleConsumer_filterTopicRouteData_NoFiltering(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	config := &Config{Endpoint: fakeAddress, NameSpace: "test-namespace", ConsumerGroup: "test-group"}
+	sc, err := newSimpleConsumer(config)
+	if err != nil {
+		t.Fatalf("failed to create simple consumer: %v", err)
+	}
+
+	queues := []*v2.MessageQueue{
+		buildTestMessageQueue(0, v2.Permission_WRITE),
+		buildTestMessageQueue(1, v2.Permission_READ_WRITE),
+	}
+
+	// normal simple consumer keeps the route untouched
+	filtered := sc.filterTopicRouteData(queues)
+	if len(filtered) != len(queues) {
+		t.Errorf("expected %d queues without filtering, got %d", len(queues), len(filtered))
+	}
+}
+
+func TestIsReadableMasterQueue(t *testing.T) {
+	cases := []struct {
+		name     string
+		queue    *v2.MessageQueue
+		expected bool
+	}{
+		{"read master", buildTestMessageQueue(0, v2.Permission_READ), true},
+		{"read-write master", buildTestMessageQueue(0, v2.Permission_READ_WRITE), true},
+		{"write-only master", buildTestMessageQueue(0, v2.Permission_WRITE), false},
+		{"readable slave", buildTestMessageQueue(1, v2.Permission_READ_WRITE), false},
+		{"none master", buildTestMessageQueue(0, v2.Permission_NONE), false},
+	}
+
+	for _, c := range cases {
+		if got := isReadableMasterQueue(c.queue); got != c.expected {
+			t.Errorf("case %s: expected %v, got %v", c.name, c.expected, got)
+		}
+	}
+}

--- a/golang/lite_subscription_manager.go
+++ b/golang/lite_subscription_manager.go
@@ -1,0 +1,268 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package golang
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/apache/rocketmq-clients/golang/v5/pkg/ticker"
+	"github.com/apache/rocketmq-clients/golang/v5/pkg/utils"
+	v2 "github.com/apache/rocketmq-clients/golang/v5/protocol/v2"
+)
+
+// clientCore is the consumer-side narrow view of a client implementation:
+// the methods are defined on the isClient contract, but the manager only
+// depends on the subset it actually needs.
+type clientCore interface {
+	isRunning() bool
+	getClient() *defaultClient
+	getRequestTimeout() time.Duration
+}
+
+// liteSubscriptionManager manages lite topic subscriptions, providing client-side
+// validation, quota enforcement, and multi-endpoint synchronization.
+type liteSubscriptionManager struct {
+	consumerImpl          clientCore
+	bindTopic             string
+	groupResource         *v2.Resource
+	namespace             string
+	liteTopicSet          sync.Map
+	liteSubscriptionQuota int32
+	maxLiteTopicSize      int32
+}
+
+func newLiteSubscriptionManager(consumer clientCore, bindTopic string, groupResource *v2.Resource, namespace string) *liteSubscriptionManager {
+	return &liteSubscriptionManager{
+		consumerImpl:          consumer,
+		bindTopic:             bindTopic,
+		groupResource:         groupResource,
+		namespace:             namespace,
+		liteSubscriptionQuota: 2000,
+		maxLiteTopicSize:      64,
+	}
+}
+
+func (m *liteSubscriptionManager) startUp() {
+	m.syncAllLiteSubscription() // syncAll after startup for subscribeLite("*")
+	ticker.Tick(m.syncAllLiteSubscription, time.Second*30, m.consumerImpl.getClient().done)
+}
+
+// sync applies server-pushed subscription settings (quota, max topic size).
+func (m *liteSubscriptionManager) sync(subscription *v2.Subscription) {
+	if subscription == nil {
+		sugarBaseLogger.Warnf("onSettingsCommand err = subscription is nil")
+		return
+	}
+	if subscription.LiteSubscriptionQuota != nil {
+		m.liteSubscriptionQuota = *subscription.LiteSubscriptionQuota
+	}
+	if subscription.MaxLiteTopicSize != nil {
+		m.maxLiteTopicSize = *subscription.MaxLiteTopicSize
+	}
+}
+
+func (m *liteSubscriptionManager) subscribeLite(liteTopic string, offsetOption ...OffsetOption) error {
+	if len(offsetOption) > 1 {
+		return errors.New("only one offset option is supported")
+	}
+	var option *OffsetOption
+	if len(offsetOption) == 1 {
+		option = &offsetOption[0]
+	}
+	if err := m.checkRunning(); err != nil {
+		return err
+	}
+	if _, loaded := m.liteTopicSet.Load(liteTopic); loaded {
+		return nil
+	}
+	if err := m.validateLiteTopic(liteTopic); err != nil {
+		return err
+	}
+	if err := m.checkLiteSubscriptionQuota(1); err != nil {
+		return err
+	}
+	if err := m.syncLiteSubscription(context.TODO(), v2.LiteSubscriptionAction_PARTIAL_ADD, []string{liteTopic}, option); err != nil {
+		sugarBaseLogger.Errorf("LitePushConsumer SubscribeLite liteTopic:%s err:%v", liteTopic, err)
+		return err
+	}
+	m.liteTopicSet.Store(liteTopic, struct{}{})
+	sugarBaseLogger.Infof("SubscribeLite %s, topic=%s, group=%s, clientId=%s",
+		liteTopic, m.bindTopic, m.groupResource.GetName(), m.consumerImpl.getClient().clientID)
+	return nil
+}
+
+func (m *liteSubscriptionManager) unsubscribeLite(liteTopic string) error {
+	if err := m.checkRunning(); err != nil {
+		return err
+	}
+	if _, loaded := m.liteTopicSet.Load(liteTopic); !loaded {
+		return nil
+	}
+	if err := m.syncLiteSubscription(context.TODO(), v2.LiteSubscriptionAction_PARTIAL_REMOVE, []string{liteTopic}, nil); err != nil {
+		sugarBaseLogger.Errorf("LitePushConsumer UnSubscribeLite liteTopic:%s err:%v", liteTopic, err)
+		return err
+	}
+	m.liteTopicSet.Delete(liteTopic)
+	sugarBaseLogger.Infof("UnsubscribeLite %s, topic=%s, group=%s, clientId=%s",
+		liteTopic, m.bindTopic, m.groupResource.GetName(), m.consumerImpl.getClient().clientID)
+	return nil
+}
+
+func (m *liteSubscriptionManager) onNotifyUnsubscribeLiteCommand(command *v2.NotifyUnsubscribeLiteCommand) {
+	liteTopic := command.LiteTopic
+	sugarBaseLogger.Infof("LitePushConsumer notifyUnsubscribeLite liteTopic:%s", liteTopic)
+	if liteTopic != "" {
+		m.liteTopicSet.Delete(liteTopic)
+	}
+}
+
+// getLiteTopicSet returns an immutable snapshot of current lite topics.
+func (m *liteSubscriptionManager) getLiteTopicSet() []string {
+	topics := make([]string, 0)
+	m.liteTopicSet.Range(func(key, value interface{}) bool {
+		if liteTopic, ok := key.(string); ok {
+			topics = append(topics, liteTopic)
+		}
+		return true
+	})
+	return topics
+}
+
+func (m *liteSubscriptionManager) syncAllLiteSubscription() {
+	if err := m.checkLiteSubscriptionQuota(0); err != nil {
+		sugarBaseLogger.Errorf("LitePushConsumer syncAllLiteSubscription quota check failed: %v", err)
+		return
+	}
+	liteTopics := m.getLiteTopicSet()
+	if err := m.syncLiteSubscription(context.TODO(), v2.LiteSubscriptionAction_COMPLETE_ADD, liteTopics, nil); err != nil {
+		sugarBaseLogger.Errorf("LitePushConsumer syncAllLiteSubscription:%v, err:%v", liteTopics, err)
+	}
+}
+
+func (m *liteSubscriptionManager) validateLiteTopic(liteTopic string) error {
+	if strings.TrimSpace(liteTopic) == "" {
+		return errors.New("liteTopic is blank")
+	}
+	if int32(len(liteTopic)) > m.maxLiteTopicSize {
+		return fmt.Errorf("liteTopic length exceeded max length %d, liteTopic: %s", m.maxLiteTopicSize, liteTopic)
+	}
+	return nil
+}
+
+func (m *liteSubscriptionManager) checkLiteSubscriptionQuota(delta int32) error {
+	currentSize := int32(len(m.getLiteTopicSet()))
+	if currentSize+delta > m.liteSubscriptionQuota {
+		return &ErrRpcStatus{
+			Code:    int32(v2.Code_LITE_SUBSCRIPTION_QUOTA_EXCEEDED),
+			Message: fmt.Sprintf("lite subscription quota exceeded %d", m.liteSubscriptionQuota),
+		}
+	}
+	return nil
+}
+
+func (m *liteSubscriptionManager) checkRunning() error {
+	if !m.consumerImpl.isRunning() {
+		err := fmt.Errorf("client not running, clientId=%s", m.consumerImpl.getClient().clientID)
+		sugarBaseLogger.Error(err.Error())
+		return err
+	}
+	return nil
+}
+
+// getRouteEndpoints extracts unique broker endpoints from the cached topic route data.
+func (m *liteSubscriptionManager) getRouteEndpoints() []*v2.Endpoints {
+	cli := m.consumerImpl.getClient()
+	item, ok := cli.router.Load(m.bindTopic)
+	if !ok {
+		return nil
+	}
+	queues, ok := item.([]*v2.MessageQueue)
+	if !ok {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var endpoints []*v2.Endpoints
+	for _, mq := range queues {
+		ep := mq.GetBroker().GetEndpoints()
+		key := utils.EndpointsToString(ep)
+		if !seen[key] {
+			seen[key] = true
+			endpoints = append(endpoints, ep)
+		}
+	}
+	return endpoints
+}
+
+func (m *liteSubscriptionManager) syncLiteSubscription(ctx context.Context, action v2.LiteSubscriptionAction, diff []string, offsetOption *OffsetOption) error {
+	request := &v2.SyncLiteSubscriptionRequest{
+		Action: action,
+		Topic: &v2.Resource{
+			Name:              m.bindTopic,
+			ResourceNamespace: m.namespace,
+		},
+		Group:        m.groupResource,
+		LiteTopicSet: diff,
+	}
+	if offsetOption != nil {
+		request.OffsetOption = offsetOption.toProtobuf()
+	}
+
+	clientId := m.consumerImpl.getClient().clientID
+	if action == v2.LiteSubscriptionAction_COMPLETE_ADD {
+		sugarBaseLogger.Infof("syncLiteSubscription action:%s, topic:%s, group:%s, clientId:%s, liteTopicCount:%d",
+			action, m.bindTopic, m.groupResource.GetName(), clientId, len(diff))
+	} else {
+		sugarBaseLogger.Infof("syncLiteSubscription action:%s, topic:%s, group:%s, clientId:%s, liteTopics:%v",
+			action, m.bindTopic, m.groupResource.GetName(), clientId, diff)
+	}
+
+	// Collect unique broker endpoints; fall back to accessPoint if no route data
+	cli := m.consumerImpl.getClient()
+	routeEndpoints := m.getRouteEndpoints()
+	if len(routeEndpoints) == 0 {
+		routeEndpoints = []*v2.Endpoints{cli.accessPoint}
+	}
+
+	timeout := m.consumerImpl.getRequestTimeout()
+
+	var firstErr error
+	for _, ep := range routeEndpoints {
+		signedCtx := cli.Sign(ctx)
+		resp, err := cli.clientManager.SyncLiteSubscription(signedCtx, ep, request, timeout)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if resp.GetStatus().GetCode() != v2.Code_OK {
+			if firstErr == nil {
+				firstErr = &ErrRpcStatus{
+					Code:    int32(resp.Status.GetCode()),
+					Message: resp.GetStatus().GetMessage(),
+				}
+			}
+		}
+	}
+	return firstErr
+}

--- a/golang/lite_subscription_manager_test.go
+++ b/golang/lite_subscription_manager_test.go
@@ -1,0 +1,487 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package golang
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	v2 "github.com/apache/rocketmq-clients/golang/v5/protocol/v2"
+	"github.com/golang/mock/gomock"
+)
+
+func TestLiteSubscriptionManager_SyncAllLiteSubscription(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+
+	m := dlpc.liteSubscriptionManager
+	m.liteTopicSet.Store("lite-topic-1", struct{}{})
+	m.liteTopicSet.Store("lite-topic-2", struct{}{})
+
+	mockRpcClient.EXPECT().SyncLiteSubscription(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req *v2.SyncLiteSubscriptionRequest) (*v2.SyncLiteSubscriptionResponse, error) {
+		if req.GetAction() != v2.LiteSubscriptionAction_COMPLETE_ADD {
+			t.Errorf("expected action COMPLETE_ADD, got %v", req.GetAction())
+		}
+		topics := req.GetLiteTopicSet()
+		if len(topics) != 2 {
+			t.Errorf("expected 2 lite topics, got %v", topics)
+		}
+		got := map[string]bool{}
+		for _, topic := range topics {
+			got[topic] = true
+		}
+		if !got["lite-topic-1"] || !got["lite-topic-2"] {
+			t.Errorf("expected full lite topic set, got %v", topics)
+		}
+		return setupSuccessResponse(), nil
+	}).Times(1)
+
+	m.syncAllLiteSubscription()
+}
+
+func TestLiteSubscriptionManager_SyncAllLiteSubscription_QuotaExceeded(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+
+	m := dlpc.liteSubscriptionManager
+	m.liteSubscriptionQuota = 1
+	m.liteTopicSet.Store("lite-topic-1", struct{}{})
+	m.liteTopicSet.Store("lite-topic-2", struct{}{})
+
+	// no EXPECT registered: any SyncLiteSubscription call would fail the test
+	m.syncAllLiteSubscription()
+}
+
+func TestLiteSubscriptionManager_StartUp(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+
+	mockRpcClient.EXPECT().SyncLiteSubscription(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req *v2.SyncLiteSubscriptionRequest) (*v2.SyncLiteSubscriptionResponse, error) {
+		if req.GetAction() != v2.LiteSubscriptionAction_COMPLETE_ADD {
+			t.Errorf("expected action COMPLETE_ADD on startUp, got %v", req.GetAction())
+		}
+		if len(req.GetLiteTopicSet()) != 0 {
+			t.Errorf("expected empty lite topic set on startUp, got %v", req.GetLiteTopicSet())
+		}
+		return setupSuccessResponse(), nil
+	}).Times(1)
+
+	dlpc.liteSubscriptionManager.startUp()
+	// stop the 30s ticker goroutine; no further sync should have happened
+	close(dlpc.cli.done)
+}
+
+func TestLiteSubscriptionManager_SyncLiteSubscription_MultiEndpointFirstErr(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+
+	queues := []*v2.MessageQueue{
+		{Broker: &v2.Broker{Endpoints: &v2.Endpoints{
+			Scheme:    v2.AddressScheme_IPv4,
+			Addresses: []*v2.Address{{Host: "127.0.0.1", Port: 80}},
+		}}},
+		{Broker: &v2.Broker{Endpoints: &v2.Endpoints{
+			Scheme:    v2.AddressScheme_IPv4,
+			Addresses: []*v2.Address{{Host: "127.0.0.2", Port: 81}},
+		}}},
+	}
+	dlpc.cli.router.Store("bind-topic", queues)
+
+	firstErr := errors.New("endpoint-1 down")
+	mockRpcClient.EXPECT().SyncLiteSubscription(gomock.Any(), gomock.Any()).Return(nil, firstErr).Times(1)
+	mockRpcClient.EXPECT().SyncLiteSubscription(gomock.Any(), gomock.Any()).Return(setupSuccessResponse(), nil).Times(1)
+
+	err = dlpc.liteSubscriptionManager.syncLiteSubscription(context.TODO(), v2.LiteSubscriptionAction_PARTIAL_ADD, []string{"lite-topic-1"}, nil)
+	if err == nil {
+		t.Fatal("expected first endpoint error to be returned")
+	}
+	if err.Error() != firstErr.Error() {
+		t.Errorf("expected first error '%v', got '%v'", firstErr, err)
+	}
+}
+
+func TestLiteSubscriptionManager_GetRouteEndpoints(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+	m := dlpc.liteSubscriptionManager
+
+	t.Run("no route data", func(t *testing.T) {
+		if endpoints := m.getRouteEndpoints(); endpoints != nil {
+			t.Errorf("expected nil endpoints without route data, got %v", endpoints)
+		}
+	})
+
+	t.Run("unexpected route type", func(t *testing.T) {
+		dlpc.cli.router.Store("bind-topic", "not-message-queues")
+		if endpoints := m.getRouteEndpoints(); endpoints != nil {
+			t.Errorf("expected nil endpoints for unexpected route type, got %v", endpoints)
+		}
+	})
+
+	t.Run("deduplicate endpoints", func(t *testing.T) {
+		sharedEndpoints := &v2.Endpoints{
+			Scheme:    v2.AddressScheme_IPv4,
+			Addresses: []*v2.Address{{Host: "127.0.0.1", Port: 80}},
+		}
+		otherEndpoints := &v2.Endpoints{
+			Scheme:    v2.AddressScheme_IPv4,
+			Addresses: []*v2.Address{{Host: "127.0.0.2", Port: 81}},
+		}
+		dlpc.cli.router.Store("bind-topic", []*v2.MessageQueue{
+			{Broker: &v2.Broker{Endpoints: sharedEndpoints}},
+			{Broker: &v2.Broker{Endpoints: sharedEndpoints}},
+			{Broker: &v2.Broker{Endpoints: otherEndpoints}},
+		})
+		endpoints := m.getRouteEndpoints()
+		if len(endpoints) != 2 {
+			t.Errorf("expected 2 unique endpoints after dedup, got %d", len(endpoints))
+		}
+	})
+}
+
+func TestLiteSubscriptionManager_ValidateLiteTopic(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+	m := dlpc.liteSubscriptionManager
+
+	if err := m.validateLiteTopic("   "); err == nil || err.Error() != "liteTopic is blank" {
+		t.Errorf("expected 'liteTopic is blank' error, got %v", err)
+	}
+
+	m.maxLiteTopicSize = 4
+	if err := m.validateLiteTopic("abcde"); err == nil || !strings.Contains(err.Error(), "exceeded max length 4") {
+		t.Errorf("expected max length exceeded error, got %v", err)
+	}
+	if err := m.validateLiteTopic("abcd"); err != nil {
+		t.Errorf("expected no error for topic within max length, got %v", err)
+	}
+}
+
+func TestLiteSubscriptionManager_SubscribeLite_QuotaExceeded(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+
+	m := dlpc.liteSubscriptionManager
+	m.liteSubscriptionQuota = 1
+	m.liteTopicSet.Store("lite-topic-1", struct{}{})
+
+	// no EXPECT registered: quota must be rejected before any RPC
+	err = dlpc.SubscribeLite("lite-topic-2")
+	if err == nil {
+		t.Fatal("expected quota exceeded error")
+	}
+	rpcErr, ok := err.(*ErrRpcStatus)
+	if !ok {
+		t.Fatalf("expected ErrRpcStatus, got %T", err)
+	}
+	if rpcErr.Code != int32(v2.Code_LITE_SUBSCRIPTION_QUOTA_EXCEEDED) {
+		t.Errorf("expected code LITE_SUBSCRIPTION_QUOTA_EXCEEDED, got %d", rpcErr.Code)
+	}
+}
+
+func TestLiteSubscriptionManager_SubscribeLite_MultipleOffsetOptions(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+
+	err = dlpc.SubscribeLite("lite-topic-1", LastOffset, MinOffset)
+	if err == nil || err.Error() != "only one offset option is supported" {
+		t.Errorf("expected 'only one offset option is supported' error, got %v", err)
+	}
+}
+
+func TestLiteSubscriptionManager_SubscribeLite_Duplicate(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+
+	dlpc.liteSubscriptionManager.liteTopicSet.Store("lite-topic-1", struct{}{})
+
+	// no EXPECT registered: duplicate subscribe must be a no-op without RPC
+	if err = dlpc.SubscribeLite("lite-topic-1"); err != nil {
+		t.Errorf("expected no error for duplicate subscribe, got %v", err)
+	}
+}
+
+func TestLiteSubscriptionManager_SubscribeLite_BlankTopic(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+
+	err = dlpc.SubscribeLite("  ")
+	if err == nil || err.Error() != "liteTopic is blank" {
+		t.Errorf("expected 'liteTopic is blank' error, got %v", err)
+	}
+}
+
+func TestLiteSubscriptionManager_UnsubscribeLite_NotSubscribed(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+
+	// no EXPECT registered: unsubscribing an unknown topic must be a no-op without RPC
+	if err = dlpc.UnSubscribeLite("unknown-topic"); err != nil {
+		t.Errorf("expected no error for unsubscribing unknown topic, got %v", err)
+	}
+}
+
+func TestLiteSubscriptionManager_UnsubscribeLite_NotRunning(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+
+	dlpc.cli.on.Store(false)
+
+	err = dlpc.UnSubscribeLite("lite-topic-1")
+	if err == nil || !strings.HasPrefix(err.Error(), "client not running, clientId=") {
+		t.Errorf("expected client not running error, got %v", err)
+	}
+}
+
+func TestLiteSubscriptionManager_UnsubscribeLite_RpcError(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+
+	dlpc.liteSubscriptionManager.liteTopicSet.Store("lite-topic-1", struct{}{})
+
+	mockRpcClient.EXPECT().SyncLiteSubscription(gomock.Any(), gomock.Any()).Return(nil, errors.New("rpc error"))
+
+	err = dlpc.UnSubscribeLite("lite-topic-1")
+	if err == nil {
+		t.Fatal("expected rpc error")
+	}
+	if _, exists := dlpc.liteSubscriptionManager.liteTopicSet.Load("lite-topic-1"); !exists {
+		t.Error("lite topic should be kept when rpc fails")
+	}
+}
+
+func TestLiteSubscriptionManager_Sync(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+	m := dlpc.liteSubscriptionManager
+
+	t.Run("nil subscription keeps defaults", func(t *testing.T) {
+		m.sync(nil)
+		if m.liteSubscriptionQuota != 2000 || m.maxLiteTopicSize != 64 {
+			t.Errorf("expected defaults kept, got quota=%d maxSize=%d", m.liteSubscriptionQuota, m.maxLiteTopicSize)
+		}
+	})
+
+	t.Run("nil fields keep previous values", func(t *testing.T) {
+		m.sync(&v2.Subscription{})
+		if m.liteSubscriptionQuota != 2000 || m.maxLiteTopicSize != 64 {
+			t.Errorf("expected previous values kept, got quota=%d maxSize=%d", m.liteSubscriptionQuota, m.maxLiteTopicSize)
+		}
+	})
+
+	t.Run("server pushed values applied", func(t *testing.T) {
+		quota := int32(100)
+		maxSize := int32(128)
+		m.sync(&v2.Subscription{
+			LiteSubscriptionQuota: &quota,
+			MaxLiteTopicSize:      &maxSize,
+		})
+		if m.liteSubscriptionQuota != quota || m.maxLiteTopicSize != maxSize {
+			t.Errorf("expected quota=%d maxSize=%d, got quota=%d maxSize=%d", quota, maxSize, m.liteSubscriptionQuota, m.maxLiteTopicSize)
+		}
+	})
+}
+
+func TestLitePushConsumer_GetLiteTopicSet(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+
+	dlpc.liteSubscriptionManager.liteTopicSet.Store("lite-topic-1", struct{}{})
+	// non-string keys must be skipped defensively
+	dlpc.liteSubscriptionManager.liteTopicSet.Store(42, struct{}{})
+
+	topics := dlpc.GetLiteTopicSet()
+	if len(topics) != 1 || topics[0] != "lite-topic-1" {
+		t.Errorf("expected ['lite-topic-1'], got %v", topics)
+	}
+}
+
+func TestNewLitePushConsumerConfig(t *testing.T) {
+	liteConfig := NewLitePushConsumerConfig("bind-topic", 30*time.Second)
+	if liteConfig.bindTopic != "bind-topic" {
+		t.Errorf("expected bind topic 'bind-topic', got %s", liteConfig.bindTopic)
+	}
+	if liteConfig.invisibleDuration != 30*time.Second {
+		t.Errorf("expected invisible duration 30s, got %v", liteConfig.invisibleDuration)
+	}
+}
+
+func TestLitePushConsumerSettings_applySettingsCommand_NilPubSub(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+
+	err = dlpc.litePushConsumerSettings.applySettingsCommand(&v2.Settings{})
+	if err == nil {
+		t.Fatal("expected error for settings without pubsub")
+	}
+}
+
+func TestPushConsumer_IsRunning_Stopping(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	dlpc, err := createTestLitePushConsumer(t)
+	if err != nil {
+		t.Fatalf("failed to create test lite push consumer: %v", err)
+	}
+
+	if !dlpc.isRunning() {
+		t.Error("expected isRunning true when client is on")
+	}
+	dlpc.stopping.Store(true)
+	if dlpc.isRunning() {
+		t.Error("expected isRunning false when stopping is in progress")
+	}
+}
+
+// clientCore contract tests: isRunning/getClient/getRequestTimeout moved down
+// from consumer implementations must stay consistent across client types.
+func TestClientCore_ProducerAccessors(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	p, err := NewProducer(&Config{Endpoint: fakeAddress})
+	if err != nil {
+		t.Fatalf("failed to create producer: %v", err)
+	}
+	dp := p.(*defaultProducer)
+
+	if dp.getClient() != dp.cli {
+		t.Error("expected getClient to return the underlying client")
+	}
+	if dp.getRequestTimeout() != dp.pSetting.requestTimeout {
+		t.Error("expected getRequestTimeout to return producer settings request timeout")
+	}
+	// on is initialized to true at construction and turned off at shutdown
+	if !dp.isRunning() {
+		t.Error("expected isRunning true when client is on")
+	}
+	dp.cli.on.Store(false)
+	if dp.isRunning() {
+		t.Error("expected isRunning false when client is off")
+	}
+}
+
+func TestClientCore_SimpleConsumerAccessors(t *testing.T) {
+	setupTest(t)
+	defer teardownTest()
+
+	sc, err := NewSimpleConsumer(&Config{Endpoint: fakeAddress, ConsumerGroup: "test-group"})
+	if err != nil {
+		t.Fatalf("failed to create simple consumer: %v", err)
+	}
+	dsc := sc.(*defaultSimpleConsumer)
+
+	if dsc.getClient() != dsc.cli {
+		t.Error("expected getClient to return the underlying client")
+	}
+	if dsc.getRequestTimeout() != dsc.scSettings.requestTimeout {
+		t.Error("expected getRequestTimeout to return simple consumer settings request timeout")
+	}
+	// on is initialized to true at construction and turned off at shutdown
+	if !dsc.isRunning() {
+		t.Error("expected isRunning true when client is on")
+	}
+	dsc.cli.on.Store(false)
+	if dsc.isRunning() {
+		t.Error("expected isRunning false when client is off")
+	}
+}

--- a/golang/loadBalancer.go
+++ b/golang/loadBalancer.go
@@ -133,6 +133,14 @@ type SubscriptionLoadBalancer interface {
 	CopyAndUpdate([]*v2.MessageQueue) SubscriptionLoadBalancer
 }
 
+// isReadableMasterQueue checks if the message queue is readable and belongs to the master broker.
+func isReadableMasterQueue(mq *v2.MessageQueue) bool {
+	permission := mq.GetPermission()
+	readable := permission == v2.Permission_READ || permission == v2.Permission_READ_WRITE
+	// master broker id is 0
+	return readable && mq.GetBroker().GetId() == 0
+}
+
 type subscriptionLoadBalancer struct {
 	messageQueues []*v2.MessageQueue
 

--- a/golang/producer.go
+++ b/golang/producer.go
@@ -73,6 +73,18 @@ func (p *defaultProducer) isOn() bool {
 	return p.cli.on.Load()
 }
 
+func (p *defaultProducer) isRunning() bool {
+	return p.cli.isRunning()
+}
+
+func (p *defaultProducer) getClient() *defaultClient {
+	return p.cli
+}
+
+func (p *defaultProducer) getRequestTimeout() time.Duration {
+	return p.pSetting.requestTimeout
+}
+
 func (p *defaultProducer) wrapHeartbeatRequest() *v2.HeartbeatRequest {
 	return &v2.HeartbeatRequest{
 		ClientType: v2.ClientType_PRODUCER,

--- a/golang/push_consumer.go
+++ b/golang/push_consumer.go
@@ -83,6 +83,22 @@ func (pc *defaultPushConsumer) isOn() bool {
 	return pc.cli.on.Load()
 }
 
+func (pc *defaultPushConsumer) isRunning() bool {
+	// graceful stop in pushConsumer
+	if pc.stopping.Load() {
+		return false
+	}
+	return pc.cli.isRunning()
+}
+
+func (pc *defaultPushConsumer) getClient() *defaultClient {
+	return pc.cli
+}
+
+func (pc *defaultPushConsumer) getRequestTimeout() time.Duration {
+	return pc.pcSettings.requestTimeout
+}
+
 func (pc *defaultPushConsumer) changeInvisibleDuration0(context context.Context, messageView *MessageView, invisibleDuration time.Duration) (*v2.ChangeInvisibleDurationResponse, error) {
 	endpoints := messageView.endpoints
 	if endpoints == nil {
@@ -654,14 +670,6 @@ func (pc *defaultPushConsumer) forwardMessageToDeadLetterQueue0(ctx context.Cont
 	request := pc.wrapForwardMessageToDeadLetterQueueRequest(messageView)
 	ctx = pc.cli.Sign(ctx)
 	return pc.cli.clientManager.ForwardMessageToDeadLetterQueue(ctx, endpoints, request, pc.cli.opts.timeout)
-}
-
-func (pc *defaultPushConsumer) isRunning() bool {
-	// graceful stop in pushConsumer
-	if pc.stopping.Load() {
-		return false
-	}
-	return pc.cli.isRunning()
 }
 
 func (pc *defaultPushConsumer) getQueueSize() int32 {

--- a/golang/simple_consumer.go
+++ b/golang/simple_consumer.go
@@ -71,6 +71,18 @@ func (sc *defaultSimpleConsumer) isOn() bool {
 	return sc.cli.on.Load()
 }
 
+func (sc *defaultSimpleConsumer) isRunning() bool {
+	return sc.cli.isRunning()
+}
+
+func (sc *defaultSimpleConsumer) getClient() *defaultClient {
+	return sc.cli
+}
+
+func (sc *defaultSimpleConsumer) getRequestTimeout() time.Duration {
+	return sc.scSettings.requestTimeout
+}
+
 func (sc *defaultSimpleConsumer) changeInvisibleDuration0(messageView *MessageView, invisibleDuration time.Duration) (*v2.ChangeInvisibleDurationResponse, error) {
 	endpoints := messageView.endpoints
 	if endpoints == nil {
@@ -93,6 +105,14 @@ func (sc *defaultSimpleConsumer) changeInvisibleDuration0(messageView *MessageVi
 		InvisibleDuration: durationpb.New(invisibleDuration),
 		MessageId:         messageView.GetMessageId(),
 	}
+
+	// Set LiteTopic only for lite consumer
+	if messageView.GetLiteTopic() != "" && sc.scSettings.GetClientType() == v2.ClientType_LITE_SIMPLE_CONSUMER {
+		request.LiteTopic = &messageView.liteTopic
+		suspend := true
+		request.Suspend = &suspend
+	}
+
 	watchTime := time.Now()
 	resp, err := sc.cli.clientManager.ChangeInvisibleDuration(ctx, endpoints, request, sc.scSettings.requestTimeout)
 	duration := time.Since(watchTime)
@@ -190,18 +210,23 @@ func (sc *defaultSimpleConsumer) wrapReceiveMessageRequest(batchSize int, messag
 }
 
 func (sc *defaultSimpleConsumer) wrapAckMessageRequest(messageView *MessageView) *v2.AckMessageRequest {
+	entry := &v2.AckMessageEntry{
+		MessageId:     messageView.GetMessageId(),
+		ReceiptHandle: messageView.GetReceiptHandle(),
+	}
+
+	// Set LiteTopic only for lite consumer
+	if messageView.GetLiteTopic() != "" && sc.scSettings.GetClientType() == v2.ClientType_LITE_SIMPLE_CONSUMER {
+		entry.LiteTopic = &messageView.liteTopic
+	}
+
 	return &v2.AckMessageRequest{
 		Group: sc.scSettings.groupName,
 		Topic: &v2.Resource{
 			Name:              messageView.GetTopic(),
 			ResourceNamespace: sc.cli.config.NameSpace,
 		},
-		Entries: []*v2.AckMessageEntry{
-			{
-				MessageId:     messageView.GetMessageId(),
-				ReceiptHandle: messageView.GetReceiptHandle(),
-			},
-		},
+		Entries: []*v2.AckMessageEntry{entry},
 	}
 }
 
@@ -347,11 +372,15 @@ func (sc *defaultSimpleConsumer) onVerifyMessageCommand(endpoints *v2.Endpoints,
 func (sc *defaultSimpleConsumer) wrapHeartbeatRequest() *v2.HeartbeatRequest {
 	return &v2.HeartbeatRequest{
 		Group:      sc.scSettings.groupName,
-		ClientType: v2.ClientType_SIMPLE_CONSUMER,
+		ClientType: sc.scSettings.clientType,
 	}
 }
 
 var NewSimpleConsumer = func(config *Config, opts ...SimpleConsumerOption) (SimpleConsumer, error) {
+	return newSimpleConsumer(config, opts...)
+}
+
+var newSimpleConsumer = func(config *Config, opts ...SimpleConsumerOption) (*defaultSimpleConsumer, error) {
 	copyOpt := defaultSimpleConsumerOptions
 	scOpts := &copyOpt
 	for _, opt := range opts {
@@ -430,12 +459,27 @@ func (sc *defaultSimpleConsumer) getSubscriptionTopicRouteResult(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	route = sc.filterTopicRouteData(route)
 	slb, err := NewSubscriptionLoadBalancer(route)
 	if err != nil {
 		return nil, err
 	}
 	sc.subTopicRouteDataResultCache.Store(topic, slb)
 	return slb, nil
+}
+
+// filterTopicRouteData keeps only the first readable master queue for lite consumers,
+// since lite consumers only need routes to brokers.
+func (sc *defaultSimpleConsumer) filterTopicRouteData(messageQueues []*v2.MessageQueue) []*v2.MessageQueue {
+	if sc.scSettings.GetClientType() != v2.ClientType_LITE_SIMPLE_CONSUMER {
+		return messageQueues
+	}
+	for _, mq := range messageQueues {
+		if isReadableMasterQueue(mq) {
+			return []*v2.MessageQueue{mq}
+		}
+	}
+	return []*v2.MessageQueue{}
 }
 
 // Ack implements SimpleConsumer


### PR DESCRIPTION
### Summary

Introduce `LiteSimpleConsumer` for consuming lite topic messages in pull mode, and extract the lite subscription logic shared with `LitePushConsumer` into a reusable `liteSubscriptionManager`.

### Changes

- Add `LiteSimpleConsumer` interface and implementation with `SubscribeLite` / `UnSubscribeLite` / `GetLiteTopicSet`
- Extract `liteSubscriptionManager` (subscribe/unsubscribe, periodic full sync every 30s, server-side unsubscribe notification) shared by lite push/simple consumers
- Carry `LiteTopic` in Ack and ChangeInvisibleDuration requests for lite simple consumer
- Filter topic route to a single readable master queue for lite simple consumer
- Report actual client type in heartbeat instead of hardcoded `SIMPLE_CONSUMER`

### How Did You Test This Change?

- Unit tests: `lite_simple_consumer_test.go`, `lite_subscription_manager_test.go` (all pass)
- Manual end-to-end verification of lite topic message send/receive/ack