### PR TITLE
[ISSUE #1334] [C++] Fix PushConsumer teardown crash and add explicit shutdown()

### DIFF
--- a/cpp/include/rocketmq/PushConsumer.h
+++ b/cpp/include/rocketmq/PushConsumer.h
@@ -41,6 +41,23 @@ public:
 
   void unsubscribe(const std::string& topic) noexcept;
 
+  /**
+   * Gracefully shut the consumer down.
+   *
+   * Call this from the application (owner) thread before releasing the
+   * PushConsumer. It cancels periodic tasks, then drains and joins the consume
+   * worker threads synchronously on the calling thread. Because the join blocks
+   * the owner until all in-flight consume tasks finish, a consume worker can
+   * never become the last owner of the underlying implementation, so the final
+   * destruction always happens on the owner thread rather than on a worker
+   * thread concurrently with process/static teardown.
+   *
+   * Idempotent: safe to call multiple times and safe to call again from the
+   * destructor. If never called explicitly, teardown still runs from the
+   * destructor, but then it is not guaranteed to run on the owner thread.
+   */
+  void shutdown() noexcept;
+
 private:
   friend class PushConsumerBuilder;
 

--- a/cpp/source/base/ThreadPoolImpl.cpp
+++ b/cpp/source/base/ThreadPoolImpl.cpp
@@ -79,10 +79,24 @@ void ThreadPoolImpl::shutdown() {
   if (state_.compare_exchange_strong(expected, State::STOPPING, std::memory_order_relaxed)) {
     work_guard_->reset();
     context_.stop();
+    auto current_id = std::this_thread::get_id();
     for (auto& thread : threads_) {
-      if (thread.joinable()) {
-        thread.join();
+      if (!thread.joinable()) {
+        continue;
       }
+      if (thread.get_id() == current_id) {
+        // shutdown() was invoked from within one of our own worker threads,
+        // e.g. the last shared_ptr to the owning PushConsumerImpl was released
+        // on a consume worker, so ~PushConsumerImpl -> shutdown() runs here.
+        // Joining the current thread raises std::system_error(EDEADLK); on the
+        // noexcept teardown path that would std::terminate. Detach self so the
+        // worker unwinds naturally once io_context::run() returns. Deterministic
+        // teardown must be driven from a non-worker thread via PushConsumer::shutdown().
+        SPDLOG_WARN("ThreadPool::shutdown() invoked from a worker thread; detaching self to avoid self-join");
+        thread.detach();
+        continue;
+      }
+      thread.join();
     }
     state_.store(State::STOPPED, std::memory_order_relaxed);
   }

--- a/cpp/source/base/tests/ThreadPoolTest.cpp
+++ b/cpp/source/base/tests/ThreadPoolTest.cpp
@@ -20,6 +20,7 @@
 #include "rocketmq/RocketMQ.h"
 #include "gtest/gtest.h"
 #include <atomic>
+#include <chrono>
 #include <functional>
 #include <thread>
 
@@ -71,6 +72,36 @@ TEST_F(ThreadPoolTest, testBasics) {
       cv.Wait(&mtx);
     }
   }
+}
+
+// Regression: shutting the pool down from within one of its own worker threads
+// must not attempt to join the calling thread (self-join deadlocks and raises
+// std::system_error EDEADLK). This mirrors the PushConsumer teardown race where
+// ~PushConsumerImpl runs on a consume worker and drives ThreadPoolImpl::shutdown().
+TEST_F(ThreadPoolTest, shutdownFromWorkerThreadDoesNotThrowTest) {
+  std::atomic<bool> threw{false};
+  std::atomic<bool> finished{false};
+
+  pool_->submit([&]() {
+    try {
+      pool_->shutdown();
+    } catch (...) {
+      threw.store(true);
+    }
+    finished.store(true);
+  });
+
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (!finished.load() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  EXPECT_TRUE(finished.load());
+  EXPECT_FALSE(threw.load());
+
+  // Give the detached worker a moment to unwind out of io_context::run()
+  // before the fixture destroys the pool (test-only synchronization).
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
 }
 
 ROCKETMQ_NAMESPACE_END

--- a/cpp/source/rocketmq/ConsumeTask.cpp
+++ b/cpp/source/rocketmq/ConsumeTask.cpp
@@ -136,6 +136,12 @@ void ConsumeTask::process() {
   }
 
   std::shared_ptr<PushConsumerImpl> consumer = svc->consumer().lock();
+  if (!consumer) {
+    // The owning PushConsumerImpl has been destructed. Bail out before touching
+    // consumer stats/config so we never dereference a null consumer.
+    SPDLOG_DEBUG("PushConsumer has been destructed; skip processing");
+    return;
+  }
 
   auto self = shared_from_this();
 

--- a/cpp/source/rocketmq/PushConsumer.cpp
+++ b/cpp/source/rocketmq/PushConsumer.cpp
@@ -41,6 +41,16 @@ void PushConsumer::unsubscribe(const std::string& topic) noexcept {
   }
 }
 
+void PushConsumer::shutdown() noexcept {
+  try {
+    if (impl_) {
+      impl_->shutdown();
+    }
+  } catch (const std::exception& e) {
+    SPDLOG_ERROR("Exception in shutdown: {}", e.what());
+  }
+}
+
 PushConsumerBuilder PushConsumer::newBuilder() {
   return {};
 }

--- a/cpp/source/rocketmq/PushConsumerImpl.cpp
+++ b/cpp/source/rocketmq/PushConsumerImpl.cpp
@@ -42,7 +42,10 @@ PushConsumerImpl::PushConsumerImpl(absl::string_view group_name) : ClientImpl(gr
 }
 
 PushConsumerImpl::~PushConsumerImpl() {
-  SPDLOG_DEBUG("DefaultMQPushConsumerImpl is destructed");
+  // Do NOT log here. The destructor may run during process/static teardown when
+  // the static spdlog default logger has already been destroyed; logging then
+  // dereferences a dangling logger (observed as EXC_BAD_ACCESS at 0x18 on macOS).
+  // Deterministic teardown should be driven earlier via PushConsumer::shutdown().
   shutdown();
 }
 

--- a/cpp/source/rocketmq/tests/ConsumeTaskTest.cpp
+++ b/cpp/source/rocketmq/tests/ConsumeTaskTest.cpp
@@ -162,6 +162,33 @@ TEST_F(ConsumeTaskTest, processWithEmptyMessagesTest) {
   task->process();
 }
 
+// Regression: the service is still alive but the owning PushConsumerImpl has
+// already been destructed, so consumer().lock() yields null. process() must not
+// dereference the null consumer (metrics/stats access), it must bail out before
+// invoking the listener.
+TEST_F(ConsumeTaskTest, processWithExpiredConsumerTest) {
+  auto msg = buildMessage("topic", "body");
+  auto task = std::make_shared<ConsumeTask>(weak_service_, weak_pq_, msg);
+
+  bool listener_invoked = false;
+  MessageListener listener = [&listener_invoked](const Message&) {
+    listener_invoked = true;
+    return ConsumeResult::SUCCESS;
+  };
+
+  // Consumer weak_ptr is expired (owning PushConsumerImpl already gone).
+  EXPECT_CALL(*service_, consumer()).WillRepeatedly(testing::Return(std::weak_ptr<PushConsumerImpl>()));
+  ON_CALL(*service_, listener()).WillByDefault(testing::ReturnRef(listener));
+
+  // With no consumer, process() must not run the listener or ack/nack.
+  EXPECT_CALL(*service_, preHandle(testing::_)).Times(0);
+  EXPECT_CALL(*service_, ack(testing::_, testing::_)).Times(0);
+  EXPECT_CALL(*service_, nack(testing::_, testing::_)).Times(0);
+
+  task->process();  // must not dereference a null consumer
+  EXPECT_FALSE(listener_invoked);
+}
+
 // --- process() state-machine: Consume → Ack on SUCCESS ---
 
 TEST_F(ConsumeTaskTest, processConsumeSuccessCallsAckTest) {

--- a/cpp/source/rocketmq/tests/PushConsumerImplTest.cpp
+++ b/cpp/source/rocketmq/tests/PushConsumerImplTest.cpp
@@ -334,4 +334,14 @@ TEST(PushConsumerImplTest, maxCachedMessageMemoryTest) {
   EXPECT_EQ(MixAll::DEFAULT_CACHED_MESSAGE_MEMORY, consumer->maxCachedMessageMemory());
 }
 
+// shutdown() must be idempotent and safe to call repeatedly, including the
+// implicit call from the destructor. This underpins the public
+// PushConsumer::shutdown() contract (explicit shutdown followed by destruction).
+TEST(PushConsumerImplTest, shutdownIsIdempotentTest) {
+  auto consumer = createConsumer();
+  consumer->shutdown();
+  consumer->shutdown();
+  // Destruction here triggers shutdown() once more; must not crash.
+}
+
 ROCKETMQ_NAMESPACE_END


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #1334

Prior reports of the same crash were auto-closed as stale rather than fixed: #421, #521.

### Brief Description

`PushConsumer` has no public `shutdown()` / `close()`, so teardown depends on releasing the last `shared_ptr`. `ConsumeTask::process()` promotes the service's `weak_ptr` into an *owning* `shared_ptr` on a consume worker thread, so an application that drops its last reference while a message is being consumed makes that worker the last owner. `~PushConsumerImpl()` then runs on the worker thread, concurrently with `process()` and process/static teardown, and crashes inside spdlog (`EXC_BAD_ACCESS` at `0x18` on macOS).

This PR:

- **Adds `PushConsumer::shutdown()`.** Called from the owner thread it cancels the periodic tasks and joins the consume workers synchronously. Because the join blocks the owner until in-flight consume tasks finish, a worker can never be the last owner, so the final destruction always happens on the owner thread. It is idempotent and remains safe to call again from the destructor.
- **Stops `ThreadPoolImpl::shutdown()` from joining the calling thread.** Self-join raises `std::system_error(EDEADLK)`, and since `PushConsumerImpl::shutdown()` is `noexcept` that terminated the process. The current worker is now detached instead, so it unwinds once `io_context::run()` returns.
- **Removes the `SPDLOG_DEBUG` call from `~PushConsumerImpl()`**, which could touch the static default logger after it was destroyed.
- **Null-checks the locked consumer in `ConsumeTask::process()`** so an expired `PushConsumerImpl` no longer causes a null dereference.

Two notes for reviewers, so the scope is not overstated:

1. The `ThreadPoolImpl` self-join guard only *hardens* the unsupported path where teardown is driven from a worker thread; it downgrades a guaranteed `terminate` to a survivable unwind. Deterministic teardown still requires calling `PushConsumer::shutdown()` from a non-worker thread, and that is what the API documentation now states.
2. This aligns C++ with the other SDKs rather than adding a new concept — Java already has `PushConsumer extends Closeable` with `close()`, and Go has `GracefulStop()`. C++ was the only one without an explicit shutdown.

The crash is not FIFO-specific: `ConsumeTask::process()`, `~PushConsumerImpl()` and `ThreadPoolImpl::shutdown()` are shared by all message types, and `fifo_` only selects a `NextStep` branch. FIFO just widens the window because consumption is serialized.

### How Did You Test This Change?

Three regression tests were added, and the first two were confirmed to fail against the unfixed code before the fix was applied:

- `ThreadPoolTest.shutdownFromWorkerThreadDoesNotThrowTest` — shuts the pool down from one of its own workers. Before the fix this aborts with `terminate called without an active exception`.
- `ConsumeTaskTest.processWithExpiredConsumerTest` — processes a task whose owning consumer has expired. Before the fix this segfaults.
- `PushConsumerImplTest.shutdownIsIdempotentTest` — covers repeated `shutdown()` calls plus the implicit one from the destructor.

Full C++ suite on this branch, rebased directly on `master`:

```
$ bazel test //source/...
Executed 36 out of 37 tests: 37 tests pass.
```

This branch contains only this fix and sits directly on `master`, so it can be reviewed and merged independently of my producer-side fix for #1335.
