### PR TITLE
[Java] prepare for next development iteration (5.2.2-SNAPSHOT)

### DIFF
--- a/java/client-apis/pom.xml
+++ b/java/client-apis/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>rocketmq-client-java-parent</artifactId>
         <groupId>org.apache.rocketmq</groupId>
-        <version>5.2.1</version>
+        <version>5.2.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/java/client-shade/pom.xml
+++ b/java/client-shade/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>rocketmq-client-java-parent</artifactId>
         <groupId>org.apache.rocketmq</groupId>
-        <version>5.2.1</version>
+        <version>5.2.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>rocketmq-client-java-parent</artifactId>
         <groupId>org.apache.rocketmq</groupId>
-        <version>5.2.1</version>
+        <version>5.2.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.apache.rocketmq</groupId>
     <artifactId>rocketmq-client-java-parent</artifactId>
     <packaging>pom</packaging>
-    <version>5.2.1</version>
+    <version>5.2.2-SNAPSHOT</version>
     <modules>
         <module>proto</module>
         <module>client-apis</module>

--- a/java/proto/pom.xml
+++ b/java/proto/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-client-java-parent</artifactId>
-        <version>5.2.1</version>
+        <version>5.2.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/java/test/pom.xml
+++ b/java/test/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-client-java-parent</artifactId>
-        <version>5.2.1</version>
+        <version>5.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>test</artifactId>


### PR DESCRIPTION
After the `java-5.2.1` release (#1278), the "prepare for next development iteration" step was missed, so master still carries `5.2.1` while 6 commits have landed since the tag.

Bump the version in all 6 Java poms to `5.2.2-SNAPSHOT`, following the same convention as previous iterations (#1186, #1115, #1007).