### PR TITLE
[java] Support receiving from specified topic (#1315)

### DIFF
--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/SimpleConsumer.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/SimpleConsumer.java
@@ -110,6 +110,20 @@ public interface SimpleConsumer extends Closeable {
     List<MessageView> receive(int maxMessageNum, Duration invisibleDuration) throws ClientException;
 
     /**
+     * Fetch messages from the specified subscribed topic synchronously.
+     * <p> This method returns immediately if there are messages available.
+     * Otherwise, it will await the passed timeout. If the timeout expires, an empty list will be returned.
+     *
+     * @param topic             subscribed topic from which messages are fetched.
+     * @param maxMessageNum     max message num of server returned.
+     * @param invisibleDuration set the invisibleDuration of messages to return from the server. These messages will be
+     *                          invisible to other consumers unless timeout.
+     * @return list of message view.
+     * @throws IllegalArgumentException if the topic is not subscribed.
+     */
+    List<MessageView> receive(String topic, int maxMessageNum, Duration invisibleDuration) throws ClientException;
+
+    /**
      * Fetch messages from the server asynchronously.
      * <p> This method returns immediately if there are messages available.
      * Otherwise, it will await the passed timeout. If the timeout expires, an empty map will be returned.
@@ -120,6 +134,20 @@ public interface SimpleConsumer extends Closeable {
      * @return list of message view.
      */
     CompletableFuture<List<MessageView>> receiveAsync(int maxMessageNum, Duration invisibleDuration);
+
+    /**
+     * Fetch messages from the specified subscribed topic asynchronously.
+     * <p> This method returns immediately if there are messages available.
+     * Otherwise, it will await the passed timeout. If the timeout expires, an empty list will be returned.
+     *
+     * @param topic             subscribed topic from which messages are fetched.
+     * @param maxMessageNum     max message num of server returned.
+     * @param invisibleDuration set the invisibleDuration of messages to return from the server. These messages will be
+     *                          invisible to other consumers unless timeout.
+     * @return list of message view.
+     * @throws IllegalArgumentException if the topic is not subscribed, completed exceptionally.
+     */
+    CompletableFuture<List<MessageView>> receiveAsync(String topic, int maxMessageNum, Duration invisibleDuration);
 
     /**
      * Ack message to server synchronously, server commit this message.

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/SimpleConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/SimpleConsumerImpl.java
@@ -137,11 +137,31 @@ class SimpleConsumerImpl extends ConsumerImpl implements SimpleConsumer {
     }
 
     /**
+     * @see SimpleConsumer#receive(String, int, Duration)
+     */
+    @Override
+    public List<MessageView> receive(String topic, int maxMessageNum, Duration invisibleDuration)
+        throws ClientException {
+        final ListenableFuture<List<MessageView>> future = receive0(topic, maxMessageNum, invisibleDuration);
+        return handleClientFuture(future);
+    }
+
+    /**
      * @see SimpleConsumer#receiveAsync(int, Duration)
      */
     @Override
     public CompletableFuture<List<MessageView>> receiveAsync(int maxMessageNum, Duration invisibleDuration) {
         final ListenableFuture<List<MessageView>> future = receive0(maxMessageNum, invisibleDuration);
+        return FutureConverter.toCompletableFuture(future);
+    }
+
+    /**
+     * @see SimpleConsumer#receiveAsync(String, int, Duration)
+     */
+    @Override
+    public CompletableFuture<List<MessageView>> receiveAsync(String topic, int maxMessageNum,
+        Duration invisibleDuration) {
+        final ListenableFuture<List<MessageView>> future = receive0(topic, maxMessageNum, invisibleDuration);
         return FutureConverter.toCompletableFuture(future);
     }
 
@@ -165,6 +185,30 @@ class SimpleConsumerImpl extends ConsumerImpl implements SimpleConsumer {
         }
         final String topic = topics.get(IntMath.mod(topicIndex.getAndIncrement(), topics.size()));
         final FilterExpression filterExpression = copy.get(topic);
+        return receive0(topic, maxMessageNum, invisibleDuration, filterExpression);
+    }
+
+    public ListenableFuture<List<MessageView>> receive0(String topic, int maxMessageNum, Duration invisibleDuration) {
+        if (!this.isRunning()) {
+            log.error("Unable to receive message because {} is not running, state={}, clientId={}",
+                clientType(), state(), clientId);
+            final IllegalStateException e = new IllegalStateException("Simple consumer is not running now");
+            return Futures.immediateFailedFuture(e);
+        }
+        if (maxMessageNum <= 0) {
+            final IllegalArgumentException e = new IllegalArgumentException("maxMessageNum must be greater than 0");
+            return Futures.immediateFailedFuture(e);
+        }
+        final HashMap<String, FilterExpression> copy = new HashMap<>(subscriptionExpressions);
+        if (!copy.containsKey(topic)) {
+            final IllegalArgumentException e = new IllegalArgumentException("Topic is not subscribed: " + topic);
+            return Futures.immediateFailedFuture(e);
+        }
+        return receive0(topic, maxMessageNum, invisibleDuration, copy.get(topic));
+    }
+
+    private ListenableFuture<List<MessageView>> receive0(String topic, int maxMessageNum, Duration invisibleDuration,
+        FilterExpression filterExpression) {
         final ListenableFuture<SubscriptionLoadBalancer> routeFuture = getSubscriptionLoadBalancer(topic);
         final ListenableFuture<ReceiveMessageResult> future0 = Futures.transformAsync(routeFuture, result -> {
             final MessageQueueImpl mq = result.takeMessageQueue();

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/SimpleConsumerImplTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/SimpleConsumerImplTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.client.java.impl.consumer;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
@@ -27,7 +28,11 @@ import apache.rocketmq.v2.AckMessageResponse;
 import apache.rocketmq.v2.ChangeInvisibleDurationRequest;
 import apache.rocketmq.v2.ChangeInvisibleDurationResponse;
 import apache.rocketmq.v2.Code;
+import apache.rocketmq.v2.ReceiveMessageRequest;
+import com.google.common.util.concurrent.Futures;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -45,6 +50,8 @@ import org.apache.rocketmq.client.java.exception.TooManyRequestsException;
 import org.apache.rocketmq.client.java.exception.UnauthorizedException;
 import org.apache.rocketmq.client.java.exception.UnsupportedException;
 import org.apache.rocketmq.client.java.message.MessageViewImpl;
+import org.apache.rocketmq.client.java.route.MessageQueueImpl;
+import org.apache.rocketmq.client.java.route.TopicRouteData;
 import org.apache.rocketmq.client.java.rpc.RpcFuture;
 import org.apache.rocketmq.client.java.tool.TestBase;
 import org.junit.Test;
@@ -69,6 +76,13 @@ public class SimpleConsumerImplTest extends TestBase {
         simpleConsumer = new SimpleConsumerImpl(clientConfiguration, FAKE_CONSUMER_GROUP_0, awaitDuration,
             subExpressions);
         simpleConsumer.receive(1, Duration.ofSeconds(1));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testReceiveFromTopicWithoutStart() throws ClientException {
+        simpleConsumer = new SimpleConsumerImpl(clientConfiguration, FAKE_CONSUMER_GROUP_0, awaitDuration,
+            subExpressions);
+        simpleConsumer.receive(FAKE_TOPIC_0, 1, Duration.ofSeconds(1));
     }
 
     @Test(expected = IllegalStateException.class)
@@ -105,6 +119,58 @@ public class SimpleConsumerImplTest extends TestBase {
         } catch (ExecutionException e) {
             assertTrue(e.getCause() instanceof IllegalArgumentException);
         }
+    }
+
+    @Test
+    public void testReceiveAsyncFromUnsubscribedTopic() throws InterruptedException {
+        simpleConsumer = Mockito.spy(new SimpleConsumerImpl(clientConfiguration, FAKE_CONSUMER_GROUP_0, awaitDuration,
+            subExpressions));
+        when(simpleConsumer.isRunning()).thenReturn(true);
+        final CompletableFuture<List<MessageView>> future = simpleConsumer.receiveAsync(FAKE_TOPIC_1, 1,
+            Duration.ofSeconds(3));
+        try {
+            future.get();
+            fail();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof IllegalArgumentException);
+        }
+    }
+
+    @Test
+    public void testReceiveAsyncFromUnsubscribedTopicAfterUnsubscribe() throws InterruptedException {
+        simpleConsumer = Mockito.spy(new SimpleConsumerImpl(clientConfiguration, FAKE_CONSUMER_GROUP_0, awaitDuration,
+            subExpressions));
+        when(simpleConsumer.isRunning()).thenReturn(true);
+        simpleConsumer.unsubscribe(FAKE_TOPIC_0);
+        final CompletableFuture<List<MessageView>> future = simpleConsumer.receiveAsync(FAKE_TOPIC_0, 1,
+            Duration.ofSeconds(3));
+        try {
+            future.get();
+            fail();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof IllegalArgumentException);
+        }
+    }
+
+    @Test
+    public void testReceiveAsyncFromSpecifiedTopic() throws ExecutionException, InterruptedException {
+        final Map<String, FilterExpression> subscriptionExpressions = createSubscriptionExpressions(FAKE_TOPIC_0);
+        subscriptionExpressions.put(FAKE_TOPIC_1, FilterExpression.SUB_ALL);
+        simpleConsumer = Mockito.spy(new SimpleConsumerImpl(clientConfiguration, FAKE_CONSUMER_GROUP_0, awaitDuration,
+            subscriptionExpressions));
+        when(simpleConsumer.isRunning()).thenReturn(true);
+        final TopicRouteData topicRouteData = LiteSimpleConsumerImplTest.fakeTopicRouteData(FAKE_TOPIC_1,
+            fakePbBroker0(), Arrays.asList(apache.rocketmq.v2.Permission.READ), Arrays.asList(0));
+        simpleConsumer.updateSubscriptionLoadBalancer(FAKE_TOPIC_1, topicRouteData);
+        doReturn(Futures.immediateFuture(new ReceiveMessageResult(fakeEndpoints(), new ArrayList<>())))
+            .when(simpleConsumer).receiveMessage(any(ReceiveMessageRequest.class), any(MessageQueueImpl.class),
+                any(Duration.class));
+
+        final List<MessageView> messages = simpleConsumer.receiveAsync(FAKE_TOPIC_1, 1, Duration.ofSeconds(3)).get();
+
+        assertTrue(messages.isEmpty());
+        Mockito.verify(simpleConsumer).receiveMessage(any(ReceiveMessageRequest.class),
+            Mockito.argThat(mq -> FAKE_TOPIC_1.equals(mq.getTopic())), any(Duration.class));
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Related to apache/rocketmq-clients#1315

### Brief Description

Add synchronous and asynchronous `SimpleConsumer.receive` overloads that accept a topic selected from the current subscriptions.

The existing receive APIs remain unchanged and continue to select across all subscribed topics. The new overloads reuse the subscribed filter expression and fail with `IllegalArgumentException` when the requested topic is not currently subscribed.

This PR implements topic-aware receive only. Queue-aware receive and exposing topic route data remain outside this change.

### How Did You Test This Change?

- Added tests for receiving from a specified subscribed topic.
- Added tests for unsubscribed topics, topics removed by `unsubscribe`, and consumers that are not running.
- Ran `SimpleConsumerImplTest`: 11 tests passed with no failures.
- Verified the Java API/client modules compile and pass Checkstyle and SpotBugs.