### PR TITLE
[ISSUE #1338] [Java] Expose client metrics through JMX

### DIFF
--- a/java/README-CN.md
+++ b/java/README-CN.md
@@ -80,6 +80,35 @@ implementation 'org.apache.rocketmq:rocketmq-client-java-noshade:${rocketmq.vers
 
 内部的[代码示例](./client/src/main/java/org/apache/rocketmq/client/java/example)可以帮助你上手不同的客户端和消息类型。
 
+## 通过 JMX 暴露 Prometheus 指标
+
+客户端可以将指标注册为 Platform MBeanServer 中的 MBean，供 Prometheus JMX Exporter 采集。该功能默认关闭，
+需要在创建任何 RocketMQ 客户端之前通过以下 JVM 系统属性开启：
+
+```text
+-Drocketmq.client.jmx.enabled=true
+```
+
+Reporter 本身不会开启网络端口。用户可以在同一 JVM 中运行 JMX Exporter Java Agent，也可以使用能够连接该 JVM
+的 standalone JMX Exporter。Exporter 需要采集匹配以下 ObjectName pattern 的 MBean：
+
+```text
+org.apache.rocketmq.client:type=message-metrics,*
+```
+
+例如，以下 JMX Exporter 配置仅采集 RocketMQ 客户端指标：
+
+```yaml
+includeObjectNames:
+  - "org.apache.rocketmq.client:type=message-metrics,*"
+rules:
+  - pattern: ".*"
+```
+
+省略 `includeObjectNames` 时，JMX Exporter 默认查询所有 MBean。如果将该 pattern 添加到已有配置中，需要同时保留
+应用仍需采集的其他 ObjectName pattern。Histogram MBean 会在对应客户端操作首次记录数据时创建，Consumer Gauge
+MBean 会在队列分配信息可用后创建。
+
 ## 日志系统
 
 采用 [Logback](https://logback.qos.ch/) 来作为实现，为了保证日志能够始终被有效地持久化，`rocketmq-client-java` 中集成了一个 shade 之后的 Logback，并会为其使用单独的配置文件。

--- a/java/README.md
+++ b/java/README.md
@@ -80,6 +80,37 @@ implementation 'org.apache.rocketmq:rocketmq-client-java-noshade:${rocketmq.vers
 More code examples are provided [example](./client/src/main/java/org/apache/rocketmq/client/java/example) to assist you
 in working with various clients and different message types.
 
+## Prometheus Metrics through JMX
+
+The client can register its metrics as MBeans in the platform MBean server for collection by a Prometheus JMX
+Exporter. This feature is disabled by default. Enable it before creating any RocketMQ client with the following JVM
+system property:
+
+```text
+-Drocketmq.client.jmx.enabled=true
+```
+
+The reporter does not open a network port. Run the JMX Exporter Java agent in the same JVM, or connect a standalone
+JMX Exporter to the JVM. The exporter must collect MBeans matching this ObjectName pattern:
+
+```text
+org.apache.rocketmq.client:type=message-metrics,*
+```
+
+For example, the following JMX Exporter configuration limits collection to RocketMQ client metrics:
+
+```yaml
+includeObjectNames:
+  - "org.apache.rocketmq.client:type=message-metrics,*"
+rules:
+  - pattern: ".*"
+```
+
+If `includeObjectNames` is omitted, JMX Exporter queries all MBeans by default. When adding the pattern to an existing
+configuration, preserve any other ObjectName patterns that the application still needs. Histogram MBeans are created
+when the corresponding client operation first records a value, and consumer gauge MBeans are created after queue
+assignments are available.
+
 ## Logging System
 
 We picked [Logback](https://logback.qos.ch/) and shaded it into the client implementation to guarantee that logging is reliably persistent. Because RocketMQ utilizes a distinct configuration file, you shouldn't be concerned that the Logback configuration file will clash with yours.

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/ClientImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/ClientImpl.java
@@ -221,25 +221,28 @@ public abstract class ClientImpl extends AbstractIdleService implements Client, 
     @Override
     protected void shutDown() throws InterruptedException {
         log.info("Begin to shutdown the rocketmq client, clientId={}", clientId);
-        notifyClientTermination();
-        if (null != this.updateRouteCacheFuture) {
-            updateRouteCacheFuture.cancel(false);
+        try {
+            notifyClientTermination();
+            if (null != this.updateRouteCacheFuture) {
+                updateRouteCacheFuture.cancel(false);
+            }
+            telemetryCommandExecutor.shutdown();
+            if (!ExecutorServices.awaitTerminated(telemetryCommandExecutor)) {
+                log.error("[Bug] Timeout to shutdown the telemetry command executor, clientId={}", clientId);
+            } else {
+                log.info("Shutdown the telemetry command executor successfully, clientId={}", clientId);
+            }
+            log.info("Begin to release all telemetry sessions, clientId={}", clientId);
+            releaseClientSessions();
+            log.info("Release all telemetry sessions successfully, clientId={}", clientId);
+            clientManager.stopAsync().awaitTerminated();
+            clientCallbackExecutor.shutdown();
+            if (!ExecutorServices.awaitTerminated(clientCallbackExecutor)) {
+                log.error("[Bug] Timeout to shutdown the client callback executor, clientId={}", clientId);
+            }
+        } finally {
+            clientMeterManager.shutdown();
         }
-        telemetryCommandExecutor.shutdown();
-        if (!ExecutorServices.awaitTerminated(telemetryCommandExecutor)) {
-            log.error("[Bug] Timeout to shutdown the telemetry command executor, clientId={}", clientId);
-        } else {
-            log.info("Shutdown the telemetry command executor successfully, clientId={}", clientId);
-        }
-        log.info("Begin to release all telemetry sessions, clientId={}", clientId);
-        releaseClientSessions();
-        log.info("Release all telemetry sessions successfully, clientId={}", clientId);
-        clientManager.stopAsync().awaitTerminated();
-        clientCallbackExecutor.shutdown();
-        if (!ExecutorServices.awaitTerminated(clientCallbackExecutor)) {
-            log.error("[Bug] Timeout to shutdown the client callback executor, clientId={}", clientId);
-        }
-        clientMeterManager.shutdown();
         log.info("Shutdown the rocketmq client successfully, clientId={}", clientId);
     }
 

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
@@ -212,16 +212,19 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
     @Override
     protected void shutDown() throws InterruptedException {
         log.info("Begin to shutdown the rocketmq {}, clientId={}", clientType(), clientId);
-        if (null != scanAssignmentsFuture) {
-            scanAssignmentsFuture.cancel(false);
+        try {
+            if (null != scanAssignmentsFuture) {
+                scanAssignmentsFuture.cancel(false);
+            }
+            log.info("Waiting for the inflight receive requests to be finished, clientId={}", clientId);
+            waitingReceiveRequestFinished();
+            log.info("Begin to Shutdown consumption executor, clientId={}", clientId);
+            this.consumptionExecutor.shutdown();
+            ExecutorServices.awaitTerminated(consumptionExecutor);
+            TimeUnit.SECONDS.sleep(1);
+        } finally {
+            super.shutDown();
         }
-        log.info("Waiting for the inflight receive requests to be finished, clientId={}", clientId);
-        waitingReceiveRequestFinished();
-        log.info("Begin to Shutdown consumption executor, clientId={}", clientId);
-        this.consumptionExecutor.shutdown();
-        ExecutorServices.awaitTerminated(consumptionExecutor);
-        TimeUnit.SECONDS.sleep(1);
-        super.shutDown();
         log.info("Shutdown the rocketmq {} successfully, clientId={}", clientType(), clientId);
     }
 

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImpl.java
@@ -186,6 +186,7 @@ class PushConsumerImpl extends ConsumerImpl implements PushConsumer {
             scanAssignmentsFuture = getScheduler().scheduleWithFixedDelay(() -> {
                 try {
                     scanAssignments();
+                    clientMeterManager.refreshGauges();
                 } catch (Throwable t) {
                     log.error("Exception raised while scanning the load assignments, clientId={}", clientId, t);
                 }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
@@ -250,6 +250,7 @@ final class ClientJmxReporter {
     }
 
     private static String formatBoundary(double value) {
+        // Encode signs and decimal points as JMX-friendly suffixes, for example, -1.5 becomes n1_5.
         String boundary = BigDecimal.valueOf(value).stripTrailingZeros().toPlainString();
         return boundary.replace('-', 'n').replace('.', '_');
     }
@@ -346,18 +347,25 @@ final class ClientJmxReporter {
         private volatile Map<String, MetricValue> metrics = Collections.emptyMap();
 
         private boolean putAllIfAbsent(Map<String, MetricValue> additions) {
-            Map<String, MetricValue> updated = new LinkedHashMap<>(metrics);
-            boolean changed = false;
+            Map<String, MetricValue> snapshot = metrics;
+            boolean hasNewMetric = false;
+            for (String metricName : additions.keySet()) {
+                if (!snapshot.containsKey(metricName)) {
+                    hasNewMetric = true;
+                    break;
+                }
+            }
+            if (!hasNewMetric) {
+                return false;
+            }
+            Map<String, MetricValue> updated = new LinkedHashMap<>(snapshot);
             for (Map.Entry<String, MetricValue> entry : additions.entrySet()) {
                 if (!updated.containsKey(entry.getKey())) {
                     updated.put(entry.getKey(), entry.getValue());
-                    changed = true;
                 }
             }
-            if (changed) {
-                metrics = Collections.unmodifiableMap(updated);
-            }
-            return changed;
+            metrics = Collections.unmodifiableMap(updated);
+            return true;
         }
 
         @Override

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
@@ -1,0 +1,413 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.java.metrics;
+
+import io.opentelemetry.api.common.Attributes;
+import java.lang.management.ManagementFactory;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.DoubleAdder;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.regex.Pattern;
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.AttributeNotFoundException;
+import javax.management.DynamicMBean;
+import javax.management.InvalidAttributeValueException;
+import javax.management.JMException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanException;
+import javax.management.MBeanInfo;
+import javax.management.MBeanOperationInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import org.apache.rocketmq.client.java.misc.ClientId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Registers RocketMQ client metrics in the platform MBean server, following Kafka's JMX reporter model.
+ *
+ * <p>The reporter does not open a network port or depend on a Prometheus library. When enabled, applications that
+ * already run a Prometheus JMX exporter can collect these MBeans. The reporter is disabled by default and can be
+ * enabled before creating a client with the {@code rocketmq.client.jmx.enabled} system property.
+ */
+final class ClientJmxReporter {
+    static final String DOMAIN = "org.apache.rocketmq.client";
+    static final String TYPE = "message-metrics";
+    static final String ENABLE_PROPERTY = "rocketmq.client.jmx.enabled";
+    private static final Logger log = LoggerFactory.getLogger(ClientJmxReporter.class);
+    private static final Pattern SAFE_OBJECT_NAME_VALUE = Pattern.compile("[\\w-%\\. \\t]*");
+    private static final MBeanOperationInfo[] NO_OPERATIONS = new MBeanOperationInfo[0];
+
+    private final ClientId clientId;
+    private final MBeanServer mBeanServer;
+    private final AtomicBoolean enabled;
+    private final Object registrationLock = new Object();
+    private final Map<ObjectName, ClientMetricsMBean> mBeans;
+    private final Map<HistogramEnum, ConcurrentMap<Attributes, JmxHistogram>> histograms;
+    private volatile GaugeObserver gaugeObserver = GaugeObserver.EMPTY;
+
+    ClientJmxReporter(ClientId clientId) {
+        this.clientId = clientId;
+        MBeanServer server = null;
+        boolean initialized = false;
+        try {
+            if (Boolean.parseBoolean(System.getProperty(ENABLE_PROPERTY, Boolean.FALSE.toString()))) {
+                server = ManagementFactory.getPlatformMBeanServer();
+                initialized = true;
+            }
+        } catch (Throwable t) {
+            log.warn("Failed to initialize the client JMX reporter, clientId={}", clientId, t);
+        }
+        this.mBeanServer = server;
+        this.enabled = new AtomicBoolean(initialized);
+        if (initialized) {
+            this.mBeans = new HashMap<>();
+            this.histograms = new EnumMap<>(HistogramEnum.class);
+            for (HistogramEnum histogram : HistogramEnum.values()) {
+                this.histograms.put(histogram, new ConcurrentHashMap<>());
+            }
+        } else {
+            this.mBeans = Collections.emptyMap();
+            this.histograms = Collections.emptyMap();
+        }
+    }
+
+    boolean isEnabled() {
+        return enabled.get();
+    }
+
+    void setGaugeObserver(GaugeObserver gaugeObserver) {
+        this.gaugeObserver = gaugeObserver;
+    }
+
+    void record(HistogramEnum histogramType, Attributes attributes, double value) {
+        if (!enabled.get()) {
+            return;
+        }
+        ConcurrentMap<Attributes, JmxHistogram> series = histograms.get(histogramType);
+        JmxHistogram histogram = series.get(attributes);
+        if (null == histogram) {
+            histogram = registerHistogram(histogramType, attributes, series);
+        }
+        if (null != histogram) {
+            histogram.record(value);
+        }
+    }
+
+    void refreshGauges() {
+        if (!enabled.get()) {
+            return;
+        }
+        GaugeObserver observer = gaugeObserver;
+        try {
+            for (GaugeEnum gauge : observer.getGauges()) {
+                Map<Attributes, Double> values = observer.getValues(gauge);
+                for (Attributes attributes : values.keySet()) {
+                    registerGauge(gauge, attributes);
+                }
+            }
+        } catch (RuntimeException e) {
+            log.warn("Failed to refresh client JMX gauges, clientId={}", clientId, e);
+        }
+    }
+
+    void shutdown() {
+        if (!enabled.compareAndSet(true, false)) {
+            return;
+        }
+        synchronized (registrationLock) {
+            for (ObjectName objectName : new ArrayList<>(mBeans.keySet())) {
+                try {
+                    if (mBeanServer.isRegistered(objectName)) {
+                        mBeanServer.unregisterMBean(objectName);
+                    }
+                } catch (JMException | RuntimeException e) {
+                    log.warn("Failed to unregister client metrics MBean, objectName={}, clientId={}",
+                        objectName, clientId, e);
+                }
+            }
+            mBeans.clear();
+        }
+    }
+
+    private JmxHistogram registerHistogram(HistogramEnum histogramType, Attributes attributes,
+        ConcurrentMap<Attributes, JmxHistogram> series) {
+        synchronized (registrationLock) {
+            JmxHistogram existed = series.get(attributes);
+            if (null != existed) {
+                return existed;
+            }
+            JmxHistogram histogram = new JmxHistogram(histogramType.getBoundaries());
+            Map<String, MetricValue> metrics = new LinkedHashMap<>();
+            String prefix = histogramType.getName();
+            metrics.put(prefix + "_count", new LongMetricValue(histogram.count::sum));
+            metrics.put(prefix + "_sum", new DoubleMetricValue(histogram.sum::sum));
+            for (int i = 0; i < histogram.boundaries.size(); i++) {
+                final int bucketIndex = i;
+                String boundary = formatBoundary(histogram.boundaries.get(i));
+                metrics.put(prefix + "_bucket_le_" + boundary,
+                    new LongMetricValue(() -> histogram.cumulativeBucketCount(bucketIndex)));
+            }
+            metrics.put(prefix + "_bucket_le_inf", new LongMetricValue(histogram.count::sum));
+            if (!registerMetrics(attributes, metrics)) {
+                return null;
+            }
+            series.put(attributes, histogram);
+            return histogram;
+        }
+    }
+
+    private void registerGauge(GaugeEnum gauge, Attributes attributes) {
+        Map<String, MetricValue> metrics = Collections.singletonMap(gauge.getName(),
+            new DoubleMetricValue(() -> getGaugeValue(gauge, attributes)));
+        registerMetrics(attributes, metrics);
+    }
+
+    private double getGaugeValue(GaugeEnum gauge, Attributes attributes) {
+        try {
+            Double value = gaugeObserver.getValues(gauge).get(attributes);
+            return null == value ? 0 : value;
+        } catch (RuntimeException e) {
+            log.warn("Failed to read client JMX gauge, gauge={}, clientId={}", gauge, clientId, e);
+            return 0;
+        }
+    }
+
+    private boolean registerMetrics(Attributes attributes, Map<String, MetricValue> metrics) {
+        synchronized (registrationLock) {
+            try {
+                ObjectName objectName = objectName(attributes);
+                ClientMetricsMBean mBean = mBeans.get(objectName);
+                if (null == mBean) {
+                    mBean = new ClientMetricsMBean();
+                    mBean.putAllIfAbsent(metrics);
+                    mBeanServer.registerMBean(mBean, objectName);
+                    mBeans.put(objectName, mBean);
+                    return true;
+                }
+                boolean changed = mBean.putAllIfAbsent(metrics);
+                if (!changed && mBeanServer.isRegistered(objectName)) {
+                    return true;
+                }
+                if (mBeanServer.isRegistered(objectName)) {
+                    mBeanServer.unregisterMBean(objectName);
+                }
+                mBeanServer.registerMBean(mBean, objectName);
+                return true;
+            } catch (JMException | RuntimeException e) {
+                log.warn("Failed to register client metrics MBean, clientId={}", clientId, e);
+                return false;
+            }
+        }
+    }
+
+    ObjectName objectName(Attributes attributes) throws JMException {
+        SortedMap<String, String> labels = new TreeMap<>();
+        attributes.forEach((key, value) -> {
+            if (null != value && !String.valueOf(value).isEmpty()) {
+                labels.put(key.getKey(), String.valueOf(value));
+            }
+        });
+        labels.put(MetricLabels.CLIENT_ID.getKey(), clientId.toString());
+        StringBuilder builder = new StringBuilder(DOMAIN).append(":type=").append(TYPE);
+        for (Map.Entry<String, String> entry : labels.entrySet()) {
+            builder.append(',').append(entry.getKey()).append('=').append(sanitize(entry.getValue()));
+        }
+        return new ObjectName(builder.toString());
+    }
+
+    private static String sanitize(String value) {
+        return SAFE_OBJECT_NAME_VALUE.matcher(value).matches() ? value : ObjectName.quote(value);
+    }
+
+    private static String formatBoundary(double value) {
+        String boundary = BigDecimal.valueOf(value).stripTrailingZeros().toPlainString();
+        return boundary.replace('-', 'n').replace('.', '_');
+    }
+
+    private interface LongValueSupplier {
+        long get();
+    }
+
+    private interface DoubleValueSupplier {
+        double get();
+    }
+
+    private interface MetricValue {
+        Number get();
+
+        String getType();
+    }
+
+    private static final class LongMetricValue implements MetricValue {
+        private final LongValueSupplier supplier;
+
+        private LongMetricValue(LongValueSupplier supplier) {
+            this.supplier = supplier;
+        }
+
+        @Override
+        public Number get() {
+            return supplier.get();
+        }
+
+        @Override
+        public String getType() {
+            return Long.class.getName();
+        }
+    }
+
+    private static final class DoubleMetricValue implements MetricValue {
+        private final DoubleValueSupplier supplier;
+
+        private DoubleMetricValue(DoubleValueSupplier supplier) {
+            this.supplier = supplier;
+        }
+
+        @Override
+        public Number get() {
+            return supplier.get();
+        }
+
+        @Override
+        public String getType() {
+            return Double.class.getName();
+        }
+    }
+
+    private static final class JmxHistogram {
+        private final List<Double> boundaries;
+        private final LongAdder count = new LongAdder();
+        private final DoubleAdder sum = new DoubleAdder();
+        private final LongAdder[] buckets;
+
+        private JmxHistogram(List<Double> boundaries) {
+            this.boundaries = boundaries;
+            this.buckets = new LongAdder[boundaries.size() + 1];
+            for (int i = 0; i < buckets.length; i++) {
+                buckets[i] = new LongAdder();
+            }
+        }
+
+        private void record(double value) {
+            count.increment();
+            sum.add(value);
+            int bucket = boundaries.size();
+            if (!Double.isNaN(value)) {
+                for (int i = 0; i < boundaries.size(); i++) {
+                    if (value <= boundaries.get(i)) {
+                        bucket = i;
+                        break;
+                    }
+                }
+            }
+            buckets[bucket].increment();
+        }
+
+        private long cumulativeBucketCount(int bucketIndex) {
+            long result = 0;
+            for (int i = 0; i <= bucketIndex; i++) {
+                result += buckets[i].sum();
+            }
+            return result;
+        }
+    }
+
+    private static final class ClientMetricsMBean implements DynamicMBean {
+        private volatile Map<String, MetricValue> metrics = Collections.emptyMap();
+
+        private boolean putAllIfAbsent(Map<String, MetricValue> additions) {
+            Map<String, MetricValue> updated = new LinkedHashMap<>(metrics);
+            boolean changed = false;
+            for (Map.Entry<String, MetricValue> entry : additions.entrySet()) {
+                if (!updated.containsKey(entry.getKey())) {
+                    updated.put(entry.getKey(), entry.getValue());
+                    changed = true;
+                }
+            }
+            if (changed) {
+                metrics = Collections.unmodifiableMap(updated);
+            }
+            return changed;
+        }
+
+        @Override
+        public Object getAttribute(String attribute) throws AttributeNotFoundException {
+            MetricValue metric = metrics.get(attribute);
+            if (null == metric) {
+                throw new AttributeNotFoundException(attribute);
+            }
+            return metric.get();
+        }
+
+        @Override
+        public AttributeList getAttributes(String[] attributes) {
+            AttributeList result = new AttributeList(attributes.length);
+            for (String attribute : attributes) {
+                MetricValue metric = metrics.get(attribute);
+                if (null != metric) {
+                    result.add(new Attribute(attribute, metric.get()));
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public void setAttribute(Attribute attribute)
+            throws AttributeNotFoundException, InvalidAttributeValueException, MBeanException, ReflectionException {
+            throw new AttributeNotFoundException(null == attribute ? null : attribute.getName());
+        }
+
+        @Override
+        public AttributeList setAttributes(AttributeList attributes) {
+            return new AttributeList();
+        }
+
+        @Override
+        public Object invoke(String actionName, Object[] params, String[] signature) throws ReflectionException {
+            throw new ReflectionException(new NoSuchMethodException(actionName));
+        }
+
+        @Override
+        public MBeanInfo getMBeanInfo() {
+            Map<String, MetricValue> snapshot = metrics;
+            MBeanAttributeInfo[] attributes = new MBeanAttributeInfo[snapshot.size()];
+            int index = 0;
+            for (Map.Entry<String, MetricValue> entry : snapshot.entrySet()) {
+                attributes[index++] = new MBeanAttributeInfo(entry.getKey(), entry.getValue().getType(),
+                    "RocketMQ client metric", true, false, false);
+            }
+            return new MBeanInfo(ClientMetricsMBean.class.getName(), "RocketMQ client metrics", attributes,
+                null, NO_OPERATIONS, null);
+        }
+    }
+}

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.DoubleAdder;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
 import javax.management.Attribute;
 import javax.management.AttributeList;
@@ -72,7 +73,7 @@ final class ClientJmxReporter {
     private final ClientId clientId;
     private final MBeanServer mBeanServer;
     private final AtomicBoolean enabled;
-    private final Object registrationLock = new Object();
+    private final ReentrantLock registrationLock = new ReentrantLock();
     private final Map<ObjectName, ClientMetricsMBean> mBeans;
     private final Map<HistogramEnum, ConcurrentMap<Attributes, JmxHistogram>> histograms;
     private final Map<GaugeEnum, Set<Attributes>> registeredGaugeAttributes;
@@ -151,7 +152,8 @@ final class ClientJmxReporter {
                 Map<Attributes, Double> values = observer.getValues(gauge);
                 observedGaugeAttributes.get(gauge).addAll(values.keySet());
             }
-            synchronized (registrationLock) {
+            registrationLock.lock();
+            try {
                 if (!enabled.get()) {
                     return;
                 }
@@ -159,18 +161,20 @@ final class ClientJmxReporter {
                     Set<Attributes> observed = observedGaugeAttributes.get(gauge);
                     Set<Attributes> registered = registeredGaugeAttributes.get(gauge);
                     for (Attributes attributes : observed) {
-                        if (!registered.contains(attributes) && registerGauge(gauge, attributes)) {
+                        if (!registered.contains(attributes) && registerGaugeLocked(gauge, attributes)) {
                             registered.add(attributes);
                         }
                     }
                     Iterator<Attributes> iterator = registered.iterator();
                     while (iterator.hasNext()) {
                         Attributes attributes = iterator.next();
-                        if (!observed.contains(attributes) && removeGauge(gauge, attributes)) {
+                        if (!observed.contains(attributes) && removeGaugeLocked(gauge, attributes)) {
                             iterator.remove();
                         }
                     }
                 }
+            } finally {
+                registrationLock.unlock();
             }
         } catch (RuntimeException e) {
             log.warn("Failed to refresh client JMX gauges, clientId={}", clientId, e);
@@ -183,7 +187,8 @@ final class ClientJmxReporter {
         if (null == mBeanServer) {
             return;
         }
-        synchronized (registrationLock) {
+        registrationLock.lock();
+        try {
             Iterator<Map.Entry<ObjectName, ClientMetricsMBean>> iterator = mBeans.entrySet().iterator();
             while (iterator.hasNext()) {
                 ObjectName objectName = iterator.next().getKey();
@@ -205,12 +210,15 @@ final class ClientJmxReporter {
             }
             suppressedRegistrations.clear();
             warnedGaugeRemovalFailures.clear();
+        } finally {
+            registrationLock.unlock();
         }
     }
 
     private JmxHistogram registerHistogram(HistogramEnum histogramType, Attributes attributes,
         ConcurrentMap<Attributes, JmxHistogram> series) {
-        synchronized (registrationLock) {
+        registrationLock.lock();
+        try {
             if (!enabled.get() || suppressedRegistrations.contains(attributes)) {
                 return null;
             }
@@ -230,24 +238,26 @@ final class ClientJmxReporter {
                     new LongMetricValue(() -> histogram.cumulativeBucketCount(bucketIndex)));
             }
             metrics.put(prefix + "_bucket_le_inf", new LongMetricValue(histogram.count::sum));
-            if (!registerMetrics(attributes, metrics)) {
+            if (!registerMetricsLocked(attributes, metrics)) {
                 return null;
             }
             series.put(attributes, histogram);
             return histogram;
+        } finally {
+            registrationLock.unlock();
         }
     }
 
-    private boolean registerGauge(GaugeEnum gauge, Attributes attributes) {
+    private boolean registerGaugeLocked(GaugeEnum gauge, Attributes attributes) {
         if (suppressedRegistrations.contains(attributes)) {
             return false;
         }
         Map<String, MetricValue> metrics = Collections.singletonMap(gauge.getName(),
             new DoubleMetricValue(() -> getGaugeValue(gauge, attributes)));
-        return registerMetrics(attributes, metrics);
+        return registerMetricsLocked(attributes, metrics);
     }
 
-    private boolean removeGauge(GaugeEnum gauge, Attributes attributes) {
+    private boolean removeGaugeLocked(GaugeEnum gauge, Attributes attributes) {
         try {
             ObjectName objectName = objectName(attributes);
             ClientMetricsMBean mBean = mBeans.get(objectName);
@@ -284,37 +294,35 @@ final class ClientJmxReporter {
         }
     }
 
-    private boolean registerMetrics(Attributes attributes, Map<String, MetricValue> metrics) {
-        synchronized (registrationLock) {
-            if (!enabled.get() || suppressedRegistrations.contains(attributes)) {
-                return false;
-            }
-            try {
-                ObjectName objectName = objectName(attributes);
-                ClientMetricsMBean mBean = mBeans.get(objectName);
-                if (null == mBean) {
-                    mBean = new ClientMetricsMBean();
-                    mBean.putAllIfAbsent(metrics);
-                    mBeanServer.registerMBean(mBean, objectName);
-                    mBeans.put(objectName, mBean);
-                    return true;
-                }
-                boolean changed = mBean.putAllIfAbsent(metrics);
-                if (!changed && mBeanServer.isRegistered(objectName)) {
-                    return true;
-                }
-                if (mBeanServer.isRegistered(objectName)) {
-                    mBeanServer.unregisterMBean(objectName);
-                }
+    private boolean registerMetricsLocked(Attributes attributes, Map<String, MetricValue> metrics) {
+        if (!enabled.get() || suppressedRegistrations.contains(attributes)) {
+            return false;
+        }
+        try {
+            ObjectName objectName = objectName(attributes);
+            ClientMetricsMBean mBean = mBeans.get(objectName);
+            if (null == mBean) {
+                mBean = new ClientMetricsMBean();
+                mBean.putAllIfAbsent(metrics);
                 mBeanServer.registerMBean(mBean, objectName);
+                mBeans.put(objectName, mBean);
                 return true;
-            } catch (JMException | RuntimeException e) {
-                if (suppressedRegistrations.add(attributes)) {
-                    log.warn("Failed to register client metrics MBean, suppress further attempts, clientId={}",
-                        clientId, e);
-                }
-                return false;
             }
+            boolean changed = mBean.putAllIfAbsent(metrics);
+            if (!changed && mBeanServer.isRegistered(objectName)) {
+                return true;
+            }
+            if (mBeanServer.isRegistered(objectName)) {
+                mBeanServer.unregisterMBean(objectName);
+            }
+            mBeanServer.registerMBean(mBean, objectName);
+            return true;
+        } catch (JMException | RuntimeException e) {
+            if (suppressedRegistrations.add(attributes)) {
+                log.warn("Failed to register client metrics MBean, suppress further attempts, clientId={}",
+                    clientId, e);
+            }
+            return false;
         }
     }
 

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
@@ -98,10 +98,7 @@ final class ClientJmxReporter {
         this.enabled = new AtomicBoolean(initialized);
         if (initialized) {
             this.mBeans = new HashMap<>();
-            this.histograms = new EnumMap<>(HistogramEnum.class);
-            for (HistogramEnum histogram : HistogramEnum.values()) {
-                this.histograms.put(histogram, new ConcurrentHashMap<>());
-            }
+            this.histograms = new ConcurrentHashMap<>();
             this.registeredGaugeAttributes = new EnumMap<>(GaugeEnum.class);
             for (GaugeEnum gauge : GaugeEnum.values()) {
                 this.registeredGaugeAttributes.put(gauge, new HashSet<>());
@@ -129,7 +126,8 @@ final class ClientJmxReporter {
         if (!enabled.get() || suppressedRegistrations.contains(attributes)) {
             return;
         }
-        ConcurrentMap<Attributes, JmxHistogram> series = histograms.get(histogramType);
+        ConcurrentMap<Attributes, JmxHistogram> series = histograms.computeIfAbsent(histogramType,
+            ignored -> new ConcurrentHashMap<>());
         JmxHistogram histogram = series.get(attributes);
         if (null == histogram) {
             histogram = registerHistogram(histogramType, attributes, series);
@@ -203,9 +201,7 @@ final class ClientJmxReporter {
                         objectName, clientId, e);
                 }
             }
-            for (ConcurrentMap<Attributes, JmxHistogram> series : histograms.values()) {
-                series.clear();
-            }
+            histograms.clear();
             for (Set<Attributes> registered : registeredGaugeAttributes.values()) {
                 registered.clear();
             }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
@@ -125,10 +125,8 @@ final class ClientJmxReporter {
         }
         ConcurrentMap<Attributes, JmxHistogram> series = histograms.computeIfAbsent(histogramType,
             ignored -> new ConcurrentHashMap<>());
-        JmxHistogram histogram = series.get(attributes);
-        if (null == histogram) {
-            histogram = registerHistogram(histogramType, attributes, series);
-        }
+        JmxHistogram histogram = series.computeIfAbsent(attributes,
+            ignored -> registerHistogram(histogramType, attributes));
         if (null != histogram) {
             histogram.record(value);
         }
@@ -219,16 +217,11 @@ final class ClientJmxReporter {
         }
     }
 
-    private JmxHistogram registerHistogram(HistogramEnum histogramType, Attributes attributes,
-        ConcurrentMap<Attributes, JmxHistogram> series) {
+    private JmxHistogram registerHistogram(HistogramEnum histogramType, Attributes attributes) {
         registrationLock.lock();
         try {
             if (!enabled.get() || suppressedRegistrations.contains(attributes)) {
                 return null;
-            }
-            JmxHistogram existed = series.get(attributes);
-            if (null != existed) {
-                return existed;
             }
             JmxHistogram histogram = new JmxHistogram(histogramType.getBoundaries());
             Map<String, MetricValue> metrics = new LinkedHashMap<>();
@@ -245,7 +238,6 @@ final class ClientJmxReporter {
             if (!registerMetricsLocked(attributes, metrics)) {
                 return null;
             }
-            series.put(attributes, histogram);
             return histogram;
         } finally {
             registrationLock.unlock();

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
@@ -20,13 +20,15 @@ package org.apache.rocketmq.client.java.metrics;
 import io.opentelemetry.api.common.Attributes;
 import java.lang.management.ManagementFactory;
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
@@ -73,6 +75,9 @@ final class ClientJmxReporter {
     private final Object registrationLock = new Object();
     private final Map<ObjectName, ClientMetricsMBean> mBeans;
     private final Map<HistogramEnum, ConcurrentMap<Attributes, JmxHistogram>> histograms;
+    private final Map<GaugeEnum, Set<Attributes>> registeredGaugeAttributes;
+    private final Set<Attributes> suppressedRegistrations;
+    private final Set<Attributes> warnedGaugeRemovalFailures;
     private volatile GaugeObserver gaugeObserver = GaugeObserver.EMPTY;
 
     ClientJmxReporter(ClientId clientId) {
@@ -95,9 +100,18 @@ final class ClientJmxReporter {
             for (HistogramEnum histogram : HistogramEnum.values()) {
                 this.histograms.put(histogram, new ConcurrentHashMap<>());
             }
+            this.registeredGaugeAttributes = new EnumMap<>(GaugeEnum.class);
+            for (GaugeEnum gauge : GaugeEnum.values()) {
+                this.registeredGaugeAttributes.put(gauge, new HashSet<>());
+            }
+            this.suppressedRegistrations = ConcurrentHashMap.newKeySet();
+            this.warnedGaugeRemovalFailures = ConcurrentHashMap.newKeySet();
         } else {
             this.mBeans = Collections.emptyMap();
             this.histograms = Collections.emptyMap();
+            this.registeredGaugeAttributes = Collections.emptyMap();
+            this.suppressedRegistrations = Collections.emptySet();
+            this.warnedGaugeRemovalFailures = Collections.emptySet();
         }
     }
 
@@ -110,7 +124,7 @@ final class ClientJmxReporter {
     }
 
     void record(HistogramEnum histogramType, Attributes attributes, double value) {
-        if (!enabled.get()) {
+        if (!enabled.get() || suppressedRegistrations.contains(attributes)) {
             return;
         }
         ConcurrentMap<Attributes, JmxHistogram> series = histograms.get(histogramType);
@@ -129,10 +143,33 @@ final class ClientJmxReporter {
         }
         GaugeObserver observer = gaugeObserver;
         try {
+            Map<GaugeEnum, Set<Attributes>> observedGaugeAttributes = new EnumMap<>(GaugeEnum.class);
+            for (GaugeEnum gauge : GaugeEnum.values()) {
+                observedGaugeAttributes.put(gauge, new HashSet<>());
+            }
             for (GaugeEnum gauge : observer.getGauges()) {
                 Map<Attributes, Double> values = observer.getValues(gauge);
-                for (Attributes attributes : values.keySet()) {
-                    registerGauge(gauge, attributes);
+                observedGaugeAttributes.get(gauge).addAll(values.keySet());
+            }
+            synchronized (registrationLock) {
+                if (!enabled.get()) {
+                    return;
+                }
+                for (GaugeEnum gauge : GaugeEnum.values()) {
+                    Set<Attributes> observed = observedGaugeAttributes.get(gauge);
+                    Set<Attributes> registered = registeredGaugeAttributes.get(gauge);
+                    for (Attributes attributes : observed) {
+                        if (!registered.contains(attributes) && registerGauge(gauge, attributes)) {
+                            registered.add(attributes);
+                        }
+                    }
+                    Iterator<Attributes> iterator = registered.iterator();
+                    while (iterator.hasNext()) {
+                        Attributes attributes = iterator.next();
+                        if (!observed.contains(attributes) && removeGauge(gauge, attributes)) {
+                            iterator.remove();
+                        }
+                    }
                 }
             }
         } catch (RuntimeException e) {
@@ -141,27 +178,42 @@ final class ClientJmxReporter {
     }
 
     void shutdown() {
-        if (!enabled.compareAndSet(true, false)) {
+        enabled.set(false);
+        gaugeObserver = GaugeObserver.EMPTY;
+        if (null == mBeanServer) {
             return;
         }
         synchronized (registrationLock) {
-            for (ObjectName objectName : new ArrayList<>(mBeans.keySet())) {
+            Iterator<Map.Entry<ObjectName, ClientMetricsMBean>> iterator = mBeans.entrySet().iterator();
+            while (iterator.hasNext()) {
+                ObjectName objectName = iterator.next().getKey();
                 try {
                     if (mBeanServer.isRegistered(objectName)) {
                         mBeanServer.unregisterMBean(objectName);
                     }
+                    iterator.remove();
                 } catch (JMException | RuntimeException e) {
                     log.warn("Failed to unregister client metrics MBean, objectName={}, clientId={}",
                         objectName, clientId, e);
                 }
             }
-            mBeans.clear();
+            for (ConcurrentMap<Attributes, JmxHistogram> series : histograms.values()) {
+                series.clear();
+            }
+            for (Set<Attributes> registered : registeredGaugeAttributes.values()) {
+                registered.clear();
+            }
+            suppressedRegistrations.clear();
+            warnedGaugeRemovalFailures.clear();
         }
     }
 
     private JmxHistogram registerHistogram(HistogramEnum histogramType, Attributes attributes,
         ConcurrentMap<Attributes, JmxHistogram> series) {
         synchronized (registrationLock) {
+            if (!enabled.get() || suppressedRegistrations.contains(attributes)) {
+                return null;
+            }
             JmxHistogram existed = series.get(attributes);
             if (null != existed) {
                 return existed;
@@ -186,10 +238,40 @@ final class ClientJmxReporter {
         }
     }
 
-    private void registerGauge(GaugeEnum gauge, Attributes attributes) {
+    private boolean registerGauge(GaugeEnum gauge, Attributes attributes) {
+        if (suppressedRegistrations.contains(attributes)) {
+            return false;
+        }
         Map<String, MetricValue> metrics = Collections.singletonMap(gauge.getName(),
             new DoubleMetricValue(() -> getGaugeValue(gauge, attributes)));
-        registerMetrics(attributes, metrics);
+        return registerMetrics(attributes, metrics);
+    }
+
+    private boolean removeGauge(GaugeEnum gauge, Attributes attributes) {
+        try {
+            ObjectName objectName = objectName(attributes);
+            ClientMetricsMBean mBean = mBeans.get(objectName);
+            if (null == mBean) {
+                warnedGaugeRemovalFailures.remove(attributes);
+                return true;
+            }
+            mBean.remove(gauge.getName());
+            if (!mBean.isEmpty()) {
+                warnedGaugeRemovalFailures.remove(attributes);
+                return true;
+            }
+            if (mBeanServer.isRegistered(objectName)) {
+                mBeanServer.unregisterMBean(objectName);
+            }
+            mBeans.remove(objectName);
+            warnedGaugeRemovalFailures.remove(attributes);
+            return true;
+        } catch (JMException | RuntimeException e) {
+            if (warnedGaugeRemovalFailures.add(attributes)) {
+                log.warn("Failed to remove stale client JMX gauge, gauge={}, clientId={}", gauge, clientId, e);
+            }
+            return false;
+        }
     }
 
     private double getGaugeValue(GaugeEnum gauge, Attributes attributes) {
@@ -204,6 +286,9 @@ final class ClientJmxReporter {
 
     private boolean registerMetrics(Attributes attributes, Map<String, MetricValue> metrics) {
         synchronized (registrationLock) {
+            if (!enabled.get() || suppressedRegistrations.contains(attributes)) {
+                return false;
+            }
             try {
                 ObjectName objectName = objectName(attributes);
                 ClientMetricsMBean mBean = mBeans.get(objectName);
@@ -224,7 +309,10 @@ final class ClientJmxReporter {
                 mBeanServer.registerMBean(mBean, objectName);
                 return true;
             } catch (JMException | RuntimeException e) {
-                log.warn("Failed to register client metrics MBean, clientId={}", clientId, e);
+                if (suppressedRegistrations.add(attributes)) {
+                    log.warn("Failed to register client metrics MBean, suppress further attempts, clientId={}",
+                        clientId, e);
+                }
                 return false;
             }
         }
@@ -366,6 +454,21 @@ final class ClientJmxReporter {
             }
             metrics = Collections.unmodifiableMap(updated);
             return true;
+        }
+
+        private boolean remove(String metricName) {
+            Map<String, MetricValue> snapshot = metrics;
+            if (!snapshot.containsKey(metricName)) {
+                return false;
+            }
+            Map<String, MetricValue> updated = new LinkedHashMap<>(snapshot);
+            updated.remove(metricName);
+            metrics = Collections.unmodifiableMap(updated);
+            return true;
+        }
+
+        private boolean isEmpty() {
+            return metrics.isEmpty();
         }
 
         @Override

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
@@ -60,7 +60,8 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The reporter does not open a network port or depend on a Prometheus library. When enabled, applications that
  * already run a Prometheus JMX exporter can collect these MBeans. The reporter is disabled by default and can be
- * enabled before creating a client with the {@code rocketmq.client.jmx.enabled} system property.
+ * enabled before creating a client with the {@code rocketmq.client.jmx.enabled} system property. The exporter should
+ * include ObjectNames matching {@code org.apache.rocketmq.client:type=message-metrics,*}.
  */
 final class ClientJmxReporter {
     static final String DOMAIN = "org.apache.rocketmq.client";

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
@@ -100,9 +100,6 @@ final class ClientJmxReporter {
             this.mBeans = new HashMap<>();
             this.histograms = new ConcurrentHashMap<>();
             this.registeredGaugeAttributes = new EnumMap<>(GaugeEnum.class);
-            for (GaugeEnum gauge : GaugeEnum.values()) {
-                this.registeredGaugeAttributes.put(gauge, new HashSet<>());
-            }
             this.suppressedRegistrations = ConcurrentHashMap.newKeySet();
             this.warnedGaugeRemovalFailures = ConcurrentHashMap.newKeySet();
         } else {
@@ -144,32 +141,42 @@ final class ClientJmxReporter {
         GaugeObserver observer = gaugeObserver;
         try {
             Map<GaugeEnum, Set<Attributes>> observedGaugeAttributes = new EnumMap<>(GaugeEnum.class);
-            for (GaugeEnum gauge : GaugeEnum.values()) {
-                observedGaugeAttributes.put(gauge, new HashSet<>());
-            }
             for (GaugeEnum gauge : observer.getGauges()) {
                 Map<Attributes, Double> values = observer.getValues(gauge);
-                observedGaugeAttributes.get(gauge).addAll(values.keySet());
+                observedGaugeAttributes.computeIfAbsent(gauge, ignored -> new HashSet<>())
+                    .addAll(values.keySet());
             }
             registrationLock.lock();
             try {
                 if (!enabled.get()) {
                     return;
                 }
-                for (GaugeEnum gauge : GaugeEnum.values()) {
-                    Set<Attributes> observed = observedGaugeAttributes.get(gauge);
-                    Set<Attributes> registered = registeredGaugeAttributes.get(gauge);
-                    for (Attributes attributes : observed) {
+                for (Map.Entry<GaugeEnum, Set<Attributes>> entry : observedGaugeAttributes.entrySet()) {
+                    GaugeEnum gauge = entry.getKey();
+                    Set<Attributes> registered = registeredGaugeAttributes.computeIfAbsent(gauge,
+                        ignored -> new HashSet<>());
+                    for (Attributes attributes : entry.getValue()) {
                         if (!registered.contains(attributes) && registerGaugeLocked(gauge, attributes)) {
                             registered.add(attributes);
                         }
                     }
+                }
+                Iterator<Map.Entry<GaugeEnum, Set<Attributes>>> gaugeIterator =
+                    registeredGaugeAttributes.entrySet().iterator();
+                while (gaugeIterator.hasNext()) {
+                    Map.Entry<GaugeEnum, Set<Attributes>> entry = gaugeIterator.next();
+                    Set<Attributes> observed = observedGaugeAttributes.getOrDefault(entry.getKey(),
+                        Collections.emptySet());
+                    Set<Attributes> registered = entry.getValue();
                     Iterator<Attributes> iterator = registered.iterator();
                     while (iterator.hasNext()) {
                         Attributes attributes = iterator.next();
-                        if (!observed.contains(attributes) && removeGaugeLocked(gauge, attributes)) {
+                        if (!observed.contains(attributes) && removeGaugeLocked(entry.getKey(), attributes)) {
                             iterator.remove();
                         }
+                    }
+                    if (registered.isEmpty()) {
+                        gaugeIterator.remove();
                     }
                 }
             } finally {

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporter.java
@@ -55,7 +55,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Registers RocketMQ client metrics in the platform MBean server, following Kafka's JMX reporter model.
+ * Registers RocketMQ client metrics in the platform MBean server.
  *
  * <p>The reporter does not open a network port or depend on a Prometheus library. When enabled, applications that
  * already run a Prometheus JMX exporter can collect these MBeans. The reporter is disabled by default and can be

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeter.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeter.java
@@ -27,6 +27,7 @@ import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.rocketmq.client.java.misc.ClientId;
 import org.apache.rocketmq.client.java.route.Endpoints;
 import org.slf4j.Logger;
@@ -35,7 +36,7 @@ import org.slf4j.LoggerFactory;
 public class ClientMeter {
     private static final Logger log = LoggerFactory.getLogger(ClientMeter.class);
 
-    private final boolean enabled;
+    private final AtomicBoolean enabled;
     private final Meter meter;
     private final Endpoints endpoints;
     private final SdkMeterProvider provider;
@@ -43,7 +44,7 @@ public class ClientMeter {
     private final ConcurrentMap<String /* histogram name */, DoubleHistogram> histogramMap;
 
     public ClientMeter(Meter meter, Endpoints endpoints, SdkMeterProvider provider, ClientId clientId) {
-        this.enabled = true;
+        this.enabled = new AtomicBoolean(true);
         this.meter = checkNotNull(meter, "meter should not be null");
         this.endpoints = checkNotNull(endpoints, "endpoints should not be null");
         this.provider = checkNotNull(provider, "provider should not be null");
@@ -52,7 +53,7 @@ public class ClientMeter {
     }
 
     private ClientMeter(ClientId clientId) {
-        this.enabled = false;
+        this.enabled = new AtomicBoolean(false);
         this.meter = null;
         this.endpoints = null;
         this.provider = null;
@@ -65,44 +66,54 @@ public class ClientMeter {
     }
 
     public boolean isEnabled() {
-        return enabled;
+        return enabled.get();
     }
 
     public void record(HistogramEnum histogramEnum, Attributes attributes, double value) {
-        final DoubleHistogram histogram = histogramMap.computeIfAbsent(histogramEnum.getName(), name -> enabled ?
+        if (!enabled.get()) {
+            return;
+        }
+        final DoubleHistogram histogram = histogramMap.computeIfAbsent(histogramEnum.getName(), name -> enabled.get() ?
             meter.histogramBuilder(histogramEnum.getName()).build() : null);
         if (null == histogram) {
+            return;
+        }
+        if (!enabled.get()) {
+            histogramMap.remove(histogramEnum.getName(), histogram);
             return;
         }
         histogram.record(value, attributes);
     }
 
     public void shutdown() {
-        if (!enabled) {
+        if (!enabled.compareAndSet(true, false)) {
+            histogramMap.clear();
             return;
         }
         log.info("Begin to shutdown client meter, clientId={}, endpoints={}", clientId, endpoints);
         final CountDownLatch latch = new CountDownLatch(1);
-        provider.shutdown().whenComplete(latch::countDown);
         try {
+            provider.shutdown().whenComplete(latch::countDown);
             latch.await();
             log.info("Shutdown client meter successfully, clientId={}, endpoints={}", clientId, endpoints);
         } catch (Throwable t) {
             log.error("Failed to shutdown message meter, clientId={}, endpoints={}", clientId, endpoints, t);
+        } finally {
+            histogramMap.clear();
         }
     }
 
     public boolean satisfy(Metric metric) {
-        if (enabled && metric.isOn() && endpoints.equals(metric.getEndpoints())) {
+        if (enabled.get() && metric.isOn() && endpoints.equals(metric.getEndpoints())) {
             return true;
         }
-        return !enabled && !metric.isOn();
+        return !enabled.get() && !metric.isOn();
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-            .add("enabled", enabled)
+            .add("enabled", enabled.get())
             .add("meter", meter)
             .add("endpoints", endpoints)
             .add("provider", provider)

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeter.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeter.java
@@ -27,7 +27,6 @@ import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.rocketmq.client.java.misc.ClientId;
 import org.apache.rocketmq.client.java.route.Endpoints;
 import org.slf4j.Logger;
@@ -36,7 +35,6 @@ import org.slf4j.LoggerFactory;
 public class ClientMeter {
     private static final Logger log = LoggerFactory.getLogger(ClientMeter.class);
 
-    private final ReentrantReadWriteLock lifecycleLock = new ReentrantReadWriteLock();
     private volatile boolean enabled;
     private final Meter meter;
     private final Endpoints endpoints;
@@ -74,51 +72,27 @@ public class ClientMeter {
         if (!enabled) {
             return;
         }
-        final String histogramName = histogramEnum.getName();
-        DoubleHistogram histogram = histogramMap.get(histogramName);
+        final DoubleHistogram histogram = histogramMap.computeIfAbsent(histogramEnum.getName(), name -> enabled ?
+            meter.histogramBuilder(histogramEnum.getName()).build() : null);
         if (null == histogram) {
-            histogram = getOrCreateHistogram(histogramName);
+            return;
         }
-        if (null != histogram) {
-            histogram.record(value, attributes);
-        }
-    }
-
-    private DoubleHistogram getOrCreateHistogram(String histogramName) {
-        // Keep the lifecycle lock around the entire compute so shutdown cannot clear the map before publication.
-        lifecycleLock.readLock().lock();
-        try {
-            if (!enabled) {
-                return null;
-            }
-            return histogramMap.computeIfAbsent(histogramName,
-                name -> meter.histogramBuilder(name).build());
-        } finally {
-            lifecycleLock.readLock().unlock();
-        }
+        histogram.record(value, attributes);
     }
 
     public void shutdown() {
-        lifecycleLock.writeLock().lock();
+        if (!enabled) {
+            return;
+        }
+        enabled = false;
+        log.info("Begin to shutdown client meter, clientId={}, endpoints={}", clientId, endpoints);
+        final CountDownLatch latch = new CountDownLatch(1);
+        provider.shutdown().whenComplete(latch::countDown);
         try {
-            if (!enabled) {
-                histogramMap.clear();
-                return;
-            }
-            enabled = false;
-            log.info("Begin to shutdown client meter, clientId={}, endpoints={}", clientId, endpoints);
-            final CountDownLatch latch = new CountDownLatch(1);
-            try {
-                provider.shutdown().whenComplete(latch::countDown);
-                latch.await();
-                log.info("Shutdown client meter successfully, clientId={}, endpoints={}", clientId, endpoints);
-            } catch (Throwable t) {
-                log.error("Failed to shutdown message meter, clientId={}, endpoints={}", clientId, endpoints, t);
-            } finally {
-                histogramMap.clear();
-            }
-        } finally {
-            lifecycleLock.writeLock().unlock();
+            latch.await();
+            log.info("Shutdown client meter successfully, clientId={}, endpoints={}", clientId, endpoints);
+        } catch (Throwable t) {
+            log.error("Failed to shutdown message meter, clientId={}, endpoints={}", clientId, endpoints, t);
         }
     }
 

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeter.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeter.java
@@ -71,14 +71,28 @@ public class ClientMeter {
     }
 
     public void record(HistogramEnum histogramEnum, Attributes attributes, double value) {
+        if (!enabled) {
+            return;
+        }
+        final String histogramName = histogramEnum.getName();
+        DoubleHistogram histogram = histogramMap.get(histogramName);
+        if (null == histogram) {
+            histogram = getOrCreateHistogram(histogramName);
+        }
+        if (null != histogram) {
+            histogram.record(value, attributes);
+        }
+    }
+
+    private DoubleHistogram getOrCreateHistogram(String histogramName) {
+        // Only instrument creation needs lifecycle coordination. Existing instruments can record without this lock.
         lifecycleLock.readLock().lock();
         try {
             if (!enabled) {
-                return;
+                return null;
             }
-            final DoubleHistogram histogram = histogramMap.computeIfAbsent(histogramEnum.getName(),
+            return histogramMap.computeIfAbsent(histogramName,
                 name -> meter.histogramBuilder(name).build());
-            histogram.record(value, attributes);
         } finally {
             lifecycleLock.readLock().unlock();
         }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeter.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeter.java
@@ -24,10 +24,10 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.rocketmq.client.java.misc.ClientId;
 import org.apache.rocketmq.client.java.route.Endpoints;
 import org.slf4j.Logger;
@@ -36,30 +36,30 @@ import org.slf4j.LoggerFactory;
 public class ClientMeter {
     private static final Logger log = LoggerFactory.getLogger(ClientMeter.class);
 
-    private final ReentrantReadWriteLock lifecycleLock = new ReentrantReadWriteLock();
-    private volatile boolean enabled;
     private final Meter meter;
     private final Endpoints endpoints;
     private final SdkMeterProvider provider;
     private final ClientId clientId;
-    private final ConcurrentMap<String /* histogram name */, DoubleHistogram> histogramMap;
+    private final AtomicReference<Map<HistogramEnum, DoubleHistogram>> histogramMap;
 
     public ClientMeter(Meter meter, Endpoints endpoints, SdkMeterProvider provider, ClientId clientId) {
-        this.enabled = true;
         this.meter = checkNotNull(meter, "meter should not be null");
         this.endpoints = checkNotNull(endpoints, "endpoints should not be null");
         this.provider = checkNotNull(provider, "provider should not be null");
         this.clientId = checkNotNull(clientId, "clientId should not be null");
-        this.histogramMap = new ConcurrentHashMap<>();
+        final Map<HistogramEnum, DoubleHistogram> histograms = new EnumMap<>(HistogramEnum.class);
+        for (HistogramEnum histogram : HistogramEnum.values()) {
+            histograms.put(histogram, meter.histogramBuilder(histogram.getName()).build());
+        }
+        this.histogramMap = new AtomicReference<>(histograms);
     }
 
     private ClientMeter(ClientId clientId) {
-        this.enabled = false;
         this.meter = null;
         this.endpoints = null;
         this.provider = null;
         this.clientId = checkNotNull(clientId, "clientId should not be null");
-        this.histogramMap = new ConcurrentHashMap<>();
+        this.histogramMap = new AtomicReference<>();
     }
 
     static ClientMeter disabledInstance(ClientId clientId) {
@@ -67,62 +67,35 @@ public class ClientMeter {
     }
 
     public boolean isEnabled() {
-        return enabled;
+        return null != histogramMap.get();
     }
 
     public void record(HistogramEnum histogramEnum, Attributes attributes, double value) {
-        if (!enabled) {
+        final Map<HistogramEnum, DoubleHistogram> histograms = histogramMap.get();
+        if (null == histograms) {
             return;
         }
-        final String histogramName = histogramEnum.getName();
-        DoubleHistogram histogram = histogramMap.get(histogramName);
-        if (null == histogram) {
-            histogram = getOrCreateHistogram(histogramName);
-        }
-        if (null != histogram) {
-            histogram.record(value, attributes);
-        }
-    }
-
-    private DoubleHistogram getOrCreateHistogram(String histogramName) {
-        // Only instrument creation needs lifecycle coordination. Existing instruments can record without this lock.
-        lifecycleLock.readLock().lock();
-        try {
-            if (!enabled) {
-                return null;
-            }
-            return histogramMap.computeIfAbsent(histogramName,
-                name -> meter.histogramBuilder(name).build());
-        } finally {
-            lifecycleLock.readLock().unlock();
-        }
+        histograms.get(histogramEnum).record(value, attributes);
     }
 
     public void shutdown() {
-        lifecycleLock.writeLock().lock();
+        final Map<HistogramEnum, DoubleHistogram> histograms = histogramMap.getAndSet(null);
+        if (null == histograms) {
+            return;
+        }
+        log.info("Begin to shutdown client meter, clientId={}, endpoints={}", clientId, endpoints);
+        final CountDownLatch latch = new CountDownLatch(1);
         try {
-            if (!enabled) {
-                histogramMap.clear();
-                return;
-            }
-            enabled = false;
-            log.info("Begin to shutdown client meter, clientId={}, endpoints={}", clientId, endpoints);
-            final CountDownLatch latch = new CountDownLatch(1);
-            try {
-                provider.shutdown().whenComplete(latch::countDown);
-                latch.await();
-                log.info("Shutdown client meter successfully, clientId={}, endpoints={}", clientId, endpoints);
-            } catch (Throwable t) {
-                log.error("Failed to shutdown message meter, clientId={}, endpoints={}", clientId, endpoints, t);
-            } finally {
-                histogramMap.clear();
-            }
-        } finally {
-            lifecycleLock.writeLock().unlock();
+            provider.shutdown().whenComplete(latch::countDown);
+            latch.await();
+            log.info("Shutdown client meter successfully, clientId={}, endpoints={}", clientId, endpoints);
+        } catch (Throwable t) {
+            log.error("Failed to shutdown message meter, clientId={}, endpoints={}", clientId, endpoints, t);
         }
     }
 
     public boolean satisfy(Metric metric) {
+        final boolean enabled = isEnabled();
         if (enabled && metric.isOn() && endpoints.equals(metric.getEndpoints())) {
             return true;
         }
@@ -132,11 +105,11 @@ public class ClientMeter {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-            .add("enabled", enabled)
+            .add("enabled", isEnabled())
             .add("meter", meter)
             .add("endpoints", endpoints)
             .add("provider", provider)
-            .add("histogramMap", histogramMap)
+            .add("histogramMap", histogramMap.get())
             .toString();
     }
 }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeter.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeter.java
@@ -79,6 +79,8 @@ public class ClientMeter {
             return;
         }
         if (!enabled.get()) {
+            // Shutdown may clear the map while this thread is creating the histogram. Do not let an in-flight record
+            // repopulate the cache after shutdown.
             histogramMap.remove(histogramEnum.getName(), histogram);
             return;
         }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeter.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeter.java
@@ -24,10 +24,10 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
-import java.util.EnumMap;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.rocketmq.client.java.misc.ClientId;
 import org.apache.rocketmq.client.java.route.Endpoints;
 import org.slf4j.Logger;
@@ -36,30 +36,30 @@ import org.slf4j.LoggerFactory;
 public class ClientMeter {
     private static final Logger log = LoggerFactory.getLogger(ClientMeter.class);
 
+    private final ReentrantReadWriteLock lifecycleLock = new ReentrantReadWriteLock();
+    private volatile boolean enabled;
     private final Meter meter;
     private final Endpoints endpoints;
     private final SdkMeterProvider provider;
     private final ClientId clientId;
-    private final AtomicReference<Map<HistogramEnum, DoubleHistogram>> histogramMap;
+    private final ConcurrentMap<String /* histogram name */, DoubleHistogram> histogramMap;
 
     public ClientMeter(Meter meter, Endpoints endpoints, SdkMeterProvider provider, ClientId clientId) {
+        this.enabled = true;
         this.meter = checkNotNull(meter, "meter should not be null");
         this.endpoints = checkNotNull(endpoints, "endpoints should not be null");
         this.provider = checkNotNull(provider, "provider should not be null");
         this.clientId = checkNotNull(clientId, "clientId should not be null");
-        final Map<HistogramEnum, DoubleHistogram> histograms = new EnumMap<>(HistogramEnum.class);
-        for (HistogramEnum histogram : HistogramEnum.values()) {
-            histograms.put(histogram, meter.histogramBuilder(histogram.getName()).build());
-        }
-        this.histogramMap = new AtomicReference<>(histograms);
+        this.histogramMap = new ConcurrentHashMap<>();
     }
 
     private ClientMeter(ClientId clientId) {
+        this.enabled = false;
         this.meter = null;
         this.endpoints = null;
         this.provider = null;
         this.clientId = checkNotNull(clientId, "clientId should not be null");
-        this.histogramMap = new AtomicReference<>();
+        this.histogramMap = new ConcurrentHashMap<>();
     }
 
     static ClientMeter disabledInstance(ClientId clientId) {
@@ -67,35 +67,62 @@ public class ClientMeter {
     }
 
     public boolean isEnabled() {
-        return null != histogramMap.get();
+        return enabled;
     }
 
     public void record(HistogramEnum histogramEnum, Attributes attributes, double value) {
-        final Map<HistogramEnum, DoubleHistogram> histograms = histogramMap.get();
-        if (null == histograms) {
+        if (!enabled) {
             return;
         }
-        histograms.get(histogramEnum).record(value, attributes);
+        final String histogramName = histogramEnum.getName();
+        DoubleHistogram histogram = histogramMap.get(histogramName);
+        if (null == histogram) {
+            histogram = getOrCreateHistogram(histogramName);
+        }
+        if (null != histogram) {
+            histogram.record(value, attributes);
+        }
+    }
+
+    private DoubleHistogram getOrCreateHistogram(String histogramName) {
+        // Keep the lifecycle lock around the entire compute so shutdown cannot clear the map before publication.
+        lifecycleLock.readLock().lock();
+        try {
+            if (!enabled) {
+                return null;
+            }
+            return histogramMap.computeIfAbsent(histogramName,
+                name -> meter.histogramBuilder(name).build());
+        } finally {
+            lifecycleLock.readLock().unlock();
+        }
     }
 
     public void shutdown() {
-        final Map<HistogramEnum, DoubleHistogram> histograms = histogramMap.getAndSet(null);
-        if (null == histograms) {
-            return;
-        }
-        log.info("Begin to shutdown client meter, clientId={}, endpoints={}", clientId, endpoints);
-        final CountDownLatch latch = new CountDownLatch(1);
+        lifecycleLock.writeLock().lock();
         try {
-            provider.shutdown().whenComplete(latch::countDown);
-            latch.await();
-            log.info("Shutdown client meter successfully, clientId={}, endpoints={}", clientId, endpoints);
-        } catch (Throwable t) {
-            log.error("Failed to shutdown message meter, clientId={}, endpoints={}", clientId, endpoints, t);
+            if (!enabled) {
+                histogramMap.clear();
+                return;
+            }
+            enabled = false;
+            log.info("Begin to shutdown client meter, clientId={}, endpoints={}", clientId, endpoints);
+            final CountDownLatch latch = new CountDownLatch(1);
+            try {
+                provider.shutdown().whenComplete(latch::countDown);
+                latch.await();
+                log.info("Shutdown client meter successfully, clientId={}, endpoints={}", clientId, endpoints);
+            } catch (Throwable t) {
+                log.error("Failed to shutdown message meter, clientId={}, endpoints={}", clientId, endpoints, t);
+            } finally {
+                histogramMap.clear();
+            }
+        } finally {
+            lifecycleLock.writeLock().unlock();
         }
     }
 
     public boolean satisfy(Metric metric) {
-        final boolean enabled = isEnabled();
         if (enabled && metric.isOn() && endpoints.equals(metric.getEndpoints())) {
             return true;
         }
@@ -105,11 +132,11 @@ public class ClientMeter {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-            .add("enabled", isEnabled())
+            .add("enabled", enabled)
             .add("meter", meter)
             .add("endpoints", endpoints)
             .add("provider", provider)
-            .add("histogramMap", histogramMap.get())
+            .add("histogramMap", histogramMap)
             .toString();
     }
 }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeter.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeter.java
@@ -27,7 +27,7 @@ import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.rocketmq.client.java.misc.ClientId;
 import org.apache.rocketmq.client.java.route.Endpoints;
 import org.slf4j.Logger;
@@ -36,7 +36,8 @@ import org.slf4j.LoggerFactory;
 public class ClientMeter {
     private static final Logger log = LoggerFactory.getLogger(ClientMeter.class);
 
-    private final AtomicBoolean enabled;
+    private final ReentrantReadWriteLock lifecycleLock = new ReentrantReadWriteLock();
+    private volatile boolean enabled;
     private final Meter meter;
     private final Endpoints endpoints;
     private final SdkMeterProvider provider;
@@ -44,7 +45,7 @@ public class ClientMeter {
     private final ConcurrentMap<String /* histogram name */, DoubleHistogram> histogramMap;
 
     public ClientMeter(Meter meter, Endpoints endpoints, SdkMeterProvider provider, ClientId clientId) {
-        this.enabled = new AtomicBoolean(true);
+        this.enabled = true;
         this.meter = checkNotNull(meter, "meter should not be null");
         this.endpoints = checkNotNull(endpoints, "endpoints should not be null");
         this.provider = checkNotNull(provider, "provider should not be null");
@@ -53,7 +54,7 @@ public class ClientMeter {
     }
 
     private ClientMeter(ClientId clientId) {
-        this.enabled = new AtomicBoolean(false);
+        this.enabled = false;
         this.meter = null;
         this.endpoints = null;
         this.provider = null;
@@ -66,56 +67,58 @@ public class ClientMeter {
     }
 
     public boolean isEnabled() {
-        return enabled.get();
+        return enabled;
     }
 
     public void record(HistogramEnum histogramEnum, Attributes attributes, double value) {
-        if (!enabled.get()) {
-            return;
+        lifecycleLock.readLock().lock();
+        try {
+            if (!enabled) {
+                return;
+            }
+            final DoubleHistogram histogram = histogramMap.computeIfAbsent(histogramEnum.getName(),
+                name -> meter.histogramBuilder(name).build());
+            histogram.record(value, attributes);
+        } finally {
+            lifecycleLock.readLock().unlock();
         }
-        final DoubleHistogram histogram = histogramMap.computeIfAbsent(histogramEnum.getName(), name -> enabled.get() ?
-            meter.histogramBuilder(histogramEnum.getName()).build() : null);
-        if (null == histogram) {
-            return;
-        }
-        if (!enabled.get()) {
-            // Shutdown may clear the map while this thread is creating the histogram. Do not let an in-flight record
-            // repopulate the cache after shutdown.
-            histogramMap.remove(histogramEnum.getName(), histogram);
-            return;
-        }
-        histogram.record(value, attributes);
     }
 
     public void shutdown() {
-        if (!enabled.compareAndSet(true, false)) {
-            histogramMap.clear();
-            return;
-        }
-        log.info("Begin to shutdown client meter, clientId={}, endpoints={}", clientId, endpoints);
-        final CountDownLatch latch = new CountDownLatch(1);
+        lifecycleLock.writeLock().lock();
         try {
-            provider.shutdown().whenComplete(latch::countDown);
-            latch.await();
-            log.info("Shutdown client meter successfully, clientId={}, endpoints={}", clientId, endpoints);
-        } catch (Throwable t) {
-            log.error("Failed to shutdown message meter, clientId={}, endpoints={}", clientId, endpoints, t);
+            if (!enabled) {
+                histogramMap.clear();
+                return;
+            }
+            enabled = false;
+            log.info("Begin to shutdown client meter, clientId={}, endpoints={}", clientId, endpoints);
+            final CountDownLatch latch = new CountDownLatch(1);
+            try {
+                provider.shutdown().whenComplete(latch::countDown);
+                latch.await();
+                log.info("Shutdown client meter successfully, clientId={}, endpoints={}", clientId, endpoints);
+            } catch (Throwable t) {
+                log.error("Failed to shutdown message meter, clientId={}, endpoints={}", clientId, endpoints, t);
+            } finally {
+                histogramMap.clear();
+            }
         } finally {
-            histogramMap.clear();
+            lifecycleLock.writeLock().unlock();
         }
     }
 
     public boolean satisfy(Metric metric) {
-        if (enabled.get() && metric.isOn() && endpoints.equals(metric.getEndpoints())) {
+        if (enabled && metric.isOn() && endpoints.equals(metric.getEndpoints())) {
             return true;
         }
-        return !enabled.get() && !metric.isOn();
+        return !enabled && !metric.isOn();
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-            .add("enabled", enabled.get())
+            .add("enabled", enabled)
             .add("meter", meter)
             .add("endpoints", endpoints)
             .add("provider", provider)

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeterManager.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeterManager.java
@@ -58,10 +58,9 @@ public class ClientMeterManager {
     private final ClientId clientId;
     private final ClientConfiguration clientConfiguration;
     private final ClientJmxReporter jmxReporter;
-    private final ReentrantLock lifecycleLock = new ReentrantLock();
+    private final ReentrantLock resetLock = new ReentrantLock();
     private volatile ClientMeter clientMeter;
     private volatile GaugeObserver gaugeObserver = GaugeObserver.EMPTY;
-    private boolean closed;
 
     public ClientMeterManager(ClientId clientId, ClientConfiguration clientConfiguration) {
         this.clientId = clientId;
@@ -71,17 +70,9 @@ public class ClientMeterManager {
     }
 
     public void setGaugeObserver(GaugeObserver gaugeObserver) {
-        lifecycleLock.lock();
-        try {
-            if (closed) {
-                return;
-            }
-            this.gaugeObserver = checkNotNull(gaugeObserver, "gaugeObserver should not be null");
-            jmxReporter.setGaugeObserver(gaugeObserver);
-            jmxReporter.refreshGauges();
-        } finally {
-            lifecycleLock.unlock();
-        }
+        this.gaugeObserver = checkNotNull(gaugeObserver, "gaugeObserver should not be null");
+        jmxReporter.setGaugeObserver(gaugeObserver);
+        jmxReporter.refreshGauges();
     }
 
     public void record(HistogramEnum histogramEnum, Attributes attributes, double value) {
@@ -94,38 +85,14 @@ public class ClientMeterManager {
     }
 
     public void shutdown() {
-        lifecycleLock.lock();
-        try {
-            closed = true;
-            gaugeObserver = GaugeObserver.EMPTY;
-            ClientMeter existedClientMeter = clientMeter;
-            clientMeter = ClientMeter.disabledInstance(clientId);
-            jmxReporter.shutdown();
-            existedClientMeter.shutdown();
-        } finally {
-            lifecycleLock.unlock();
-        }
-    }
-
-    public void reset(Metric metric) {
-        lifecycleLock.lock();
-        try {
-            resetLocked(metric);
-        } finally {
-            lifecycleLock.unlock();
-        }
+        clientMeter.shutdown();
+        jmxReporter.shutdown();
     }
 
     @SuppressWarnings({"deprecation", "resource"})
-    private void resetLocked(Metric metric) {
-        ManagedChannel newChannel = null;
-        OtlpGrpcMetricExporter newExporter = null;
-        SdkMeterProvider newProvider = null;
+    public void reset(Metric metric) {
+        resetLock.lock();
         try {
-            if (closed) {
-                log.info("Ignore metrics reset after manager shutdown, clientId={}", clientId);
-                return;
-            }
             if (clientMeter.satisfy(metric)) {
                 log.info("Metric settings is satisfied by the current message meter, metric={}, clientId={}",
                     metric, clientId);
@@ -133,9 +100,8 @@ public class ClientMeterManager {
             }
             if (!metric.isOn()) {
                 log.info("Metric is off, clientId={}", clientId);
-                ClientMeter existedClientMeter = clientMeter;
+                clientMeter.shutdown();
                 clientMeter = ClientMeter.disabledInstance(clientId);
-                existedClientMeter.shutdown();
                 return;
             }
             final Endpoints endpoints = metric.getEndpoints();
@@ -156,8 +122,8 @@ public class ClientMeterManager {
                 IpNameResolverFactory metricResolverFactory = new IpNameResolverFactory(socketAddresses);
                 channelBuilder.nameResolverFactory(metricResolverFactory);
             }
-            newChannel = channelBuilder.build();
-            newExporter = OtlpGrpcMetricExporter.builder().setChannel(newChannel)
+            ManagedChannel channel = channelBuilder.build();
+            OtlpGrpcMetricExporter exporter = OtlpGrpcMetricExporter.builder().setChannel(channel)
                 .setTimeout(METRIC_EXPORTER_RPC_TIMEOUT)
                 .build();
 
@@ -179,10 +145,10 @@ public class ClientMeterManager {
                 .setType(InstrumentType.HISTOGRAM).setName(HistogramEnum.PROCESS_TIME.getName()).build();
             final View processTimeView = View.builder().setAggregation(HistogramEnum.PROCESS_TIME.getBucket()).build();
 
-            PeriodicMetricReader reader = PeriodicMetricReader.builder(newExporter)
+            PeriodicMetricReader reader = PeriodicMetricReader.builder(exporter)
                 .setInterval(METRIC_READER_INTERVAL).build();
 
-            newProvider = SdkMeterProvider.builder()
+            final SdkMeterProvider provider = SdkMeterProvider.builder()
                 .setResource(Resource.empty())
                 .registerMetricReader(reader)
                 .registerView(sendSuccessCostTimeInstrumentSelector, sendSuccessCostTimeView)
@@ -191,15 +157,12 @@ public class ClientMeterManager {
                 .registerView(processTimeInstrumentSelector, processTimeView)
                 .build();
 
-            final OpenTelemetrySdk openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(newProvider).build();
+            final OpenTelemetrySdk openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(provider).build();
             Meter meter = openTelemetry.getMeter(METRIC_INSTRUMENTATION_NAME);
 
             // Reset message meter.
             ClientMeter existedClientMeter = clientMeter;
-            clientMeter = new ClientMeter(meter, endpoints, newProvider, clientId);
-            newChannel = null;
-            newExporter = null;
-            newProvider = null;
+            clientMeter = new ClientMeter(meter, endpoints, provider, clientId);
             existedClientMeter.shutdown();
             log.info("Metrics is on, endpoints={}, clientId={}", endpoints, clientId);
 
@@ -218,14 +181,9 @@ public class ClientMeterManager {
                 });
             }
         } catch (Throwable t) {
-            if (null != newProvider) {
-                newProvider.shutdown();
-            } else if (null != newExporter) {
-                newExporter.shutdown();
-            } else if (null != newChannel) {
-                newChannel.shutdownNow();
-            }
             log.error("Exception raised when resetting message meter, clientId={}", clientId, t);
+        } finally {
+            resetLock.unlock();
         }
     }
 

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeterManager.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeterManager.java
@@ -56,25 +56,35 @@ public class ClientMeterManager {
 
     private final ClientId clientId;
     private final ClientConfiguration clientConfiguration;
+    private final ClientJmxReporter jmxReporter;
     private volatile ClientMeter clientMeter;
     private volatile GaugeObserver gaugeObserver = GaugeObserver.EMPTY;
 
     public ClientMeterManager(ClientId clientId, ClientConfiguration clientConfiguration) {
         this.clientId = clientId;
         this.clientConfiguration = clientConfiguration;
+        this.jmxReporter = new ClientJmxReporter(clientId);
         this.clientMeter = ClientMeter.disabledInstance(clientId);
     }
 
     public void setGaugeObserver(GaugeObserver gaugeObserver) {
         this.gaugeObserver = checkNotNull(gaugeObserver, "gaugeObserver should not be null");
+        jmxReporter.setGaugeObserver(gaugeObserver);
+        jmxReporter.refreshGauges();
     }
 
     public void record(HistogramEnum histogramEnum, Attributes attributes, double value) {
         clientMeter.record(histogramEnum, attributes, value);
+        jmxReporter.record(histogramEnum, attributes, value);
+    }
+
+    public void refreshGauges() {
+        jmxReporter.refreshGauges();
     }
 
     public void shutdown() {
         clientMeter.shutdown();
+        jmxReporter.shutdown();
     }
 
     @SuppressWarnings({"deprecation", "resource"})
@@ -174,6 +184,6 @@ public class ClientMeterManager {
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean isEnabled() {
-        return clientMeter.isEnabled();
+        return clientMeter.isEnabled() || jmxReporter.isEnabled();
     }
 }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeterManager.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeterManager.java
@@ -59,6 +59,7 @@ public class ClientMeterManager {
     private final ClientJmxReporter jmxReporter;
     private volatile ClientMeter clientMeter;
     private volatile GaugeObserver gaugeObserver = GaugeObserver.EMPTY;
+    private boolean closed;
 
     public ClientMeterManager(ClientId clientId, ClientConfiguration clientConfiguration) {
         this.clientId = clientId;
@@ -67,7 +68,10 @@ public class ClientMeterManager {
         this.clientMeter = ClientMeter.disabledInstance(clientId);
     }
 
-    public void setGaugeObserver(GaugeObserver gaugeObserver) {
+    public synchronized void setGaugeObserver(GaugeObserver gaugeObserver) {
+        if (closed) {
+            return;
+        }
         this.gaugeObserver = checkNotNull(gaugeObserver, "gaugeObserver should not be null");
         jmxReporter.setGaugeObserver(gaugeObserver);
         jmxReporter.refreshGauges();
@@ -82,14 +86,25 @@ public class ClientMeterManager {
         jmxReporter.refreshGauges();
     }
 
-    public void shutdown() {
-        clientMeter.shutdown();
+    public synchronized void shutdown() {
+        closed = true;
+        gaugeObserver = GaugeObserver.EMPTY;
+        ClientMeter existedClientMeter = clientMeter;
+        clientMeter = ClientMeter.disabledInstance(clientId);
         jmxReporter.shutdown();
+        existedClientMeter.shutdown();
     }
 
     @SuppressWarnings({"deprecation", "resource"})
     public synchronized void reset(Metric metric) {
+        ManagedChannel newChannel = null;
+        OtlpGrpcMetricExporter newExporter = null;
+        SdkMeterProvider newProvider = null;
         try {
+            if (closed) {
+                log.info("Ignore metrics reset after manager shutdown, clientId={}", clientId);
+                return;
+            }
             if (clientMeter.satisfy(metric)) {
                 log.info("Metric settings is satisfied by the current message meter, metric={}, clientId={}",
                     metric, clientId);
@@ -97,8 +112,9 @@ public class ClientMeterManager {
             }
             if (!metric.isOn()) {
                 log.info("Metric is off, clientId={}", clientId);
-                clientMeter.shutdown();
+                ClientMeter existedClientMeter = clientMeter;
                 clientMeter = ClientMeter.disabledInstance(clientId);
+                existedClientMeter.shutdown();
                 return;
             }
             final Endpoints endpoints = metric.getEndpoints();
@@ -119,8 +135,8 @@ public class ClientMeterManager {
                 IpNameResolverFactory metricResolverFactory = new IpNameResolverFactory(socketAddresses);
                 channelBuilder.nameResolverFactory(metricResolverFactory);
             }
-            ManagedChannel channel = channelBuilder.build();
-            OtlpGrpcMetricExporter exporter = OtlpGrpcMetricExporter.builder().setChannel(channel)
+            newChannel = channelBuilder.build();
+            newExporter = OtlpGrpcMetricExporter.builder().setChannel(newChannel)
                 .setTimeout(METRIC_EXPORTER_RPC_TIMEOUT)
                 .build();
 
@@ -142,10 +158,10 @@ public class ClientMeterManager {
                 .setType(InstrumentType.HISTOGRAM).setName(HistogramEnum.PROCESS_TIME.getName()).build();
             final View processTimeView = View.builder().setAggregation(HistogramEnum.PROCESS_TIME.getBucket()).build();
 
-            PeriodicMetricReader reader = PeriodicMetricReader.builder(exporter)
+            PeriodicMetricReader reader = PeriodicMetricReader.builder(newExporter)
                 .setInterval(METRIC_READER_INTERVAL).build();
 
-            final SdkMeterProvider provider = SdkMeterProvider.builder()
+            newProvider = SdkMeterProvider.builder()
                 .setResource(Resource.empty())
                 .registerMetricReader(reader)
                 .registerView(sendSuccessCostTimeInstrumentSelector, sendSuccessCostTimeView)
@@ -154,12 +170,15 @@ public class ClientMeterManager {
                 .registerView(processTimeInstrumentSelector, processTimeView)
                 .build();
 
-            final OpenTelemetrySdk openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(provider).build();
+            final OpenTelemetrySdk openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(newProvider).build();
             Meter meter = openTelemetry.getMeter(METRIC_INSTRUMENTATION_NAME);
 
             // Reset message meter.
             ClientMeter existedClientMeter = clientMeter;
-            clientMeter = new ClientMeter(meter, endpoints, provider, clientId);
+            clientMeter = new ClientMeter(meter, endpoints, newProvider, clientId);
+            newChannel = null;
+            newExporter = null;
+            newProvider = null;
             existedClientMeter.shutdown();
             log.info("Metrics is on, endpoints={}, clientId={}", endpoints, clientId);
 
@@ -178,6 +197,13 @@ public class ClientMeterManager {
                 });
             }
         } catch (Throwable t) {
+            if (null != newProvider) {
+                newProvider.shutdown();
+            } else if (null != newExporter) {
+                newExporter.shutdown();
+            } else if (null != newChannel) {
+                newChannel.shutdownNow();
+            }
             log.error("Exception raised when resetting message meter, clientId={}", clientId, t);
         }
     }

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeterManager.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/ClientMeterManager.java
@@ -39,6 +39,7 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 import org.apache.rocketmq.client.apis.ClientConfiguration;
 import org.apache.rocketmq.client.java.misc.ClientId;
 import org.apache.rocketmq.client.java.route.Endpoints;
@@ -57,6 +58,7 @@ public class ClientMeterManager {
     private final ClientId clientId;
     private final ClientConfiguration clientConfiguration;
     private final ClientJmxReporter jmxReporter;
+    private final ReentrantLock lifecycleLock = new ReentrantLock();
     private volatile ClientMeter clientMeter;
     private volatile GaugeObserver gaugeObserver = GaugeObserver.EMPTY;
     private boolean closed;
@@ -68,13 +70,18 @@ public class ClientMeterManager {
         this.clientMeter = ClientMeter.disabledInstance(clientId);
     }
 
-    public synchronized void setGaugeObserver(GaugeObserver gaugeObserver) {
-        if (closed) {
-            return;
+    public void setGaugeObserver(GaugeObserver gaugeObserver) {
+        lifecycleLock.lock();
+        try {
+            if (closed) {
+                return;
+            }
+            this.gaugeObserver = checkNotNull(gaugeObserver, "gaugeObserver should not be null");
+            jmxReporter.setGaugeObserver(gaugeObserver);
+            jmxReporter.refreshGauges();
+        } finally {
+            lifecycleLock.unlock();
         }
-        this.gaugeObserver = checkNotNull(gaugeObserver, "gaugeObserver should not be null");
-        jmxReporter.setGaugeObserver(gaugeObserver);
-        jmxReporter.refreshGauges();
     }
 
     public void record(HistogramEnum histogramEnum, Attributes attributes, double value) {
@@ -86,17 +93,31 @@ public class ClientMeterManager {
         jmxReporter.refreshGauges();
     }
 
-    public synchronized void shutdown() {
-        closed = true;
-        gaugeObserver = GaugeObserver.EMPTY;
-        ClientMeter existedClientMeter = clientMeter;
-        clientMeter = ClientMeter.disabledInstance(clientId);
-        jmxReporter.shutdown();
-        existedClientMeter.shutdown();
+    public void shutdown() {
+        lifecycleLock.lock();
+        try {
+            closed = true;
+            gaugeObserver = GaugeObserver.EMPTY;
+            ClientMeter existedClientMeter = clientMeter;
+            clientMeter = ClientMeter.disabledInstance(clientId);
+            jmxReporter.shutdown();
+            existedClientMeter.shutdown();
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    public void reset(Metric metric) {
+        lifecycleLock.lock();
+        try {
+            resetLocked(metric);
+        } finally {
+            lifecycleLock.unlock();
+        }
     }
 
     @SuppressWarnings({"deprecation", "resource"})
-    public synchronized void reset(Metric metric) {
+    private void resetLocked(Metric metric) {
         ManagedChannel newChannel = null;
         OtlpGrpcMetricExporter newExporter = null;
         SdkMeterProvider newProvider = null;

--- a/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/HistogramEnum.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/metrics/HistogramEnum.java
@@ -18,7 +18,10 @@
 package org.apache.rocketmq.client.java.metrics;
 
 import io.opentelemetry.sdk.metrics.Aggregation;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public enum HistogramEnum {
     /**
@@ -28,8 +31,7 @@ public enum HistogramEnum {
      *
      * <p>The time unit of bucket is milliseconds.
      */
-    SEND_COST_TIME("rocketmq_send_cost_time", Aggregation.explicitBucketHistogram(Arrays.asList(1.0, 5.0,
-        10.0, 20.0, 50.0, 200.0, 500.0))),
+    SEND_COST_TIME("rocketmq_send_cost_time", Arrays.asList(1.0, 5.0, 10.0, 20.0, 50.0, 200.0, 500.0)),
 
     /**
      * A histogram that records the latency of message delivery from remote.
@@ -38,8 +40,7 @@ public enum HistogramEnum {
      *
      * <p>The time unit of bucket is milliseconds.
      */
-    DELIVERY_LATENCY("rocketmq_delivery_latency", Aggregation.explicitBucketHistogram(Arrays.asList(1.0,
-        5.0, 10.0, 20.0, 50.0, 200.0, 500.0))),
+    DELIVERY_LATENCY("rocketmq_delivery_latency", Arrays.asList(1.0, 5.0, 10.0, 20.0, 50.0, 200.0, 500.0)),
 
     /**
      * A histogram that records await time of message consumption.
@@ -48,8 +49,8 @@ public enum HistogramEnum {
      *
      * <p>The time unit of bucket is milliseconds.
      */
-    AWAIT_TIME("rocketmq_await_time", Aggregation.explicitBucketHistogram(Arrays.asList(1.0, 5.0,
-        20.0, 100.0, 1000.0, 5 * 1000.0, 10 * 1000.0))),
+    AWAIT_TIME("rocketmq_await_time", Arrays.asList(1.0, 5.0, 20.0, 100.0, 1000.0, 5 * 1000.0,
+        10 * 1000.0)),
     /**
      * A histogram that records the process time of message consumption.
      *
@@ -58,15 +59,17 @@ public enum HistogramEnum {
      *
      * <p>The time unit of bucket is milliseconds.
      */
-    PROCESS_TIME("rocketmq_process_time", Aggregation.explicitBucketHistogram(Arrays.asList(1.0, 5.0,
-        10.0, 100.0, 1000.0, 10 * 1000.0, 60 * 1000.0)));
+    PROCESS_TIME("rocketmq_process_time", Arrays.asList(1.0, 5.0, 10.0, 100.0, 1000.0, 10 * 1000.0,
+        60 * 1000.0));
 
     private final String name;
     private final Aggregation bucket;
+    private final List<Double> boundaries;
 
-    HistogramEnum(String name, Aggregation bucket) {
+    HistogramEnum(String name, List<Double> boundaries) {
         this.name = name;
-        this.bucket = bucket;
+        this.boundaries = Collections.unmodifiableList(new ArrayList<>(boundaries));
+        this.bucket = Aggregation.explicitBucketHistogram(this.boundaries);
     }
 
     public String getName() {
@@ -75,5 +78,9 @@ public enum HistogramEnum {
 
     public Aggregation getBucket() {
         return bucket;
+    }
+
+    List<Double> getBoundaries() {
+        return boundaries;
     }
 }

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/ClientImplTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/ClientImplTest.java
@@ -18,6 +18,8 @@
 package org.apache.rocketmq.client.java.impl;
 
 import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -38,10 +40,13 @@ import apache.rocketmq.v2.Resource;
 import apache.rocketmq.v2.TelemetryCommand;
 import apache.rocketmq.v2.VerifyMessageCommand;
 import io.grpc.stub.StreamObserver;
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.apache.rocketmq.client.apis.ClientConfiguration;
 import org.apache.rocketmq.client.apis.ClientException;
 import org.apache.rocketmq.client.java.route.Endpoints;
@@ -171,5 +176,39 @@ public class ClientImplTest extends TestBase {
         final ClientImpl client = createClient();
         doReturn(false).when(client).isRunning();
         client.checkRunning();
+    }
+
+    @Test
+    public void testMeterShutdownIsGuaranteedWhenInterrupted() throws Exception {
+        String property = "rocketmq.client.jmx.enabled";
+        String oldValue = System.getProperty(property);
+        System.setProperty(property, Boolean.TRUE.toString());
+        try {
+            ClientImpl client = createClient();
+            assertTrue(client.clientMeterManager.isEnabled());
+            ExecutorService executor = Mockito.mock(ExecutorService.class);
+            Mockito.when(executor.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS))
+                .thenThrow(new InterruptedException());
+            setField(client, "telemetryCommandExecutor", executor);
+            try {
+                client.shutDown();
+                fail();
+            } catch (InterruptedException expected) {
+                // Expected.
+            }
+            assertFalse(client.clientMeterManager.isEnabled());
+        } finally {
+            if (null == oldValue) {
+                System.clearProperty(property);
+            } else {
+                System.setProperty(property, oldValue);
+            }
+        }
+    }
+
+    private static void setField(ClientImpl client, String name, Object value) throws Exception {
+        Field field = ClientImpl.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(client, value);
     }
 }

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImplTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/PushConsumerImplTest.java
@@ -18,6 +18,9 @@
 package org.apache.rocketmq.client.java.impl.consumer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -25,13 +28,18 @@ import static org.mockito.Mockito.verify;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.apache.rocketmq.client.apis.ClientConfiguration;
 import org.apache.rocketmq.client.apis.ClientException;
 import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
 import org.apache.rocketmq.client.apis.consumer.FilterExpression;
 import org.apache.rocketmq.client.apis.consumer.MessageListener;
+import org.apache.rocketmq.client.java.impl.ClientImpl;
+import org.apache.rocketmq.client.java.metrics.ClientMeterManager;
 import org.apache.rocketmq.client.java.route.MessageQueueImpl;
 import org.apache.rocketmq.client.java.tool.TestBase;
 import org.junit.Test;
@@ -105,5 +113,49 @@ public class PushConsumerImplTest extends TestBase {
         pushConsumer.scanAssignments();
         verify(pushConsumer, never()).syncProcessQueue(any(String.class), any(Assignments.class),
             any(FilterExpression.class));
+    }
+
+    @Test
+    public void testMeterShutdownIsGuaranteedWhenConsumptionShutdownIsInterrupted() throws Exception {
+        String property = "rocketmq.client.jmx.enabled";
+        String oldValue = System.getProperty(property);
+        System.setProperty(property, Boolean.TRUE.toString());
+        try {
+            PushConsumerImpl consumer = new PushConsumerImpl(clientConfiguration, FAKE_CONSUMER_GROUP_0,
+                subscriptionExpressions, messageListener, maxCacheMessageCount, maxCacheMessageSizeInBytes,
+                consumptionThreadCount);
+            ClientMeterManager meterManager = (ClientMeterManager) getField(ClientImpl.class, consumer,
+                "clientMeterManager");
+            assertTrue(meterManager.isEnabled());
+            ExecutorService executor = Mockito.mock(ExecutorService.class);
+            Mockito.when(executor.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS))
+                .thenThrow(new InterruptedException());
+            setField(PushConsumerImpl.class, consumer, "consumptionExecutor", executor);
+            try {
+                consumer.shutDown();
+                fail();
+            } catch (InterruptedException expected) {
+                // Expected.
+            }
+            assertFalse(meterManager.isEnabled());
+        } finally {
+            if (null == oldValue) {
+                System.clearProperty(property);
+            } else {
+                System.setProperty(property, oldValue);
+            }
+        }
+    }
+
+    private static Object getField(Class<?> owner, Object target, String name) throws Exception {
+        Field field = owner.getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+
+    private static void setField(Class<?> owner, Object target, String name, Object value) throws Exception {
+        Field field = owner.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
     }
 }

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporterTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporterTest.java
@@ -64,6 +64,7 @@ public class ClientJmxReporterTest extends TestBase {
     public void testHistogramRegistrationAndShutdown() throws Exception {
         reporter = new ClientJmxReporter(new ClientId());
         assertTrue(reporter.isEnabled());
+        assertTrue(histogramSeries(reporter).isEmpty());
         Attributes attributes = Attributes.builder()
             .put(MetricLabels.TOPIC, FAKE_TOPIC_0)
             .put(MetricLabels.INVOCATION_STATUS, InvocationStatus.SUCCESS.getName())
@@ -71,6 +72,7 @@ public class ClientJmxReporterTest extends TestBase {
 
         reporter.record(HistogramEnum.SEND_COST_TIME, attributes, 0.5);
         reporter.record(HistogramEnum.SEND_COST_TIME, attributes, 5);
+        assertEquals(Collections.singleton(HistogramEnum.SEND_COST_TIME), histogramSeries(reporter).keySet());
 
         MBeanServer server = ManagementFactory.getPlatformMBeanServer();
         ObjectName objectName = reporter.objectName(attributes);
@@ -266,12 +268,13 @@ public class ClientJmxReporterTest extends TestBase {
     }
 
     private static void assertHistogramSeriesEmpty(ClientJmxReporter reporter) throws Exception {
+        assertTrue(histogramSeries(reporter).isEmpty());
+    }
+
+    private static Map<?, ?> histogramSeries(ClientJmxReporter reporter) throws Exception {
         Field field = ClientJmxReporter.class.getDeclaredField("histograms");
         field.setAccessible(true);
-        Map<?, ?> histograms = (Map<?, ?>) field.get(reporter);
-        for (Object series : histograms.values()) {
-            assertTrue(((Map<?, ?>) series).isEmpty());
-        }
+        return (Map<?, ?>) field.get(reporter);
     }
 
     private static boolean hasAttribute(MBeanServer server, ObjectName objectName, String attribute) throws Exception {

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporterTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporterTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -194,14 +195,18 @@ public class ClientJmxReporterTest extends TestBase {
             }
         });
 
-        synchronized (registrationLock(reporter)) {
+        ReentrantLock registrationLock = registrationLock(reporter);
+        registrationLock.lock();
+        try {
             recordThread.start();
             long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-            while (Thread.State.BLOCKED != recordThread.getState() && System.nanoTime() < deadline) {
+            while (!registrationLock.hasQueuedThread(recordThread) && System.nanoTime() < deadline) {
                 Thread.yield();
             }
-            assertEquals(Thread.State.BLOCKED, recordThread.getState());
+            assertTrue(registrationLock.hasQueuedThread(recordThread));
             reporter.shutdown();
+        } finally {
+            registrationLock.unlock();
         }
         recordThread.join(TimeUnit.SECONDS.toMillis(5));
 
@@ -254,10 +259,10 @@ public class ClientJmxReporterTest extends TestBase {
         return result;
     }
 
-    private static Object registrationLock(ClientJmxReporter reporter) throws Exception {
+    private static ReentrantLock registrationLock(ClientJmxReporter reporter) throws Exception {
         Field field = ClientJmxReporter.class.getDeclaredField("registrationLock");
         field.setAccessible(true);
-        return field.get(reporter);
+        return (ReentrantLock) field.get(reporter);
     }
 
     private static void assertHistogramSeriesEmpty(ClientJmxReporter reporter) throws Exception {

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporterTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporterTest.java
@@ -23,11 +23,15 @@ import static org.junit.Assert.assertTrue;
 
 import io.opentelemetry.api.common.Attributes;
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.management.timer.Timer;
@@ -114,6 +118,8 @@ public class ClientJmxReporterTest extends TestBase {
         values.set(Collections.emptyMap());
         assertEquals(0D, (Double) server.getAttribute(objectName,
             GaugeEnum.CONSUMER_CACHED_MESSAGES.getName()), 0.001);
+        reporter.refreshGauges();
+        assertFalse(server.isRegistered(objectName));
     }
 
     @Test
@@ -124,6 +130,8 @@ public class ClientJmxReporterTest extends TestBase {
             .put(MetricLabels.CONSUMER_GROUP, FAKE_CONSUMER_GROUP_0)
             .build();
         reporter.record(HistogramEnum.DELIVERY_LATENCY, attributes, 10);
+        AtomicReference<Map<Attributes, Double>> values =
+            new AtomicReference<>(singletonValue(attributes, 1024D));
         reporter.setGaugeObserver(new GaugeObserver() {
             @Override
             public List<GaugeEnum> getGauges() {
@@ -132,7 +140,7 @@ public class ClientJmxReporterTest extends TestBase {
 
             @Override
             public Map<Attributes, Double> getValues(GaugeEnum gauge) {
-                return singletonValue(attributes, 1024D);
+                return values.get();
             }
         });
         reporter.refreshGauges();
@@ -142,6 +150,12 @@ public class ClientJmxReporterTest extends TestBase {
         assertEquals(1L, server.getAttribute(objectName, "rocketmq_delivery_latency_count"));
         assertEquals(1024D, (Double) server.getAttribute(objectName,
             GaugeEnum.CONSUMER_CACHED_BYTES.getName()), 0.001);
+
+        values.set(Collections.emptyMap());
+        reporter.refreshGauges();
+        assertTrue(server.isRegistered(objectName));
+        assertEquals(1L, server.getAttribute(objectName, "rocketmq_delivery_latency_count"));
+        assertFalse(hasAttribute(server, objectName, GaugeEnum.CONSUMER_CACHED_BYTES.getName()));
     }
 
     @Test
@@ -153,10 +167,65 @@ public class ClientJmxReporterTest extends TestBase {
         server.registerMBean(new Timer(), objectName);
         try {
             reporter.record(HistogramEnum.SEND_COST_TIME, attributes, 1);
-
             assertTrue(server.isInstanceOf(objectName, Timer.class.getName()));
-        } finally {
+
             server.unregisterMBean(objectName);
+            reporter.record(HistogramEnum.SEND_COST_TIME, attributes, 2);
+            assertFalse(server.isRegistered(objectName));
+        } finally {
+            if (server.isRegistered(objectName) && server.isInstanceOf(objectName, Timer.class.getName())) {
+                server.unregisterMBean(objectName);
+            }
+        }
+    }
+
+    @Test
+    public void testRegistrationDoesNotRaceWithShutdown() throws Exception {
+        reporter = new ClientJmxReporter(new ClientId());
+        Attributes attributes = Attributes.builder().put(MetricLabels.TOPIC, FAKE_TOPIC_0).build();
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        ObjectName objectName = reporter.objectName(attributes);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        Thread recordThread = new Thread(() -> {
+            try {
+                reporter.record(HistogramEnum.SEND_COST_TIME, attributes, 1);
+            } catch (Throwable t) {
+                failure.set(t);
+            }
+        });
+
+        synchronized (registrationLock(reporter)) {
+            recordThread.start();
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (Thread.State.BLOCKED != recordThread.getState() && System.nanoTime() < deadline) {
+                Thread.yield();
+            }
+            assertEquals(Thread.State.BLOCKED, recordThread.getState());
+            reporter.shutdown();
+        }
+        recordThread.join(TimeUnit.SECONDS.toMillis(5));
+
+        assertFalse(recordThread.isAlive());
+        assertTrue(null == failure.get());
+        assertFalse(server.isRegistered(objectName));
+    }
+
+    @Test
+    public void testRepeatedShutdownReleasesMBeansAndHistograms() throws Exception {
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        ObjectName query = new ObjectName(ClientJmxReporter.DOMAIN + ":type=" + ClientJmxReporter.TYPE + ",*");
+        Set<ObjectName> baseline = server.queryNames(query, null);
+
+        for (int i = 0; i < 20; i++) {
+            reporter = new ClientJmxReporter(new ClientId());
+            Attributes attributes = Attributes.builder().put(MetricLabels.TOPIC, FAKE_TOPIC_0 + i).build();
+            reporter.record(HistogramEnum.SEND_COST_TIME, attributes, i);
+            assertTrue(server.isRegistered(reporter.objectName(attributes)));
+
+            reporter.shutdown();
+
+            assertEquals(baseline, server.queryNames(query, null));
+            assertHistogramSeriesEmpty(reporter);
         }
     }
 
@@ -183,5 +252,29 @@ public class ClientJmxReporterTest extends TestBase {
         Map<Attributes, Double> result = new HashMap<>();
         result.put(attributes, value);
         return result;
+    }
+
+    private static Object registrationLock(ClientJmxReporter reporter) throws Exception {
+        Field field = ClientJmxReporter.class.getDeclaredField("registrationLock");
+        field.setAccessible(true);
+        return field.get(reporter);
+    }
+
+    private static void assertHistogramSeriesEmpty(ClientJmxReporter reporter) throws Exception {
+        Field field = ClientJmxReporter.class.getDeclaredField("histograms");
+        field.setAccessible(true);
+        Map<?, ?> histograms = (Map<?, ?>) field.get(reporter);
+        for (Object series : histograms.values()) {
+            assertTrue(((Map<?, ?>) series).isEmpty());
+        }
+    }
+
+    private static boolean hasAttribute(MBeanServer server, ObjectName objectName, String attribute) throws Exception {
+        for (MBeanAttributeInfo info : server.getMBeanInfo(objectName).getAttributes()) {
+            if (attribute.equals(info.getName())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporterTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporterTest.java
@@ -90,6 +90,7 @@ public class ClientJmxReporterTest extends TestBase {
     @Test
     public void testGaugeValueIsReadFromObserver() throws Exception {
         reporter = new ClientJmxReporter(new ClientId());
+        assertTrue(registeredGaugeAttributes(reporter).isEmpty());
         Attributes attributes = Attributes.builder()
             .put(MetricLabels.TOPIC, FAKE_TOPIC_0)
             .put(MetricLabels.CONSUMER_GROUP, FAKE_CONSUMER_GROUP_0)
@@ -108,6 +109,8 @@ public class ClientJmxReporterTest extends TestBase {
             }
         });
         reporter.refreshGauges();
+        assertEquals(Collections.singleton(GaugeEnum.CONSUMER_CACHED_MESSAGES),
+            registeredGaugeAttributes(reporter).keySet());
 
         MBeanServer server = ManagementFactory.getPlatformMBeanServer();
         ObjectName objectName = reporter.objectName(attributes);
@@ -123,6 +126,7 @@ public class ClientJmxReporterTest extends TestBase {
             GaugeEnum.CONSUMER_CACHED_MESSAGES.getName()), 0.001);
         reporter.refreshGauges();
         assertFalse(server.isRegistered(objectName));
+        assertTrue(registeredGaugeAttributes(reporter).isEmpty());
     }
 
     @Test
@@ -273,6 +277,12 @@ public class ClientJmxReporterTest extends TestBase {
 
     private static Map<?, ?> histogramSeries(ClientJmxReporter reporter) throws Exception {
         Field field = ClientJmxReporter.class.getDeclaredField("histograms");
+        field.setAccessible(true);
+        return (Map<?, ?>) field.get(reporter);
+    }
+
+    private static Map<?, ?> registeredGaugeAttributes(ClientJmxReporter reporter) throws Exception {
+        Field field = ClientJmxReporter.class.getDeclaredField("registeredGaugeAttributes");
         field.setAccessible(true);
         return (Map<?, ?>) field.get(reporter);
     }

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporterTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientJmxReporterTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.java.metrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.opentelemetry.api.common.Attributes;
+import java.lang.management.ManagementFactory;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.management.timer.Timer;
+import org.apache.rocketmq.client.java.misc.ClientId;
+import org.apache.rocketmq.client.java.tool.TestBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClientJmxReporterTest extends TestBase {
+    private ClientJmxReporter reporter;
+    private String oldEnablePropertyValue;
+
+    @Before
+    public void setUp() {
+        oldEnablePropertyValue = System.getProperty(ClientJmxReporter.ENABLE_PROPERTY);
+        System.setProperty(ClientJmxReporter.ENABLE_PROPERTY, Boolean.TRUE.toString());
+    }
+
+    @After
+    public void tearDown() {
+        if (null != reporter) {
+            reporter.shutdown();
+        }
+        restoreEnableProperty();
+    }
+
+    @Test
+    public void testHistogramRegistrationAndShutdown() throws Exception {
+        reporter = new ClientJmxReporter(new ClientId());
+        assertTrue(reporter.isEnabled());
+        Attributes attributes = Attributes.builder()
+            .put(MetricLabels.TOPIC, FAKE_TOPIC_0)
+            .put(MetricLabels.INVOCATION_STATUS, InvocationStatus.SUCCESS.getName())
+            .build();
+
+        reporter.record(HistogramEnum.SEND_COST_TIME, attributes, 0.5);
+        reporter.record(HistogramEnum.SEND_COST_TIME, attributes, 5);
+
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        ObjectName objectName = reporter.objectName(attributes);
+        assertTrue(server.isRegistered(objectName));
+        assertEquals(2L, server.getAttribute(objectName, "rocketmq_send_cost_time_count"));
+        assertEquals(5.5, (Double) server.getAttribute(objectName, "rocketmq_send_cost_time_sum"), 0.001);
+        assertEquals(1L, server.getAttribute(objectName, "rocketmq_send_cost_time_bucket_le_1"));
+        assertEquals(2L, server.getAttribute(objectName, "rocketmq_send_cost_time_bucket_le_5"));
+        assertEquals(2L, server.getAttribute(objectName, "rocketmq_send_cost_time_bucket_le_inf"));
+
+        reporter.shutdown();
+        assertFalse(server.isRegistered(objectName));
+    }
+
+    @Test
+    public void testGaugeValueIsReadFromObserver() throws Exception {
+        reporter = new ClientJmxReporter(new ClientId());
+        Attributes attributes = Attributes.builder()
+            .put(MetricLabels.TOPIC, FAKE_TOPIC_0)
+            .put(MetricLabels.CONSUMER_GROUP, FAKE_CONSUMER_GROUP_0)
+            .build();
+        AtomicReference<Map<Attributes, Double>> values =
+            new AtomicReference<>(singletonValue(attributes, 3D));
+        reporter.setGaugeObserver(new GaugeObserver() {
+            @Override
+            public List<GaugeEnum> getGauges() {
+                return Collections.singletonList(GaugeEnum.CONSUMER_CACHED_MESSAGES);
+            }
+
+            @Override
+            public Map<Attributes, Double> getValues(GaugeEnum gauge) {
+                return values.get();
+            }
+        });
+        reporter.refreshGauges();
+
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        ObjectName objectName = reporter.objectName(attributes);
+        assertEquals(3D, (Double) server.getAttribute(objectName,
+            GaugeEnum.CONSUMER_CACHED_MESSAGES.getName()), 0.001);
+
+        values.set(singletonValue(attributes, 9D));
+        assertEquals(9D, (Double) server.getAttribute(objectName,
+            GaugeEnum.CONSUMER_CACHED_MESSAGES.getName()), 0.001);
+
+        values.set(Collections.emptyMap());
+        assertEquals(0D, (Double) server.getAttribute(objectName,
+            GaugeEnum.CONSUMER_CACHED_MESSAGES.getName()), 0.001);
+    }
+
+    @Test
+    public void testMetricsWithSameLabelsShareMBean() throws Exception {
+        reporter = new ClientJmxReporter(new ClientId());
+        Attributes attributes = Attributes.builder()
+            .put(MetricLabels.TOPIC, FAKE_TOPIC_0)
+            .put(MetricLabels.CONSUMER_GROUP, FAKE_CONSUMER_GROUP_0)
+            .build();
+        reporter.record(HistogramEnum.DELIVERY_LATENCY, attributes, 10);
+        reporter.setGaugeObserver(new GaugeObserver() {
+            @Override
+            public List<GaugeEnum> getGauges() {
+                return Collections.singletonList(GaugeEnum.CONSUMER_CACHED_BYTES);
+            }
+
+            @Override
+            public Map<Attributes, Double> getValues(GaugeEnum gauge) {
+                return singletonValue(attributes, 1024D);
+            }
+        });
+        reporter.refreshGauges();
+
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        ObjectName objectName = reporter.objectName(attributes);
+        assertEquals(1L, server.getAttribute(objectName, "rocketmq_delivery_latency_count"));
+        assertEquals(1024D, (Double) server.getAttribute(objectName,
+            GaugeEnum.CONSUMER_CACHED_BYTES.getName()), 0.001);
+    }
+
+    @Test
+    public void testExistingMBeanIsNotReplaced() throws Exception {
+        reporter = new ClientJmxReporter(new ClientId());
+        Attributes attributes = Attributes.builder().put(MetricLabels.TOPIC, FAKE_TOPIC_0).build();
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        ObjectName objectName = reporter.objectName(attributes);
+        server.registerMBean(new Timer(), objectName);
+        try {
+            reporter.record(HistogramEnum.SEND_COST_TIME, attributes, 1);
+
+            assertTrue(server.isInstanceOf(objectName, Timer.class.getName()));
+        } finally {
+            server.unregisterMBean(objectName);
+        }
+    }
+
+    @Test
+    public void testDisabledByDefault() throws Exception {
+        System.clearProperty(ClientJmxReporter.ENABLE_PROPERTY);
+        Attributes attributes = Attributes.builder().put(MetricLabels.TOPIC, FAKE_TOPIC_0).build();
+        reporter = new ClientJmxReporter(new ClientId());
+        reporter.record(HistogramEnum.SEND_COST_TIME, attributes, 1);
+
+        assertFalse(reporter.isEnabled());
+        assertFalse(ManagementFactory.getPlatformMBeanServer().isRegistered(reporter.objectName(attributes)));
+    }
+
+    private void restoreEnableProperty() {
+        if (null == oldEnablePropertyValue) {
+            System.clearProperty(ClientJmxReporter.ENABLE_PROPERTY);
+        } else {
+            System.setProperty(ClientJmxReporter.ENABLE_PROPERTY, oldEnablePropertyValue);
+        }
+    }
+
+    private static Map<Attributes, Double> singletonValue(Attributes attributes, double value) {
+        Map<Attributes, Double> result = new HashMap<>();
+        result.put(attributes, value);
+        return result;
+    }
+}

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientMeterManagerTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientMeterManagerTest.java
@@ -84,26 +84,6 @@ public class ClientMeterManagerTest extends TestBase {
         }
     }
 
-    @Test
-    public void testResetAfterShutdownDoesNotEnableMeter() {
-        String oldValue = System.getProperty(ClientJmxReporter.ENABLE_PROPERTY);
-        System.setProperty(ClientJmxReporter.ENABLE_PROPERTY, Boolean.FALSE.toString());
-        try {
-            final ClientConfiguration clientConfiguration =
-                ClientConfiguration.newBuilder().setEndpoints(FAKE_ENDPOINTS).build();
-            ClientMeterManager meterManager = new ClientMeterManager(new ClientId(), clientConfiguration);
-            meterManager.shutdown();
-
-            final Metric metric = new Metric(apache.rocketmq.v2.Metric.newBuilder().setOn(true)
-                .setEndpoints(fakePbEndpoints0()).build());
-            meterManager.reset(metric);
-
-            assertFalse(meterManager.isEnabled());
-        } finally {
-            restoreEnableProperty(oldValue);
-        }
-    }
-
     private static void restoreEnableProperty(String oldValue) {
         if (null == oldValue) {
             System.clearProperty(ClientJmxReporter.ENABLE_PROPERTY);

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientMeterManagerTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientMeterManagerTest.java
@@ -40,14 +40,47 @@ public class ClientMeterManagerTest extends TestBase {
     }
 
     @Test
-    public void testResetWithMetricOff() {
-        final ClientConfiguration clientConfiguration =
-            ClientConfiguration.newBuilder().setEndpoints(FAKE_ENDPOINTS).build();
-        ClientId clientId = new ClientId();
-        final ClientMeterManager meterManager = new ClientMeterManager(clientId, clientConfiguration);
-        final Metric metric =
-            new Metric(apache.rocketmq.v2.Metric.newBuilder().setOn(false).setEndpoints(fakePbEndpoints0()).build());
-        meterManager.reset(metric);
-        assertFalse(meterManager.isEnabled());
+    public void testResetWithMetricOffAndJmxEnabled() {
+        String oldValue = System.getProperty(ClientJmxReporter.ENABLE_PROPERTY);
+        System.setProperty(ClientJmxReporter.ENABLE_PROPERTY, Boolean.TRUE.toString());
+        try {
+            final ClientConfiguration clientConfiguration =
+                ClientConfiguration.newBuilder().setEndpoints(FAKE_ENDPOINTS).build();
+            ClientId clientId = new ClientId();
+            final ClientMeterManager meterManager = new ClientMeterManager(clientId, clientConfiguration);
+            final Metric metric = new Metric(apache.rocketmq.v2.Metric.newBuilder().setOn(false)
+                .setEndpoints(fakePbEndpoints0()).build());
+            meterManager.reset(metric);
+
+            assertTrue(meterManager.isEnabled());
+        } finally {
+            restoreEnableProperty(oldValue);
+        }
+    }
+
+    @Test
+    public void testResetWithMetricAndJmxOff() {
+        String oldValue = System.getProperty(ClientJmxReporter.ENABLE_PROPERTY);
+        System.setProperty(ClientJmxReporter.ENABLE_PROPERTY, Boolean.FALSE.toString());
+        try {
+            final ClientConfiguration clientConfiguration =
+                ClientConfiguration.newBuilder().setEndpoints(FAKE_ENDPOINTS).build();
+            ClientMeterManager meterManager = new ClientMeterManager(new ClientId(), clientConfiguration);
+            final Metric metric = new Metric(apache.rocketmq.v2.Metric.newBuilder().setOn(false)
+                .setEndpoints(fakePbEndpoints0()).build());
+            meterManager.reset(metric);
+
+            assertFalse(meterManager.isEnabled());
+        } finally {
+            restoreEnableProperty(oldValue);
+        }
+    }
+
+    private static void restoreEnableProperty(String oldValue) {
+        if (null == oldValue) {
+            System.clearProperty(ClientJmxReporter.ENABLE_PROPERTY);
+        } else {
+            System.setProperty(ClientJmxReporter.ENABLE_PROPERTY, oldValue);
+        }
     }
 }

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientMeterManagerTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientMeterManagerTest.java
@@ -36,7 +36,11 @@ public class ClientMeterManagerTest extends TestBase {
         final Metric metric =
             new Metric(apache.rocketmq.v2.Metric.newBuilder().setOn(true).setEndpoints(fakePbEndpoints0()).build());
         meterManager.reset(metric);
-        assertTrue(meterManager.isEnabled());
+        try {
+            assertTrue(meterManager.isEnabled());
+        } finally {
+            meterManager.shutdown();
+        }
     }
 
     @Test
@@ -52,7 +56,11 @@ public class ClientMeterManagerTest extends TestBase {
                 .setEndpoints(fakePbEndpoints0()).build());
             meterManager.reset(metric);
 
-            assertTrue(meterManager.isEnabled());
+            try {
+                assertTrue(meterManager.isEnabled());
+            } finally {
+                meterManager.shutdown();
+            }
         } finally {
             restoreEnableProperty(oldValue);
         }
@@ -67,6 +75,26 @@ public class ClientMeterManagerTest extends TestBase {
                 ClientConfiguration.newBuilder().setEndpoints(FAKE_ENDPOINTS).build();
             ClientMeterManager meterManager = new ClientMeterManager(new ClientId(), clientConfiguration);
             final Metric metric = new Metric(apache.rocketmq.v2.Metric.newBuilder().setOn(false)
+                .setEndpoints(fakePbEndpoints0()).build());
+            meterManager.reset(metric);
+
+            assertFalse(meterManager.isEnabled());
+        } finally {
+            restoreEnableProperty(oldValue);
+        }
+    }
+
+    @Test
+    public void testResetAfterShutdownDoesNotEnableMeter() {
+        String oldValue = System.getProperty(ClientJmxReporter.ENABLE_PROPERTY);
+        System.setProperty(ClientJmxReporter.ENABLE_PROPERTY, Boolean.FALSE.toString());
+        try {
+            final ClientConfiguration clientConfiguration =
+                ClientConfiguration.newBuilder().setEndpoints(FAKE_ENDPOINTS).build();
+            ClientMeterManager meterManager = new ClientMeterManager(new ClientId(), clientConfiguration);
+            meterManager.shutdown();
+
+            final Metric metric = new Metric(apache.rocketmq.v2.Metric.newBuilder().setOn(true)
                 .setEndpoints(fakePbEndpoints0()).build());
             meterManager.reset(metric);
 

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientMeterTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientMeterTest.java
@@ -48,9 +48,6 @@ public class ClientMeterTest extends TestBase {
         assertEquals(1, histogramMap(clientMeter).size());
         clientMeter.shutdown();
         assertFalse(clientMeter.isEnabled());
-        assertTrue(histogramMap(clientMeter).isEmpty());
-        clientMeter.record(HistogramEnum.SEND_COST_TIME, Attributes.empty(), 2);
-        assertTrue(histogramMap(clientMeter).isEmpty());
     }
 
     @Test

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientMeterTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientMeterTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.rocketmq.client.java.metrics;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import apache.rocketmq.v2.Endpoints;
@@ -28,6 +30,7 @@ import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.resources.Resource;
 import java.lang.reflect.Field;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.rocketmq.client.java.misc.ClientId;
 import org.apache.rocketmq.client.java.tool.TestBase;
 import org.junit.Test;
@@ -42,13 +45,14 @@ public class ClientMeterTest extends TestBase {
         final ClientId clientId = new ClientId();
         final ClientMeter clientMeter = new ClientMeter(meter, fakeEndpoints(), provider, clientId);
         assertTrue(clientMeter.isEnabled());
+        assertEquals(HistogramEnum.values().length, histogramMap(clientMeter).size());
         clientMeter.record(HistogramEnum.SEND_COST_TIME, Attributes.empty(), 1);
         assertFalse(histogramMap(clientMeter).isEmpty());
         clientMeter.shutdown();
         assertFalse(clientMeter.isEnabled());
-        assertTrue(histogramMap(clientMeter).isEmpty());
+        assertNull(histogramMap(clientMeter));
         clientMeter.record(HistogramEnum.SEND_COST_TIME, Attributes.empty(), 2);
-        assertTrue(histogramMap(clientMeter).isEmpty());
+        assertNull(histogramMap(clientMeter));
     }
 
     @Test
@@ -106,6 +110,7 @@ public class ClientMeterTest extends TestBase {
     private static Map<?, ?> histogramMap(ClientMeter clientMeter) throws Exception {
         Field field = ClientMeter.class.getDeclaredField("histogramMap");
         field.setAccessible(true);
-        return (Map<?, ?>) field.get(clientMeter);
+        AtomicReference<?> reference = (AtomicReference<?>) field.get(clientMeter);
+        return (Map<?, ?>) reference.get();
     }
 }

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientMeterTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientMeterTest.java
@@ -19,7 +19,6 @@ package org.apache.rocketmq.client.java.metrics;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import apache.rocketmq.v2.Endpoints;
@@ -30,7 +29,6 @@ import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.resources.Resource;
 import java.lang.reflect.Field;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.rocketmq.client.java.misc.ClientId;
 import org.apache.rocketmq.client.java.tool.TestBase;
 import org.junit.Test;
@@ -45,14 +43,14 @@ public class ClientMeterTest extends TestBase {
         final ClientId clientId = new ClientId();
         final ClientMeter clientMeter = new ClientMeter(meter, fakeEndpoints(), provider, clientId);
         assertTrue(clientMeter.isEnabled());
-        assertEquals(HistogramEnum.values().length, histogramMap(clientMeter).size());
+        assertTrue(histogramMap(clientMeter).isEmpty());
         clientMeter.record(HistogramEnum.SEND_COST_TIME, Attributes.empty(), 1);
-        assertFalse(histogramMap(clientMeter).isEmpty());
+        assertEquals(1, histogramMap(clientMeter).size());
         clientMeter.shutdown();
         assertFalse(clientMeter.isEnabled());
-        assertNull(histogramMap(clientMeter));
+        assertTrue(histogramMap(clientMeter).isEmpty());
         clientMeter.record(HistogramEnum.SEND_COST_TIME, Attributes.empty(), 2);
-        assertNull(histogramMap(clientMeter));
+        assertTrue(histogramMap(clientMeter).isEmpty());
     }
 
     @Test
@@ -110,7 +108,6 @@ public class ClientMeterTest extends TestBase {
     private static Map<?, ?> histogramMap(ClientMeter clientMeter) throws Exception {
         Field field = ClientMeter.class.getDeclaredField("histogramMap");
         field.setAccessible(true);
-        AtomicReference<?> reference = (AtomicReference<?>) field.get(clientMeter);
-        return (Map<?, ?>) reference.get();
+        return (Map<?, ?>) field.get(clientMeter);
     }
 }

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientMeterTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/metrics/ClientMeterTest.java
@@ -21,10 +21,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import apache.rocketmq.v2.Endpoints;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.resources.Resource;
+import java.lang.reflect.Field;
+import java.util.Map;
 import org.apache.rocketmq.client.java.misc.ClientId;
 import org.apache.rocketmq.client.java.tool.TestBase;
 import org.junit.Test;
@@ -32,14 +35,20 @@ import org.junit.Test;
 public class ClientMeterTest extends TestBase {
 
     @Test
-    public void testShutdownWithEnabledMeter() {
+    public void testShutdownWithEnabledMeter() throws Exception {
         final SdkMeterProvider provider = SdkMeterProvider.builder().setResource(Resource.empty()).build();
         final OpenTelemetrySdk openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(provider).build();
         Meter meter = openTelemetry.getMeter("test");
         final ClientId clientId = new ClientId();
         final ClientMeter clientMeter = new ClientMeter(meter, fakeEndpoints(), provider, clientId);
         assertTrue(clientMeter.isEnabled());
+        clientMeter.record(HistogramEnum.SEND_COST_TIME, Attributes.empty(), 1);
+        assertFalse(histogramMap(clientMeter).isEmpty());
         clientMeter.shutdown();
+        assertFalse(clientMeter.isEnabled());
+        assertTrue(histogramMap(clientMeter).isEmpty());
+        clientMeter.record(HistogramEnum.SEND_COST_TIME, Attributes.empty(), 2);
+        assertTrue(histogramMap(clientMeter).isEmpty());
     }
 
     @Test
@@ -91,5 +100,12 @@ public class ClientMeterTest extends TestBase {
         final Endpoints pbEndpoints1 = fakePbEndpoints1();
         metric = new Metric(apache.rocketmq.v2.Metric.newBuilder().setOn(true).setEndpoints(pbEndpoints1).build());
         assertFalse(clientMeter.satisfy(metric));
+        clientMeter.shutdown();
+    }
+
+    private static Map<?, ?> histogramMap(ClientMeter clientMeter) throws Exception {
+        Field field = ClientMeter.class.getDeclaredField("histogramMap");
+        field.setAccessible(true);
+        return (Map<?, ?>) field.get(clientMeter);
     }
 }


### PR DESCRIPTION
## What changed

- Add an internal Kafka-style JMX reporter for the Java gRPC client's existing message metrics.
- Keep JMX reporting disabled by default and enable it with `-Drocketmq.client.jmx.enabled=true` before constructing a client.
- Register label-set MBeans under the `org.apache.rocketmq.client` domain without adding a public client API, network endpoint, or Prometheus dependency.
- Keep the reporter independent from the server-controlled OTLP metrics setting and unregister client-owned MBeans on shutdown.
- Refresh PushConsumer gauge registrations after assignment scans while reading gauge values dynamically.

## Metrics

- `rocketmq_send_cost_time`: count, sum, and histogram buckets, labeled by topic, client ID, and invocation status.
- `rocketmq_delivery_latency`: count, sum, and histogram buckets.
- `rocketmq_await_time`: count, sum, and histogram buckets.
- `rocketmq_process_time`: count, sum, and histogram buckets.
- `rocketmq_consumer_cached_messages`: gauge.
- `rocketmq_consumer_cached_bytes`: gauge.

Applications that already run a Prometheus JMX Exporter can scrape these MBeans. With the property unset, the reporter does not initialize the platform MBean server or allocate metric containers.

## Validation

- JDK 11: `mvn -pl client -am -Dmaven.gitcommitid.skip=true test` — 302 tests, 0 failures, 1 existing skip.
- JDK 21: reporter and manager tests — 8 tests, 0 failures.
- JDK 8 runtime: reporter and manager JUnit tests — 8 tests, 0 failures.
- Checkstyle and SpotBugs passed.
- Generated class major version remains 52.

Fixes #1338
