### PR TITLE
[ISSUE #1340] [Java] Resume PushConsumer receive after cache drains

### DIFF
--- a/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImpl.java
+++ b/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImpl.java
@@ -41,6 +41,7 @@ import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
@@ -107,6 +108,7 @@ class ProcessQueueImpl implements ProcessQueue {
 
     private final AtomicLong receptionTimes;
     private final AtomicLong receivedMessagesQuantity;
+    private final AtomicReference<CachePause> cachePauseRef;
 
     private volatile long activityNanoTime = System.nanoTime();
     private volatile long cacheFullNanoTime = Long.MIN_VALUE;
@@ -121,6 +123,7 @@ class ProcessQueueImpl implements ProcessQueue {
         this.cachedMessagesBytes = new AtomicLong();
         this.receptionTimes = new AtomicLong(0);
         this.receivedMessagesQuantity = new AtomicLong(0);
+        this.cachePauseRef = new AtomicReference<>();
     }
 
     @Override
@@ -131,6 +134,7 @@ class ProcessQueueImpl implements ProcessQueue {
     @Override
     public void drop() {
         this.dropped = true;
+        cachePauseRef.set(null);
     }
 
     @Override
@@ -186,11 +190,15 @@ class ProcessQueueImpl implements ProcessQueue {
     }
 
     private void receiveMessageLater(Duration delay, String attemptId) {
+        receiveMessageLater(delay, attemptId, () -> receiveMessage(attemptId));
+    }
+
+    private void receiveMessageLater(Duration delay, String attemptId, Runnable command) {
         final ClientId clientId = consumer.getClientId();
         final ScheduledExecutorService scheduler = consumer.getScheduler();
         try {
             log.info("Try to receive message later, mq={}, delay={}, clientId={}", mq, delay, clientId);
-            scheduler.schedule(() -> receiveMessage(attemptId), delay.toNanos(), TimeUnit.NANOSECONDS);
+            scheduler.schedule(command, delay.toNanos(), TimeUnit.NANOSECONDS);
         } catch (Throwable t) {
             if (scheduler.isShutdown()) {
                 return;
@@ -215,12 +223,50 @@ class ProcessQueueImpl implements ProcessQueue {
             log.info("Process queue has been dropped, no longer receive message, mq={}, clientId={}", mq, clientId);
             return;
         }
+        if (null != cachePauseRef.get()) {
+            return;
+        }
         if (this.isCacheFull()) {
             log.warn("Process queue cache is full, would receive message later, mq={}, clientId={}", mq, clientId);
-            receiveMessageLater(RECEIVING_BACKOFF_DELAY_WHEN_CACHE_IS_FULL, attemptId);
+            pauseMessageReceiving(attemptId);
             return;
         }
         receiveMessageImmediately(attemptId);
+    }
+
+    private void pauseMessageReceiving(String attemptId) {
+        final CachePause pause = new CachePause(attemptId);
+        if (!cachePauseRef.compareAndSet(null, pause)) {
+            return;
+        }
+        receiveMessageLater(RECEIVING_BACKOFF_DELAY_WHEN_CACHE_IS_FULL, attemptId,
+            () -> resumeMessageReceiving(pause));
+        // Avoid a lost wake-up if cache eviction reaches the low watermark while the pause is being installed.
+        resumeMessageReceivingIfCacheDrained();
+    }
+
+    private void resumeMessageReceivingIfCacheDrained() {
+        final CachePause pause = cachePauseRef.get();
+        if (null == pause || !isCacheDrainedToResume()) {
+            return;
+        }
+        resumeMessageReceiving(pause);
+    }
+
+    private boolean isCacheDrainedToResume() {
+        final long cachedMessageCount = cachedMessages.size();
+        final long cachedMessageBytes = cachedMessageBytes();
+        final long cachedMessageCountLowWatermark = consumer.cacheMessageCountThresholdPerQueue() / 5L;
+        final long cachedMessageBytesLowWatermark = consumer.cacheMessageBytesThresholdPerQueue() / 5L;
+        return cachedMessageCount <= cachedMessageCountLowWatermark
+            && cachedMessageBytes <= cachedMessageBytesLowWatermark;
+    }
+
+    private void resumeMessageReceiving(CachePause pause) {
+        if (!cachePauseRef.compareAndSet(pause, null)) {
+            return;
+        }
+        receiveMessage(pause.attemptId);
     }
 
     private void receiveMessageImmediately() {
@@ -416,6 +462,15 @@ class ProcessQueueImpl implements ProcessQueue {
             }
         } finally {
             cachedMessageLock.writeLock().unlock();
+        }
+        resumeMessageReceivingIfCacheDrained();
+    }
+
+    private static final class CachePause {
+        private final String attemptId;
+
+        private CachePause(String attemptId) {
+            this.attemptId = attemptId;
         }
     }
 

--- a/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImplTest.java
+++ b/java/client/src/test/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImplTest.java
@@ -18,11 +18,17 @@
 package org.apache.rocketmq.client.java.impl.consumer;
 
 import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,6 +49,13 @@ import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.rocketmq.client.apis.ClientConfiguration;
 import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
@@ -97,6 +110,7 @@ public class ProcessQueueImplTest extends TestBase {
 
         AtomicLong receivedMessagesQuantity = new AtomicLong(0);
         when(pushConsumer.getReceivedMessagesQuantity()).thenReturn(receivedMessagesQuantity);
+        when(pushConsumer.getReceptionTimes()).thenReturn(new AtomicLong(0));
         when(pushConsumer.getConsumeService()).thenReturn(consumeService);
     }
 
@@ -140,6 +154,168 @@ public class ProcessQueueImplTest extends TestBase {
         await().atMost(Duration.ofSeconds(3))
             .untilAsserted(() -> verify(pushConsumer, times(cachedMessagesCountThresholdPerQueue))
                 .receiveMessage(any(ReceiveMessageRequest.class), any(MessageQueueImpl.class), any(Duration.class)));
+    }
+
+    @Test
+    public void testResumeMessageReceivingAtCountLowWatermark() {
+        final List<ScheduledTask> scheduledTasks = useCapturingScheduler();
+        stubCacheThresholds(10, 1000);
+        final List<MessageViewImpl> messages = cacheMessages(10, 1);
+        stubAckMessageSuccess();
+
+        processQueue.receiveMessage("count-low-watermark-attempt");
+        assertEquals(1, countScheduledTasks(scheduledTasks, Duration.ofSeconds(1)));
+        preparePendingReceive();
+
+        eraseMessages(messages.subList(0, 7));
+        verifyReceiveMessageTimes(0);
+
+        processQueue.eraseMessage(messages.get(7), ConsumeResult.SUCCESS);
+        verifyReceiveMessageTimes(1);
+    }
+
+    @Test
+    public void testResumeMessageReceivingAtBytesLowWatermark() {
+        useCapturingScheduler();
+        stubCacheThresholds(100, 50);
+        final List<MessageViewImpl> messages = cacheMessages(5, 10);
+        stubAckMessageSuccess();
+
+        processQueue.receiveMessage("bytes-low-watermark-attempt");
+        preparePendingReceive();
+        eraseMessages(messages.subList(0, 3));
+        verifyReceiveMessageTimes(0);
+
+        processQueue.eraseMessage(messages.get(3), ConsumeResult.SUCCESS);
+        verifyReceiveMessageTimes(1);
+    }
+
+    @Test
+    public void testResumeMessageReceivingAtZeroLowWatermark() {
+        useCapturingScheduler();
+        stubCacheThresholds(4, 4);
+        final List<MessageViewImpl> messages = cacheMessages(4, 1);
+        stubAckMessageSuccess();
+
+        processQueue.receiveMessage("zero-low-watermark-attempt");
+        preparePendingReceive();
+        eraseMessages(messages.subList(0, 3));
+        verifyReceiveMessageTimes(0);
+
+        processQueue.eraseMessage(messages.get(3), ConsumeResult.SUCCESS);
+        verifyReceiveMessageTimes(1);
+    }
+
+    @Test
+    public void testConcurrentCacheEvictionAndFallbackResumeOnlyOnce() throws InterruptedException {
+        final List<ScheduledTask> scheduledTasks = useCapturingScheduler();
+        stubCacheThresholds(10, 1000);
+        final List<MessageViewImpl> messages = cacheMessages(10, 1);
+        stubAckMessageSuccess();
+
+        processQueue.receiveMessage("concurrent-resume-attempt");
+        final ScheduledTask fallback = getOnlyScheduledTask(scheduledTasks, Duration.ofSeconds(1));
+        preparePendingReceive();
+        final int concurrentTasks = 9;
+        final CountDownLatch ready = new CountDownLatch(concurrentTasks);
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(concurrentTasks);
+        final ExecutorService executor = Executors.newFixedThreadPool(concurrentTasks);
+        try {
+            for (MessageViewImpl message : messages.subList(0, 8)) {
+                executor.execute(() -> {
+                    ready.countDown();
+                    awaitLatch(start);
+                    processQueue.eraseMessage(message, ConsumeResult.SUCCESS);
+                    done.countDown();
+                });
+            }
+            executor.execute(() -> {
+                ready.countDown();
+                awaitLatch(start);
+                fallback.command.run();
+                done.countDown();
+            });
+            assertTrue(ready.await(3, TimeUnit.SECONDS));
+            start.countDown();
+            assertTrue(done.await(3, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+
+        verifyReceiveMessageTimes(1);
+    }
+
+    @Test
+    public void testOldFallbackDoesNotResumeNewCachePause() {
+        final List<ScheduledTask> scheduledTasks = useCapturingScheduler();
+        stubCacheThresholds(1, 1);
+        stubAckMessageSuccess();
+
+        final MessageViewImpl firstMessage = cacheMessages(1, 1).get(0);
+        processQueue.receiveMessage("first-attempt");
+        final ScheduledTask firstFallback = getOnlyScheduledTask(scheduledTasks, Duration.ofSeconds(1));
+        preparePendingReceive();
+        processQueue.eraseMessage(firstMessage, ConsumeResult.SUCCESS);
+        verifyReceiveMessageTimes(1);
+
+        final MessageViewImpl secondMessage = cacheMessages(1, 1).get(0);
+        processQueue.receiveMessage("second-attempt");
+        assertEquals(2, countScheduledTasks(scheduledTasks, Duration.ofSeconds(1)));
+
+        firstFallback.command.run();
+        verifyReceiveMessageTimes(1);
+
+        processQueue.eraseMessage(secondMessage, ConsumeResult.SUCCESS);
+        verifyReceiveMessageTimes(2);
+    }
+
+    @Test
+    public void testCachePauseResumeReusesAttemptId() {
+        useCapturingScheduler();
+        stubCacheThresholds(1, 1);
+        stubAckMessageSuccess();
+        final String attemptId = "cache-pause-attempt";
+        final MessageViewImpl message = cacheMessages(1, 1).get(0);
+
+        processQueue.receiveMessage(attemptId);
+        preparePendingReceive();
+        processQueue.eraseMessage(message, ConsumeResult.SUCCESS);
+
+        verify(pushConsumer).wrapReceiveMessageRequest(anyInt(), any(MessageQueueImpl.class),
+            any(FilterExpression.class), any(Duration.class), eq(attemptId));
+    }
+
+    @Test
+    public void testCachePauseDoesNotResumeAfterDrop() {
+        final List<ScheduledTask> scheduledTasks = useCapturingScheduler();
+        stubCacheThresholds(1, 1);
+        stubAckMessageSuccess();
+        final MessageViewImpl message = cacheMessages(1, 1).get(0);
+
+        processQueue.receiveMessage("dropped-attempt");
+        final ScheduledTask fallback = getOnlyScheduledTask(scheduledTasks, Duration.ofSeconds(1));
+        processQueue.drop();
+        processQueue.eraseMessage(message, ConsumeResult.SUCCESS);
+        fallback.command.run();
+
+        verifyReceiveMessageTimes(0);
+    }
+
+    @Test
+    public void testCachePauseDoesNotReceiveAfterConsumerStopped() {
+        final List<ScheduledTask> scheduledTasks = useCapturingScheduler();
+        stubCacheThresholds(1, 1);
+        stubAckMessageSuccess();
+        final MessageViewImpl message = cacheMessages(1, 1).get(0);
+
+        processQueue.receiveMessage("stopped-attempt");
+        final ScheduledTask fallback = getOnlyScheduledTask(scheduledTasks, Duration.ofSeconds(1));
+        when(pushConsumer.isRunning()).thenReturn(false);
+        processQueue.eraseMessage(message, ConsumeResult.SUCCESS);
+        fallback.command.run();
+
+        verifyReceiveMessageTimes(0);
     }
 
     @Test
@@ -283,5 +459,100 @@ public class ProcessQueueImplTest extends TestBase {
                 .multipliedBy(forwardingToDeadLetterQueueTimes).plus(tolerance))
             .untilAsserted(() -> verify(pushConsumer, times(forwardingToDeadLetterQueueTimes))
                 .forwardMessageToDeadLetterQueue(any(MessageViewImpl.class)));
+    }
+
+    private List<ScheduledTask> useCapturingScheduler() {
+        final List<ScheduledTask> scheduledTasks = new CopyOnWriteArrayList<>();
+        final ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+        when(scheduler.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class))).thenAnswer(invocation -> {
+            final Runnable command = invocation.getArgument(0);
+            final long delay = invocation.getArgument(1);
+            final TimeUnit unit = invocation.getArgument(2);
+            scheduledTasks.add(new ScheduledTask(command, unit.toNanos(delay)));
+            return mock(ScheduledFuture.class);
+        });
+        when(pushConsumer.getScheduler()).thenReturn(scheduler);
+        return scheduledTasks;
+    }
+
+    private void stubCacheThresholds(int messageCount, int messageBytes) {
+        when(pushConsumer.cacheMessageCountThresholdPerQueue()).thenReturn(messageCount);
+        when(pushConsumer.cacheMessageBytesThresholdPerQueue()).thenReturn(messageBytes);
+    }
+
+    private List<MessageViewImpl> cacheMessages(int count, int messageBytes) {
+        final List<MessageViewImpl> messages = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            messages.add(fakeMessageViewImpl(messageBytes, false));
+        }
+        processQueue.cacheMessages(messages);
+        return messages;
+    }
+
+    private void stubAckMessageSuccess() {
+        when(pushConsumer.ackMessage(any(MessageViewImpl.class))).thenAnswer(ignored -> okAckMessageResponseFuture());
+    }
+
+    private void eraseMessages(List<MessageViewImpl> messages) {
+        for (MessageViewImpl message : messages) {
+            processQueue.eraseMessage(message, ConsumeResult.SUCCESS);
+        }
+    }
+
+    private void preparePendingReceive() {
+        when(pushSubscriptionSettings.getReceiveBatchSize()).thenReturn(32);
+        when(pushSubscriptionSettings.getLongPollingTimeout()).thenReturn(Duration.ofSeconds(15));
+        final ReceiveMessageRequest request = ReceiveMessageRequest.newBuilder().build();
+        when(pushConsumer.wrapReceiveMessageRequest(anyInt(), any(MessageQueueImpl.class),
+            any(FilterExpression.class), any(Duration.class), nullable(String.class))).thenReturn(request);
+        when(pushConsumer.receiveMessage(any(ReceiveMessageRequest.class), any(MessageQueueImpl.class),
+            any(Duration.class))).thenReturn(SettableFuture.create());
+    }
+
+    private void verifyReceiveMessageTimes(int expectedTimes) {
+        verify(pushConsumer, times(expectedTimes)).receiveMessage(any(ReceiveMessageRequest.class),
+            any(MessageQueueImpl.class), any(Duration.class));
+    }
+
+    private int countScheduledTasks(List<ScheduledTask> scheduledTasks, Duration delay) {
+        int count = 0;
+        for (ScheduledTask task : scheduledTasks) {
+            if (delay.toNanos() == task.delayNanos) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private ScheduledTask getOnlyScheduledTask(List<ScheduledTask> scheduledTasks, Duration delay) {
+        ScheduledTask result = null;
+        for (ScheduledTask task : scheduledTasks) {
+            if (delay.toNanos() != task.delayNanos) {
+                continue;
+            }
+            assertNull(result);
+            result = task;
+        }
+        assertNotNull(result);
+        return result;
+    }
+
+    private static void awaitLatch(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static final class ScheduledTask {
+        private final Runnable command;
+        private final long delayNanos;
+
+        private ScheduledTask(Runnable command, long delayNanos) {
+            this.command = command;
+            this.delayNanos = delayNanos;
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fixes #1340.

Java PushConsumer currently waits for the full one-second cache backoff after a `ProcessQueue` becomes full, even when ACK/NACK completion has already drained its local cache. With many assigned queues, the per-queue cache quota can be small, so this fixed receive gap can repeat under backlog and reduce receive throughput further.

Issue #1196 and PR #1214 increased the default total message cache, but the fixed recovery gap remained unchanged.

## Brief changelog

- Add a distinct `CachePause` token for each cache-full pause and retain that round's not-yet-sent receive `attemptId`.
- Store the active pause in an `AtomicReference` and use token-identity CAS so ACK/NACK completions and the fallback timer can schedule at most one resume.
- Resume through the consumer scheduler when both cached message count and cached bytes are at or below 20% of their current per-queue thresholds (`threshold / 5L`). Thresholds below five therefore use a zero low watermark.
- Keep the existing one-second task as a liveness fallback.
- Ignore stale timers from older pause rounds, preventing ABA against a newer pause.
- Stop recovery for dropped queues and stopped consumers.

The total count/byte cache limits and their existing per-queue high-watermark calculation are unchanged.

## Verifying this change

Added unit coverage for:

- exact 20% count and byte low-watermark boundaries;
- zero low watermark when a threshold is below five;
- concurrent cache eviction and fallback timer scheduling only one resume;
- a stale timer not affecting a newer pause;
- reuse of the paused receive `attemptId`;
- dropped queues and stopped consumers.

Validation with JDK 11:

```text
mvn -pl client -am -DskipITs -DfailIfNoTests=false -Dtest=ProcessQueueImplTest test
Tests run: 19, Failures: 0, Errors: 0, Skipped: 0

mvn -pl test -am -DskipITs -DfailIfNoTests=false -Dtest=AttemptIdIntegrationTest test
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

Both reactor builds also completed Checkstyle and SpotBugs successfully.
