### PR TITLE
[Go] Fix round-robin load balancer always selecting the same queue

### DIFF
--- a/golang/loadBalancer.go
+++ b/golang/loadBalancer.go
@@ -73,7 +73,7 @@ func (plb *publishingLoadBalancer) TakeMessageQueues(excluded *sync.Map, count i
 	candidateBrokerNames := make(map[string]bool, 32)
 
 	for i := 0; i < len(plb.messageQueues); i++ {
-		idx := utils.Mod(next+i, len(plb.messageQueues))
+		idx := utils.Mod(next+int32(i), len(plb.messageQueues))
 		selectMessageQueue := plb.messageQueues[idx]
 		broker := selectMessageQueue.Broker
 		brokerName := broker.GetName()
@@ -102,7 +102,7 @@ func (plb *publishingLoadBalancer) TakeMessageQueues(excluded *sync.Map, count i
 	}
 	if len(candidates) == 0 {
 		for i := 0; i < len(plb.messageQueues); i++ {
-			idx := utils.Mod(next+i, len(plb.messageQueues))
+			idx := utils.Mod(next+int32(i), len(plb.messageQueues))
 			selectMessageQueue := plb.messageQueues[idx]
 			broker := selectMessageQueue.Broker
 			brokerName := broker.GetName()

--- a/golang/loadBalancer.go
+++ b/golang/loadBalancer.go
@@ -73,7 +73,7 @@ func (plb *publishingLoadBalancer) TakeMessageQueues(excluded *sync.Map, count i
 	candidateBrokerNames := make(map[string]bool, 32)
 
 	for i := 0; i < len(plb.messageQueues); i++ {
-		idx := utils.Mod(next+1, len(plb.messageQueues))
+		idx := utils.Mod(next+i, len(plb.messageQueues))
 		selectMessageQueue := plb.messageQueues[idx]
 		broker := selectMessageQueue.Broker
 		brokerName := broker.GetName()
@@ -102,7 +102,7 @@ func (plb *publishingLoadBalancer) TakeMessageQueues(excluded *sync.Map, count i
 	}
 	if len(candidates) == 0 {
 		for i := 0; i < len(plb.messageQueues); i++ {
-			idx := utils.Mod(next+1, len(plb.messageQueues))
+			idx := utils.Mod(next+i, len(plb.messageQueues))
 			selectMessageQueue := plb.messageQueues[idx]
 			broker := selectMessageQueue.Broker
 			brokerName := broker.GetName()


### PR DESCRIPTION
## Summary
- Fix a bug in `TakeMessageQueues` where the index calculation used `next+1` (constant) instead of `next+i` (loop-varying), causing every loop iteration to examine the same message queue
- This defeats the round-robin intent and prevents proper load distribution across brokers
- The same bug exists in both the main loop and the fallback loop

## Test plan
- [ ] Verify round-robin selection distributes across different queues
- [ ] Verify existing tests pass