### PR TITLE
[ISSUE #1321] [Java] Preserve attempt ID until messages are received

### DIFF
--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImpl.java
@@ -32,7 +32,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
-import io.grpc.StatusRuntimeException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -251,6 +250,9 @@ class ProcessQueueImpl implements ProcessQueue {
             Futures.addCallback(future, new FutureCallback<ReceiveMessageResult>() {
                     @Override
                     public void onSuccess(ReceiveMessageResult result) {
+                        // Rotate the attempt ID based on the raw response because messages removed by an interceptor
+                        // were still delivered by the server for this attempt.
+                        final boolean hasReceivedMessages = !result.getMessageViewImpls().isEmpty();
                         // Intercept after message reception.
                         final List<GeneralMessage> generalMessages = result.getMessageViewImpls().stream()
                             .map((Function<MessageView, GeneralMessage>) GeneralMessageImpl::new)
@@ -298,35 +300,29 @@ class ProcessQueueImpl implements ProcessQueue {
                                 // Create new ReceiveMessageResult with filtered messages.
                                 ReceiveMessageResult filteredResult =
                                     ReceiveMessageResult.createFilteredResult(result, remainingMessages);
-                                onReceiveMessageResult(filteredResult);
+                                onReceiveMessageResult(filteredResult, request.getAttemptId(), hasReceivedMessages);
                             } catch (Throwable t) {
                                 // Should never reach here.
                                 log.error("[Bug] Exception raised while handling receive result, mq={}, endpoints={}, "
                                     + "clientId={}", mq, endpoints, clientId, t);
-                                onReceiveMessageException(t, attemptId);
+                                onReceiveMessageException(t, request.getAttemptId());
                             }
                         } else {
                             // When filtering is disabled, use original result directly to avoid performance overhead.
                             try {
-                                onReceiveMessageResult(result);
+                                onReceiveMessageResult(result, request.getAttemptId(), hasReceivedMessages);
                             } catch (Throwable t) {
                                 // Should never reach here.
                                 log.error("[Bug] Exception raised while handling receive result, mq={}, endpoints={}, "
                                     + "clientId={}", mq, endpoints, clientId, t);
-                                onReceiveMessageException(t, attemptId);
+                                onReceiveMessageException(t, request.getAttemptId());
                             }
                         }
                     }
 
                     @Override
                     public void onFailure(Throwable t) {
-                        String nextAttemptId = null;
-                        if (t instanceof StatusRuntimeException) {
-                            StatusRuntimeException exception = (StatusRuntimeException) t;
-                            if (io.grpc.Status.DEADLINE_EXCEEDED.getCode() == exception.getStatus().getCode()) {
-                                nextAttemptId = request.getAttemptId();
-                            }
-                        }
+                        final String nextAttemptId = request.getAttemptId();
                         // Intercept after message reception.
                         final MessageInterceptorContextImpl context0 =
                             new MessageInterceptorContextImpl(context, MessageHookPointsStatus.ERROR);
@@ -397,7 +393,7 @@ class ProcessQueueImpl implements ProcessQueue {
         return cachedMessagesBytes.get();
     }
 
-    private void onReceiveMessageResult(ReceiveMessageResult result) {
+    private void onReceiveMessageResult(ReceiveMessageResult result, String attemptId, boolean hasReceivedMessages) {
         final List<MessageViewImpl> messages = result.getMessageViewImpls();
         if (!messages.isEmpty()) {
             cacheMessages(messages);
@@ -405,7 +401,11 @@ class ProcessQueueImpl implements ProcessQueue {
             consumer.getReceivedMessagesQuantity().getAndAdd(messages.size());
             consumer.getConsumeService().consume(this, messages);
         }
-        receiveMessage();
+        if (hasReceivedMessages) {
+            receiveMessage();
+            return;
+        }
+        receiveMessage(attemptId);
     }
 
     private void evictCache(MessageViewImpl messageView) {

--- a/java/test/src/test/java/org/apache/rocketmq/test/client/AttemptIdIntegrationTest.java
+++ b/java/test/src/test/java/org/apache/rocketmq/test/client/AttemptIdIntegrationTest.java
@@ -20,9 +20,19 @@ package org.apache.rocketmq.test.client;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import apache.rocketmq.v2.Digest;
+import apache.rocketmq.v2.DigestType;
+import apache.rocketmq.v2.Encoding;
+import apache.rocketmq.v2.Message;
+import apache.rocketmq.v2.MessageType;
 import apache.rocketmq.v2.ReceiveMessageRequest;
 import apache.rocketmq.v2.ReceiveMessageResponse;
+import apache.rocketmq.v2.Resource;
+import apache.rocketmq.v2.SystemProperties;
+import com.google.protobuf.ByteString;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import java.nio.charset.StandardCharsets;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
@@ -36,6 +46,7 @@ import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
 import org.apache.rocketmq.client.apis.consumer.FilterExpression;
 import org.apache.rocketmq.client.apis.consumer.FilterExpressionType;
 import org.apache.rocketmq.client.apis.consumer.PushConsumer;
+import org.apache.rocketmq.client.java.message.MessageIdCodec;
 import org.apache.rocketmq.test.server.BaseMockServerImpl;
 import org.apache.rocketmq.test.server.GrpcServerIntegrationTest;
 import org.apache.rocketmq.test.server.MockServer;
@@ -46,7 +57,7 @@ public class AttemptIdIntegrationTest extends GrpcServerIntegrationTest {
     private final String topic = "topic";
     private MockServer serverImpl;
 
-     static class MockServerImpl extends BaseMockServerImpl {
+    static class MockServerImpl extends BaseMockServerImpl {
         public final List<String> attemptIdList = new CopyOnWriteArrayList<>();
         public final AtomicBoolean serverDeadlineFlag = new AtomicBoolean(true);
 
@@ -58,7 +69,7 @@ public class AttemptIdIntegrationTest extends GrpcServerIntegrationTest {
         public void receiveMessage(ReceiveMessageRequest request,
             StreamObserver<ReceiveMessageResponse> responseObserver) {
             // prevent too much request
-            if (attemptIdList.size() >= 3) {
+            if (attemptIdList.size() >= 5) {
                 try {
                     Thread.sleep(100);
                 } catch (InterruptedException e) {
@@ -68,10 +79,34 @@ public class AttemptIdIntegrationTest extends GrpcServerIntegrationTest {
             attemptIdList.add(request.getAttemptId());
             if (serverDeadlineFlag.compareAndSet(true, false)) {
                 // timeout
-            } else {
-                responseObserver.onNext(ReceiveMessageResponse.newBuilder().setStatus(mockStatus).build());
-                responseObserver.onCompleted();
+                return;
             }
+            if (attemptIdList.size() == 2) {
+                responseObserver.onError(Status.UNAVAILABLE.asRuntimeException());
+                return;
+            }
+            responseObserver.onNext(ReceiveMessageResponse.newBuilder().setStatus(mockStatus).build());
+            if (attemptIdList.size() == 4) {
+                responseObserver.onNext(ReceiveMessageResponse.newBuilder().setMessage(mockMessage()).build());
+            }
+            responseObserver.onCompleted();
+        }
+
+        private Message mockMessage() {
+            final Digest digest = Digest.newBuilder().setType(DigestType.CRC32).setChecksum("9EF61F95").build();
+            final SystemProperties systemProperties = SystemProperties.newBuilder()
+                .setMessageType(MessageType.NORMAL)
+                .setMessageId(MessageIdCodec.getInstance().nextMessageId().toString())
+                .setBornHost("127.0.0.1")
+                .setBodyDigest(digest)
+                .setBodyEncoding(Encoding.IDENTITY)
+                .setReceiptHandle("receipt-handle")
+                .build();
+            return Message.newBuilder()
+                .setTopic(Resource.newBuilder().setName(topic).build())
+                .setBody(ByteString.copyFrom("foobar", StandardCharsets.UTF_8))
+                .setSystemProperties(systemProperties)
+                .build();
         }
     }
 
@@ -83,7 +118,7 @@ public class AttemptIdIntegrationTest extends GrpcServerIntegrationTest {
     }
 
     @Test
-    public void test() throws Exception {
+    public void testAttemptIdIsRotatedOnlyAfterMessagesAreReceived() throws Exception {
         final ClientServiceProvider provider = ClientServiceProvider.loadService();
         String accessKey = "yourAccessKey";
         String secretKey = "yourSecretKey";
@@ -106,11 +141,13 @@ public class AttemptIdIntegrationTest extends GrpcServerIntegrationTest {
             .setMessageListener(messageView -> ConsumeResult.SUCCESS)
             .build();
         try {
-            await().atMost(java.time.Duration.ofSeconds(5)).untilAsserted(() -> {
+            await().atMost(java.time.Duration.ofSeconds(8)).untilAsserted(() -> {
                 List<String> attemptIdList = ((MockServerImpl) serverImpl).attemptIdList;
-                assertThat(attemptIdList.size()).isGreaterThanOrEqualTo(3);
+                assertThat(attemptIdList.size()).isGreaterThanOrEqualTo(5);
                 assertThat(attemptIdList.get(0)).isEqualTo(attemptIdList.get(1));
-                assertThat(attemptIdList.get(0)).isNotEqualTo(attemptIdList.get(2));
+                assertThat(attemptIdList.get(1)).isEqualTo(attemptIdList.get(2));
+                assertThat(attemptIdList.get(2)).isEqualTo(attemptIdList.get(3));
+                assertThat(attemptIdList.get(3)).isNotEqualTo(attemptIdList.get(4));
             });
         } finally {
             pushConsumer.close();


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #1321

### Brief Description

The Java push consumer previously generated a new receive attempt ID after every successful response, including an empty response, and preserved the current attempt ID only when a receive RPC failed with `DEADLINE_EXCEEDED`.

This change keeps the request attempt ID across:

- any failed receive RPC, regardless of the gRPC status; and
- a successful receive response that contains no messages.

A new attempt ID is generated only after the raw receive response contains at least one message. The check intentionally happens before message-interceptor filtering because the server has completed delivery even if the interceptor removes every returned message.

This allows a retry to recover a server-side receive result after a response is lost or one HTTP/2 receive stream is reset, which is especially important when the previous attempt owns FIFO order state.

The change is limited to `PushConsumer`. `SimpleConsumer` does not populate an attempt ID in its receive request, so its behavior is unchanged. ACK, redelivery, and delivery-attempt semantics are not changed, and this does not introduce exactly-once delivery.

### How Did You Test This Change?

Ran the Java test reactor on JDK 11, including compilation, Checkstyle, SpotBugs, and the updated integration test:

```shell
mvn -pl test -am -Dtest=AttemptIdIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Result: `BUILD SUCCESS`; `AttemptIdIntegrationTest` passed 1/1.

The integration test verifies one consecutive sequence of a deadline, a non-deadline transport failure, an empty response, and a response containing a message. The first four requests use the same attempt ID, and the request after the message response uses a new ID.

Also validated on Kubernetes with newly created NORMAL/FIFO topics and consumer groups and an external h2c proxy that resets only one `ReceiveMessage` HTTP/2 stream while preserving the TCP connection and unrelated streams:

- Old client: after `CANCELLED: RST_STREAM`, the next receive used a different attempt ID; in the reproduced FIFO lock case no callback occurred within 180 seconds.
- Modified client: the retry reused the same attempt ID, received the original FIFO message in about one second with `deliveryAttempt=1`, and acknowledged it successfully.
- A response blackhole ending in `DEADLINE_EXCEEDED` was used as a control; the old client already retained the attempt ID for that status.
