### PR TITLE
[Java] Fix to use correct logger class in CompositedMessageInterceptor

### DIFF
--- a/java/client/src/main/java/org/apache/rocketmq/client/java/hook/CompositedMessageInterceptor.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/hook/CompositedMessageInterceptor.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("rawtypes")
 public class CompositedMessageInterceptor implements MessageInterceptor {
-    private static final Logger log = LoggerFactory.getLogger(MessageInterceptor.class);
+    private static final Logger log = LoggerFactory.getLogger(CompositedMessageInterceptor.class);
     private static final AttributeKey<Map<Integer, Map<AttributeKey, Attribute>>> INTERCEPTOR_ATTRIBUTES_KEY =
         AttributeKey.create("composited_interceptor_attributes");
     private final List<MessageInterceptor> interceptors = new ArrayList<>();


### PR DESCRIPTION
### Problem

`CompositedMessageInterceptor` and `MessageMeterInterceptor` both implement `MessageInterceptor` interface

Logger in `MessageMeterInterceptor` was initialized with `MessageMeterInterceptor.class` but logger in `CompositedMessageInterceptor` was initialized with `MessageInterceptor.class` (the interface) instead of
`CompositedMessageInterceptor.class`
This routed all log output to the wrong logger name, making per-class log level configuration ineffective and error tracing misleading.

### Changes

Replaced `MessageInterceptor.class` with `CompositedMessageInterceptor.class`

