### PR TITLE
[Java] Support batch acknowledgements for PushConsumer

### DIFF
--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/AckMessageBatcher.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/AckMessageBatcher.java
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.java.impl.consumer;
+
+import apache.rocketmq.v2.AckMessageResponse;
+import apache.rocketmq.v2.AckMessageResultEntry;
+import apache.rocketmq.v2.Code;
+import apache.rocketmq.v2.Status;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.rocketmq.client.java.message.MessageViewImpl;
+import org.apache.rocketmq.client.java.route.Endpoints;
+import org.apache.rocketmq.client.java.rpc.RpcFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Accumulates acknowledgements produced by one push consumer. A request can contain messages for only one topic and
+ * one endpoint, so each client-local batch is partitioned by these two fields.
+ */
+class AckMessageBatcher {
+    static final int MAX_BATCH_SIZE = 1024;
+    static final Duration MAX_BATCH_DELAY = Duration.ofSeconds(5);
+    static final Duration MAX_BATCHABLE_DURATION = Duration.ofSeconds(25);
+
+    private static final Logger log = LoggerFactory.getLogger(AckMessageBatcher.class);
+    private static final Status MISSING_RESULT_STATUS = Status.newBuilder()
+        .setCode(Code.INTERNAL_ERROR)
+        .setMessage("Batch acknowledgement response does not contain the message result")
+        .build();
+
+    private final PushConsumerImpl consumer;
+    private final ScheduledExecutorService scheduler;
+    private final int maxBatchSize;
+    private final Duration maxBatchDelay;
+
+    private final Object lock = new Object();
+    @GuardedBy("lock")
+    private final Map<BatchKey, Batch> batches = new LinkedHashMap<>();
+    @GuardedBy("lock")
+    private final Set<Batch> inflightBatches = new HashSet<>();
+    @GuardedBy("lock")
+    private boolean closed;
+
+    AckMessageBatcher(PushConsumerImpl consumer, ScheduledExecutorService scheduler) {
+        this(consumer, scheduler, MAX_BATCH_SIZE, MAX_BATCH_DELAY);
+    }
+
+    AckMessageBatcher(PushConsumerImpl consumer, ScheduledExecutorService scheduler, int maxBatchSize,
+        Duration maxBatchDelay) {
+        this.consumer = consumer;
+        this.scheduler = scheduler;
+        this.maxBatchSize = maxBatchSize;
+        this.maxBatchDelay = maxBatchDelay;
+    }
+
+    boolean isBatchable(MessageViewImpl messageView) {
+        if (consumer.isLiteConsumer()) {
+            return false;
+        }
+        final long elapsedMillis = System.currentTimeMillis() - messageView.getDecodeTimestamp();
+        return elapsedMillis >= 0 && elapsedMillis <= MAX_BATCHABLE_DURATION.toMillis();
+    }
+
+    /**
+     * @return a per-message response future, or {@code null} if the batcher is already closed.
+     */
+    ListenableFuture<AckMessageResponse> enqueue(MessageViewImpl messageView) {
+        final PendingAck pendingAck = new PendingAck(messageView);
+        Batch batchToFlush = null;
+        synchronized (lock) {
+            if (closed) {
+                return null;
+            }
+            final BatchKey key = new BatchKey(messageView.getEndpoints(), messageView.getTopic());
+            Batch batch = batches.get(key);
+            if (null == batch) {
+                batch = new Batch(key);
+                try {
+                    final Batch newBatch = batch;
+                    batch.flushFuture = scheduler.schedule(() -> flush(newBatch), maxBatchDelay.toNanos(),
+                        TimeUnit.NANOSECONDS);
+                } catch (Throwable t) {
+                    log.warn("Failed to schedule batch acknowledgement, topic={}, endpoints={}",
+                        messageView.getTopic(), messageView.getEndpoints(), t);
+                    return null;
+                }
+                batches.put(key, batch);
+            }
+            batch.pendingAcks.add(pendingAck);
+            if (batch.pendingAcks.size() >= maxBatchSize) {
+                batches.remove(key);
+                batch.flushFuture.cancel(false);
+                inflightBatches.add(batch);
+                batchToFlush = batch;
+            }
+        }
+        if (null != batchToFlush) {
+            send(batchToFlush);
+        }
+        return pendingAck.responseFuture;
+    }
+
+    private void flush(Batch batch) {
+        synchronized (lock) {
+            if (batches.get(batch.key) != batch) {
+                return;
+            }
+            batches.remove(batch.key);
+            inflightBatches.add(batch);
+        }
+        send(batch);
+    }
+
+    ListenableFuture<List<AckMessageResponse>> flushAndClose() {
+        final List<Batch> batchesToFlush;
+        final List<ListenableFuture<AckMessageResponse>> responseFuturesSnapshot;
+        synchronized (lock) {
+            closed = true;
+            batchesToFlush = new ArrayList<>(batches.values());
+            batches.clear();
+            for (Batch batch : batchesToFlush) {
+                batch.flushFuture.cancel(false);
+                inflightBatches.add(batch);
+            }
+            responseFuturesSnapshot = new ArrayList<>();
+            for (Batch batch : inflightBatches) {
+                for (PendingAck pendingAck : batch.pendingAcks) {
+                    responseFuturesSnapshot.add(pendingAck.responseFuture);
+                }
+            }
+        }
+        for (Batch batch : batchesToFlush) {
+            send(batch);
+        }
+        return Futures.allAsList(responseFuturesSnapshot);
+    }
+
+    private void send(Batch batch) {
+        final List<MessageViewImpl> messageViews = new ArrayList<>(batch.pendingAcks.size());
+        for (PendingAck pendingAck : batch.pendingAcks) {
+            messageViews.add(pendingAck.messageView);
+        }
+        final RpcFuture<apache.rocketmq.v2.AckMessageRequest, AckMessageResponse> responseFuture =
+            consumer.ackMessage(messageViews);
+        Futures.addCallback(responseFuture, new FutureCallback<AckMessageResponse>() {
+            @Override
+            public void onSuccess(AckMessageResponse response) {
+                complete(batch.pendingAcks, response);
+                onBatchCompleted(batch);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                for (PendingAck pendingAck : batch.pendingAcks) {
+                    pendingAck.responseFuture.setException(t);
+                }
+                onBatchCompleted(batch);
+            }
+        }, MoreExecutors.directExecutor());
+    }
+
+    private void onBatchCompleted(Batch batch) {
+        synchronized (lock) {
+            inflightBatches.remove(batch);
+        }
+    }
+
+    private void complete(List<PendingAck> pendingAcks, AckMessageResponse response) {
+        if (response.getEntriesCount() == 0) {
+            final Status status = Code.OK.equals(response.getStatus().getCode())
+                ? MISSING_RESULT_STATUS : response.getStatus();
+            for (PendingAck pendingAck : pendingAcks) {
+                pendingAck.responseFuture.set(responseFor(pendingAck.messageView, status));
+            }
+            return;
+        }
+
+        final Map<String, Deque<AckMessageResultEntry>> resultTable = new HashMap<>();
+        for (AckMessageResultEntry entry : response.getEntriesList()) {
+            resultTable.computeIfAbsent(entry.getMessageId(), ignored -> new ArrayDeque<>()).add(entry);
+        }
+        for (PendingAck pendingAck : pendingAcks) {
+            final String messageId = pendingAck.messageView.getMessageId().toString();
+            final Deque<AckMessageResultEntry> results = resultTable.get(messageId);
+            final AckMessageResultEntry entry = null == results ? null : results.pollFirst();
+            if (null == entry) {
+                pendingAck.responseFuture.set(responseFor(pendingAck.messageView, MISSING_RESULT_STATUS));
+                continue;
+            }
+            pendingAck.responseFuture.set(AckMessageResponse.newBuilder()
+                .setStatus(entry.getStatus())
+                .addEntries(entry)
+                .build());
+        }
+        final int extraResultCount = resultTable.values().stream().mapToInt(Collection::size).sum();
+        if (extraResultCount > 0) {
+            log.warn("Batch acknowledgement response contains {} unmatched entries, topic={}, endpoints={}",
+                extraResultCount, pendingAcks.get(0).messageView.getTopic(),
+                pendingAcks.get(0).messageView.getEndpoints());
+        }
+    }
+
+    private AckMessageResponse responseFor(MessageViewImpl messageView, Status status) {
+        final AckMessageResultEntry entry = AckMessageResultEntry.newBuilder()
+            .setMessageId(messageView.getMessageId().toString())
+            .setReceiptHandle(messageView.getReceiptHandle())
+            .setStatus(status)
+            .build();
+        return AckMessageResponse.newBuilder().setStatus(status).addEntries(entry).build();
+    }
+
+    private static class PendingAck {
+        private final MessageViewImpl messageView;
+        private final SettableFuture<AckMessageResponse> responseFuture = SettableFuture.create();
+
+        private PendingAck(MessageViewImpl messageView) {
+            this.messageView = messageView;
+        }
+    }
+
+    private static class Batch {
+        private final BatchKey key;
+        private final List<PendingAck> pendingAcks = new ArrayList<>();
+        private ScheduledFuture<?> flushFuture;
+
+        private Batch(BatchKey key) {
+            this.key = key;
+        }
+    }
+
+    private static class BatchKey {
+        private final Endpoints endpoints;
+        private final String topic;
+
+        private BatchKey(Endpoints endpoints, String topic) {
+            this.endpoints = endpoints;
+            this.topic = topic;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof BatchKey)) {
+                return false;
+            }
+            BatchKey batchKey = (BatchKey) o;
+            return Objects.equals(endpoints, batchKey.endpoints) && Objects.equals(topic, batchKey.topic);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * Objects.hashCode(endpoints) + Objects.hashCode(topic);
+        }
+    }
+}

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumerImpl.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.rocketmq.client.apis.ClientConfiguration;
 import org.apache.rocketmq.client.apis.consumer.FilterExpression;
 import org.apache.rocketmq.client.apis.message.MessageId;
@@ -124,20 +125,24 @@ public abstract class ConsumerImpl extends ClientImpl {
         }
     }
 
-    private AckMessageRequest wrapAckMessageRequest(MessageViewImpl messageView) {
+    private AckMessageRequest wrapAckMessageRequest(List<MessageViewImpl> messageViews) {
+        final MessageViewImpl firstMessageView = messageViews.get(0);
         final apache.rocketmq.v2.Resource topicResource = apache.rocketmq.v2.Resource.newBuilder()
             .setResourceNamespace(clientConfiguration.getNamespace())
-            .setName(messageView.getTopic())
+            .setName(firstMessageView.getTopic())
             .build();
-        final AckMessageEntry.Builder builder = AckMessageEntry.newBuilder()
-            .setMessageId(messageView.getMessageId().toString())
-            .setReceiptHandle(messageView.getReceiptHandle());
-        if (isLiteConsumer()) {
-            messageView.getLiteTopic().ifPresent(builder::setLiteTopic);
+        final AckMessageRequest.Builder requestBuilder = AckMessageRequest.newBuilder()
+            .setGroup(getProtobufGroup()).setTopic(topicResource);
+        for (MessageViewImpl messageView : messageViews) {
+            final AckMessageEntry.Builder entryBuilder = AckMessageEntry.newBuilder()
+                .setMessageId(messageView.getMessageId().toString())
+                .setReceiptHandle(messageView.getReceiptHandle());
+            if (isLiteConsumer()) {
+                messageView.getLiteTopic().ifPresent(entryBuilder::setLiteTopic);
+            }
+            requestBuilder.addEntries(entryBuilder.build());
         }
-        final AckMessageEntry entry = builder.build();
-        return AckMessageRequest.newBuilder().setGroup(getProtobufGroup()).setTopic(topicResource)
-            .addEntries(entry).build();
+        return requestBuilder.build();
     }
 
     protected ChangeInvisibleDurationRequest wrapChangeInvisibleDuration(MessageViewImpl messageView,
@@ -161,13 +166,19 @@ public abstract class ConsumerImpl extends ClientImpl {
     }
 
     protected RpcFuture<AckMessageRequest, AckMessageResponse> ackMessage(MessageViewImpl messageView) {
-        final Endpoints endpoints = messageView.getEndpoints();
+        return ackMessage(Collections.singletonList(messageView));
+    }
+
+    protected RpcFuture<AckMessageRequest, AckMessageResponse> ackMessage(List<MessageViewImpl> messageViews) {
+        final Endpoints endpoints = messageViews.get(0).getEndpoints();
         RpcFuture<AckMessageRequest, AckMessageResponse> future;
-        final List<GeneralMessage> generalMessages = Collections.singletonList(new GeneralMessageImpl(messageView));
+        final List<GeneralMessage> generalMessages = messageViews.stream()
+            .map(messageView -> (GeneralMessage) new GeneralMessageImpl(messageView))
+            .collect(Collectors.toList());
         final MessageInterceptorContextImpl context = new MessageInterceptorContextImpl(MessageHookPoints.ACK);
         doBefore(context, generalMessages);
         try {
-            final AckMessageRequest request = wrapAckMessageRequest(messageView);
+            final AckMessageRequest request = wrapAckMessageRequest(messageViews);
             final Duration requestTimeout = clientConfiguration.getRequestTimeout();
             future = this.getClientManager().ackMessage(endpoints, request, requestTimeout);
         } catch (Throwable t) {

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.rocketmq.client.java.impl.consumer;
 
-import apache.rocketmq.v2.AckMessageRequest;
 import apache.rocketmq.v2.AckMessageResponse;
 import apache.rocketmq.v2.ChangeInvisibleDurationRequest;
 import apache.rocketmq.v2.ChangeInvisibleDurationResponse;
@@ -546,7 +545,8 @@ class ProcessQueueImpl implements ProcessQueue {
         }
         ListenableFuture<Void> future;
         if (ConsumeResult.SUCCESS.equals(consumeResult)) {
-            future = ackMessage(messageView);
+            // FIFO acknowledgements are not delayed because the next message in the group depends on them.
+            future = ackMessage(messageView, false);
         } else if (consumeResult instanceof ConsumeResultSuspend) {
             ConsumeResultSuspend consumeResultSuspend = (ConsumeResultSuspend) consumeResult;
             log.info("Suspend consumption, consumerGroup={}, topic={}, liteTopic={}, messageId={}, result={}",
@@ -634,22 +634,27 @@ class ProcessQueueImpl implements ProcessQueue {
     }
 
     private ListenableFuture<Void> ackMessage(final MessageViewImpl messageView) {
+        return ackMessage(messageView, true);
+    }
+
+    private ListenableFuture<Void> ackMessage(final MessageViewImpl messageView, final boolean batchable) {
         SettableFuture<Void> future = SettableFuture.create();
-        ackMessage(messageView, 1, future);
+        ackMessage(messageView, 1, future, batchable);
         return future;
     }
 
-    private void ackMessage(final MessageViewImpl messageView, final int attempt, final SettableFuture<Void> future0) {
+    private void ackMessage(final MessageViewImpl messageView, final int attempt, final SettableFuture<Void> future0,
+        final boolean batchable) {
         final ClientId clientId = consumer.getClientId();
         final String consumerGroup = consumer.getConsumerGroup();
         final MessageId messageId = messageView.getMessageId();
         final Endpoints endpoints = messageView.getEndpoints();
-        final RpcFuture<AckMessageRequest, AckMessageResponse> future =
-            consumer.ackMessage(messageView);
+        final ListenableFuture<AckMessageResponse> future = batchable && attempt == 1
+            ? consumer.batchAckMessage(messageView) : consumer.ackMessage(messageView);
         Futures.addCallback(future, new FutureCallback<AckMessageResponse>() {
             @Override
             public void onSuccess(AckMessageResponse response) {
-                final String requestId = future.getContext().getRequestId();
+                final String requestId = getRequestId(future);
                 final Status status = response.getStatus();
                 final Code code = status.getCode();
                 if (Code.INVALID_RECEIPT_HANDLE.equals(code)) {
@@ -698,7 +703,7 @@ class ProcessQueueImpl implements ProcessQueue {
         final MessageId messageId = messageView.getMessageId();
         final ScheduledExecutorService scheduler = consumer.getScheduler();
         try {
-            scheduler.schedule(() -> ackMessage(messageView, attempt, future),
+            scheduler.schedule(() -> ackMessage(messageView, attempt, future, false),
                 ACK_MESSAGE_FAILURE_BACKOFF_DELAY.toNanos(), TimeUnit.NANOSECONDS);
         } catch (Throwable t) {
             if (scheduler.isShutdown()) {
@@ -709,6 +714,14 @@ class ProcessQueueImpl implements ProcessQueue {
                 mq, messageId, consumer.getClientId());
             ackMessageLater(messageView, 1 + attempt, future);
         }
+    }
+
+    private String getRequestId(ListenableFuture<AckMessageResponse> future) {
+        if (!(future instanceof RpcFuture)) {
+            return "-";
+        }
+        final org.apache.rocketmq.client.java.rpc.Context context = ((RpcFuture<?, ?>) future).getContext();
+        return null == context ? "-" : context.getRequestId();
     }
 
     @Override

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.client.java.impl.consumer;
 
+import apache.rocketmq.v2.AckMessageResponse;
 import apache.rocketmq.v2.Code;
 import apache.rocketmq.v2.ForwardMessageToDeadLetterQueueRequest;
 import apache.rocketmq.v2.ForwardMessageToDeadLetterQueueResponse;
@@ -41,12 +42,14 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import org.apache.rocketmq.client.apis.ClientConfiguration;
@@ -116,6 +119,7 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
 
     private final ConcurrentMap<MessageQueueImpl, ProcessQueue> processQueueTable;
     private ConsumeService consumeService;
+    private volatile AckMessageBatcher ackMessageBatcher;
 
     private volatile ScheduledFuture<?> scanAssignmentsFuture;
 
@@ -181,6 +185,7 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
                 getConsumerGroup());
             this.clientMeterManager.setGaugeObserver(gaugeObserver);
             super.startUp();
+            this.ackMessageBatcher = new AckMessageBatcher(this, getScheduler());
             this.consumeService = createConsumeService();
             // Scan assignments periodically.
             scanAssignmentsFuture = getScheduler().scheduleWithFixedDelay(() -> {
@@ -205,7 +210,7 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
      * 2. cancel scanAssignmentsFuture, do not create new processQueue
      * 3. waiting all inflight receive request finished or timeout
      * 4. shutdown consumptionExecutor and waiting all message consumption finished
-     * 5. sleep 1s to ack message async
+     * 5. flush accumulated acknowledgements, then sleep 1s for asynchronous retries
      * 6. shutdown clientImpl
      */
     @Override
@@ -219,6 +224,15 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
         log.info("Begin to Shutdown consumption executor, clientId={}", clientId);
         this.consumptionExecutor.shutdown();
         ExecutorServices.awaitTerminated(consumptionExecutor);
+        final AckMessageBatcher batcher = this.ackMessageBatcher;
+        if (null != batcher) {
+            try {
+                batcher.flushAndClose().get(clientConfiguration.getRequestTimeout().toMillis(),
+                    TimeUnit.MILLISECONDS);
+            } catch (ExecutionException | TimeoutException e) {
+                log.warn("Failed to flush all batched acknowledgements before shutdown, clientId={}", clientId, e);
+            }
+        }
         TimeUnit.SECONDS.sleep(1);
         super.shutDown();
         log.info("Shutdown the rocketmq {} successfully, clientId={}", clientType(), clientId);
@@ -498,6 +512,15 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
 
     public ConsumeService getConsumeService() {
         return consumeService;
+    }
+
+    ListenableFuture<AckMessageResponse> batchAckMessage(MessageViewImpl messageView) {
+        final AckMessageBatcher batcher = this.ackMessageBatcher;
+        if (null == batcher || !batcher.isBatchable(messageView)) {
+            return ackMessage(messageView);
+        }
+        final ListenableFuture<AckMessageResponse> future = batcher.enqueue(messageView);
+        return null == future ? ackMessage(messageView) : future;
     }
 
     @Override

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/AckMessageBatcherTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/AckMessageBatcherTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.java.impl.consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import apache.rocketmq.v2.AckMessageRequest;
+import apache.rocketmq.v2.AckMessageResponse;
+import apache.rocketmq.v2.AckMessageResultEntry;
+import apache.rocketmq.v2.Code;
+import apache.rocketmq.v2.Status;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.rocketmq.client.java.message.MessageViewImpl;
+import org.apache.rocketmq.client.java.rpc.RpcFuture;
+import org.apache.rocketmq.client.java.tool.TestBase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AckMessageBatcherTest extends TestBase {
+    @Mock
+    private PushConsumerImpl consumer;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testFlushWhenBatchSizeReached() throws Exception {
+        final MessageViewImpl messageView0 = fakeMessageViewImpl();
+        final MessageViewImpl messageView1 = fakeMessageViewImpl();
+        final AckMessageResponse response = response(Code.OK, messageView0, messageView1);
+        when(consumer.ackMessage(anyList())).thenReturn(new RpcFuture<>(fakeRpcContext(), null,
+            Futures.immediateFuture(response)));
+        final AckMessageBatcher batcher = new AckMessageBatcher(consumer, SCHEDULER, 2, Duration.ofDays(1));
+
+        final ListenableFuture<AckMessageResponse> future0 = batcher.enqueue(messageView0);
+        assertFalse(future0.isDone());
+        final ListenableFuture<AckMessageResponse> future1 = batcher.enqueue(messageView1);
+
+        assertEquals(Code.OK, future0.get(1, TimeUnit.SECONDS).getStatus().getCode());
+        assertEquals(Code.OK, future1.get(1, TimeUnit.SECONDS).getStatus().getCode());
+        final ArgumentCaptor<List<MessageViewImpl>> captor = ArgumentCaptor.forClass(List.class);
+        verify(consumer).ackMessage(captor.capture());
+        assertEquals(2, captor.getValue().size());
+    }
+
+    @Test
+    public void testFlushWhenDelayReached() throws Exception {
+        final MessageViewImpl messageView = fakeMessageViewImpl();
+        when(consumer.ackMessage(anyList())).thenReturn(new RpcFuture<>(fakeRpcContext(), null,
+            Futures.immediateFuture(response(Code.OK, messageView))));
+        final AckMessageBatcher batcher = new AckMessageBatcher(consumer, SCHEDULER, 1024,
+            Duration.ofMillis(20));
+
+        final ListenableFuture<AckMessageResponse> future = batcher.enqueue(messageView);
+
+        assertEquals(Code.OK, future.get(1, TimeUnit.SECONDS).getStatus().getCode());
+        verify(consumer).ackMessage(anyList());
+    }
+
+    @Test
+    public void testMapIndividualResultsByMessageId() throws Exception {
+        final MessageViewImpl messageView0 = fakeMessageViewImpl();
+        final MessageViewImpl messageView1 = fakeMessageViewImpl();
+        final Status ok = Status.newBuilder().setCode(Code.OK).build();
+        final Status invalidHandle = Status.newBuilder().setCode(Code.INVALID_RECEIPT_HANDLE).build();
+        final AckMessageResponse response = AckMessageResponse.newBuilder()
+            .setStatus(Status.newBuilder().setCode(Code.MULTIPLE_RESULTS))
+            .addEntries(entry(messageView1, invalidHandle))
+            .addEntries(entry(messageView0, ok))
+            .build();
+        when(consumer.ackMessage(anyList())).thenReturn(new RpcFuture<>(fakeRpcContext(), null,
+            Futures.immediateFuture(response)));
+        final AckMessageBatcher batcher = new AckMessageBatcher(consumer, SCHEDULER, 2, Duration.ofDays(1));
+
+        final ListenableFuture<AckMessageResponse> future0 = batcher.enqueue(messageView0);
+        final ListenableFuture<AckMessageResponse> future1 = batcher.enqueue(messageView1);
+
+        assertEquals(Code.OK, future0.get().getStatus().getCode());
+        assertEquals(Code.INVALID_RECEIPT_HANDLE, future1.get().getStatus().getCode());
+    }
+
+    @Test
+    public void testMissingIndividualResultsAreRetriedByCaller() throws Exception {
+        final MessageViewImpl messageView0 = fakeMessageViewImpl();
+        final MessageViewImpl messageView1 = fakeMessageViewImpl();
+        final AckMessageResponse response = response(Code.OK, messageView0);
+        when(consumer.ackMessage(anyList())).thenReturn(new RpcFuture<>(fakeRpcContext(), null,
+            Futures.immediateFuture(response)));
+        final AckMessageBatcher batcher = new AckMessageBatcher(consumer, SCHEDULER, 2, Duration.ofDays(1));
+
+        final ListenableFuture<AckMessageResponse> future0 = batcher.enqueue(messageView0);
+        final ListenableFuture<AckMessageResponse> future1 = batcher.enqueue(messageView1);
+
+        assertEquals(Code.OK, future0.get().getStatus().getCode());
+        assertEquals(Code.INTERNAL_ERROR, future1.get().getStatus().getCode());
+    }
+
+    @Test
+    public void testFlushAndClosePartitionsDifferentEndpoints() throws Exception {
+        final MessageViewImpl messageView0 = fakeMessageViewImpl(fakeMessageQueueImpl0());
+        final MessageViewImpl messageView1 = fakeMessageViewImpl(fakeMessageQueueImpl1());
+        when(consumer.ackMessage(anyList())).thenAnswer(invocation -> {
+            final List<MessageViewImpl> messages = invocation.getArgument(0);
+            return new RpcFuture<AckMessageRequest, AckMessageResponse>(fakeRpcContext(), null,
+                Futures.immediateFuture(response(Code.OK, messages.toArray(new MessageViewImpl[0]))));
+        });
+        final AckMessageBatcher batcher = new AckMessageBatcher(consumer, SCHEDULER, 1024, Duration.ofDays(1));
+
+        batcher.enqueue(messageView0);
+        batcher.enqueue(messageView1);
+        batcher.flushAndClose().get(1, TimeUnit.SECONDS);
+
+        verify(consumer, times(2)).ackMessage(anyList());
+        assertNull(batcher.enqueue(fakeMessageViewImpl()));
+    }
+
+    @Test
+    public void testFlushAndCloseWaitsForInflightBatch() throws Exception {
+        final MessageViewImpl messageView = fakeMessageViewImpl();
+        final SettableFuture<AckMessageResponse> rpcResponse = SettableFuture.create();
+        when(consumer.ackMessage(anyList())).thenReturn(new RpcFuture<>(fakeRpcContext(), null, rpcResponse));
+        final AckMessageBatcher batcher = new AckMessageBatcher(consumer, SCHEDULER, 1, Duration.ofDays(1));
+
+        final ListenableFuture<AckMessageResponse> messageFuture = batcher.enqueue(messageView);
+        final ListenableFuture<List<AckMessageResponse>> closeFuture = batcher.flushAndClose();
+        assertFalse(closeFuture.isDone());
+        rpcResponse.set(response(Code.OK, messageView));
+
+        assertEquals(Code.OK, messageFuture.get(1, TimeUnit.SECONDS).getStatus().getCode());
+        assertEquals(1, closeFuture.get(1, TimeUnit.SECONDS).size());
+    }
+
+    @Test
+    public void testBatchOnlyRecentlyConsumedNonLiteMessages() {
+        final MessageViewImpl freshMessage = fakeMessageViewImpl();
+        final MessageViewImpl slowMessage = Mockito.spy(fakeMessageViewImpl());
+        Mockito.doReturn(System.currentTimeMillis() - AckMessageBatcher.MAX_BATCHABLE_DURATION.toMillis() - 1)
+            .when(slowMessage).getDecodeTimestamp();
+        when(consumer.isLiteConsumer()).thenReturn(false);
+        final AckMessageBatcher batcher = new AckMessageBatcher(consumer, SCHEDULER);
+
+        assertTrue(batcher.isBatchable(freshMessage));
+        assertFalse(batcher.isBatchable(slowMessage));
+        when(consumer.isLiteConsumer()).thenReturn(true);
+        assertFalse(batcher.isBatchable(freshMessage));
+    }
+
+    private AckMessageResponse response(Code code, MessageViewImpl... messageViews) {
+        final Status status = Status.newBuilder().setCode(code).build();
+        final AckMessageResponse.Builder builder = AckMessageResponse.newBuilder().setStatus(status);
+        for (MessageViewImpl messageView : messageViews) {
+            builder.addEntries(entry(messageView, status));
+        }
+        return builder.build();
+    }
+
+    private AckMessageResultEntry entry(MessageViewImpl messageView, Status status) {
+        return AckMessageResultEntry.newBuilder()
+            .setMessageId(messageView.getMessageId().toString())
+            .setReceiptHandle(messageView.getReceiptHandle())
+            .setStatus(status)
+            .build();
+    }
+}

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ConsumerImplTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ConsumerImplTest.java
@@ -27,6 +27,7 @@ import apache.rocketmq.v2.ReceiveMessageRequest;
 import apache.rocketmq.v2.ReceiveMessageResponse;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -44,6 +45,7 @@ import org.apache.rocketmq.client.java.tool.TestBase;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -98,6 +100,32 @@ public class ConsumerImplTest extends TestBase {
             pushConsumer.ackMessage(messageView);
         final AckMessageResponse rpcInvocation = future0.get();
         Assert.assertEquals(rpcInvocation, future.get());
+    }
+
+    @Test
+    public void testBatchAckMessage() throws ExecutionException, InterruptedException {
+        int maxCacheMessageCount = 8;
+        int maxCacheMessageSizeInBytes = 1024;
+        int consumptionThreadCount = 4;
+        PushConsumerImpl pushConsumer = Mockito.spy(new PushConsumerImpl(clientConfiguration, FAKE_CONSUMER_GROUP_0,
+            subscriptionExpressions, messageListener, maxCacheMessageCount, maxCacheMessageSizeInBytes,
+            consumptionThreadCount));
+        final ClientManager clientManager = Mockito.mock(ClientManager.class);
+        Mockito.doReturn(clientManager).when(pushConsumer).getClientManager();
+        final RpcFuture<AckMessageRequest, AckMessageResponse> future = okAckMessageResponseFuture();
+        Mockito.doReturn(future).when(clientManager).ackMessage(any(Endpoints.class),
+            any(AckMessageRequest.class), any(Duration.class));
+        final MessageViewImpl messageView0 = fakeMessageViewImpl();
+        final MessageViewImpl messageView1 = fakeMessageViewImpl();
+
+        pushConsumer.ackMessage(Arrays.asList(messageView0, messageView1)).get();
+
+        final ArgumentCaptor<AckMessageRequest> requestCaptor = ArgumentCaptor.forClass(AckMessageRequest.class);
+        Mockito.verify(clientManager).ackMessage(any(Endpoints.class), requestCaptor.capture(), any(Duration.class));
+        final AckMessageRequest request = requestCaptor.getValue();
+        Assert.assertEquals(2, request.getEntriesCount());
+        Assert.assertEquals(messageView0.getMessageId().toString(), request.getEntries(0).getMessageId());
+        Assert.assertEquals(messageView1.getMessageId().toString(), request.getEntries(1).getMessageId());
     }
 
     @Test

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImplTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImplTest.java
@@ -149,10 +149,10 @@ public class ProcessQueueImplTest extends TestBase {
         messageViewList.add(messageView);
         processQueue.cacheMessages(messageViewList);
         RpcFuture<AckMessageRequest, AckMessageResponse> future0 = okAckMessageResponseFuture();
-        when(pushConsumer.ackMessage(any(MessageViewImpl.class))).thenReturn(future0);
+        when(pushConsumer.batchAckMessage(any(MessageViewImpl.class))).thenReturn(future0);
         processQueue.eraseMessage(messageView, ConsumeResult.SUCCESS);
         await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> verify(pushConsumer, times(1))
-            .ackMessage(eq(messageView)));
+            .batchAckMessage(eq(messageView)));
     }
 
     @Test
@@ -162,13 +162,16 @@ public class ProcessQueueImplTest extends TestBase {
         messageViewList.add(messageView);
         processQueue.cacheMessages(messageViewList);
         RpcFuture<AckMessageRequest, AckMessageResponse> future0 = new RpcFuture<>(new Exception());
+        when(pushConsumer.batchAckMessage(any(MessageViewImpl.class))).thenReturn(future0);
         when(pushConsumer.ackMessage(any(MessageViewImpl.class))).thenReturn(future0);
         processQueue.eraseMessage(messageView, ConsumeResult.SUCCESS);
         int ackTimes = 3;
         final Duration tolerance = Duration.ofMillis(500);
         await().atMost(ProcessQueueImpl.ACK_MESSAGE_FAILURE_BACKOFF_DELAY.multipliedBy(ackTimes)
-            .plus(tolerance)).untilAsserted(() -> verify(pushConsumer, times(ackTimes))
-            .ackMessage(eq(messageView)));
+            .plus(tolerance)).untilAsserted(() -> {
+                verify(pushConsumer, times(1)).batchAckMessage(eq(messageView));
+                verify(pushConsumer, times(ackTimes - 1)).ackMessage(eq(messageView));
+            });
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #1325

### Brief Description

The Java gRPC PushConsumer currently sends one acknowledgement RPC for every successfully consumed message even though `AckMessageRequest` supports repeated entries. Under a high consume rate, these one-entry requests add substantial client and Proxy overhead.

This change introduces one acknowledgement batcher per PushConsumer:

- Batches are partitioned by endpoint and topic to match the request routing and protocol constraints.
- A batch is flushed after 5 seconds or when it reaches 1,024 messages.
- Only messages consumed within 25 seconds of receive/decode are eligible. Slow messages use the existing immediate acknowledgement path.
- FIFO acknowledgements remain immediate because subsequent ordered messages depend on them.
- Lite consumers retain the existing immediate acknowledgement behavior.
- Multi-entry responses are mapped back to each message by message ID. Missing or failed results use the existing delayed individual retry path; invalid receipt handles preserve the existing no-retry behavior.
- PushConsumer shutdown waits for consumption to finish and then flushes pending and in-flight acknowledgement batches.
- ACK interceptors still receive all messages included in each batch.

The current RocketMQ Proxy protocol and batch-ACK path already accept repeated entries, so this change does not require a protocol update.

At approximately 8,000 TPS in the medium 2B workload, two controlled candidate runs averaged about 20.4 entries per ACK RPC, reducing ACK RPC volume by approximately 95.1%. Total Java consumer CPU decreased by approximately 20.6%, while throughput remained unchanged. A separate single-topic validation observed requests with exactly 1,024 entries.

### How Did You Test This Change?

- `zsh -ic 'javaswitch 11 >/dev/null && mvn -f java/pom.xml -pl client -am test'`
  - 304 tests run
  - 0 failures
  - 0 errors
  - 1 skipped
- Checkstyle: 0 violations
- SpotBugs: 0 errors or warnings
- Verified the compiled batcher class remains Java 8 compatible (`major version: 52`).
- Ran an end-to-end Kubernetes smoke test against a two-Broker/two-Proxy deployment with batch ACK enabled.
- Ran a medium 2B A-B-B-A comparison with 1,000 topics, 1,000 groups, 2,000 producers, 2,000 consumers, 4 KiB messages, 120 seconds warm-up, and 300 seconds sampling per round.

| Metric | Baseline mean | Batch ACK mean | Change |
| --- | ---: | ---: | ---: |
| Send TPS | 7,981.0 | 7,981.5 | +0.01% |
| Consumer total CPU | 3.446 cores | 2.736 cores | -20.59% |
| Consumer CPU p95 | 3.658 cores | 2.975 cores | -18.67% |
| Proxy total CPU | 10.998 cores | 9.052 cores | -17.70% |
| E2E latency p99 | 21.682 ms | 20.515 ms | -5.38% |
