### PR TITLE
chore: add JSpecify @NullMarked annotations to org.apache.rocketmq.client.apis

### DIFF
--- a/java/client-apis/pom.xml
+++ b/java/client-apis/pom.xml
@@ -34,5 +34,10 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/package-info.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/package-info.java
@@ -15,20 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.rocketmq.client.apis.producer;
+@NullMarked
+package org.apache.rocketmq.client.apis.consumer;
 
-import org.apache.rocketmq.client.apis.message.MessageId;
-
-/**
- * A receipt from the server, which only makes sense when the message is sent successfully.
- */
-public interface SendReceipt {
-    MessageId getMessageId();
-
-    /**
-     * Unique handle to identify a message to recall, only delay message is supported for now
-     *
-     * @return the recall handle, or an empty string if the message type does not support recall.
-     */
-    String getRecallHandle();
-}
+import org.jspecify.annotations.NullMarked;

--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/message/package-info.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/message/package-info.java
@@ -15,20 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.rocketmq.client.apis.producer;
+@NullMarked
+package org.apache.rocketmq.client.apis.message;
 
-import org.apache.rocketmq.client.apis.message.MessageId;
-
-/**
- * A receipt from the server, which only makes sense when the message is sent successfully.
- */
-public interface SendReceipt {
-    MessageId getMessageId();
-
-    /**
-     * Unique handle to identify a message to recall, only delay message is supported for now
-     *
-     * @return the recall handle, or an empty string if the message type does not support recall.
-     */
-    String getRecallHandle();
-}
+import org.jspecify.annotations.NullMarked;

--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/package-info.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/package-info.java
@@ -15,20 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.rocketmq.client.apis.producer;
+@NullMarked
+package org.apache.rocketmq.client.apis;
 
-import org.apache.rocketmq.client.apis.message.MessageId;
-
-/**
- * A receipt from the server, which only makes sense when the message is sent successfully.
- */
-public interface SendReceipt {
-    MessageId getMessageId();
-
-    /**
-     * Unique handle to identify a message to recall, only delay message is supported for now
-     *
-     * @return the recall handle, or an empty string if the message type does not support recall.
-     */
-    String getRecallHandle();
-}
+import org.jspecify.annotations.NullMarked;

--- a/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/producer/package-info.java
+++ b/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/producer/package-info.java
@@ -15,20 +15,7 @@
  * limitations under the License.
  */
 
+@NullMarked
 package org.apache.rocketmq.client.apis.producer;
 
-import org.apache.rocketmq.client.apis.message.MessageId;
-
-/**
- * A receipt from the server, which only makes sense when the message is sent successfully.
- */
-public interface SendReceipt {
-    MessageId getMessageId();
-
-    /**
-     * Unique handle to identify a message to recall, only delay message is supported for now
-     *
-     * @return the recall handle, or an empty string if the message type does not support recall.
-     */
-    String getRecallHandle();
-}
+import org.jspecify.annotations.NullMarked;

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -53,6 +53,7 @@
         <protobuf.version>3.24.4</protobuf.version>
         <grpc.version>1.50.0</grpc.version>
         <guava.version>32.0.0-jre</guava.version>
+        <jspecify.version>1.0.0</jspecify.version>
         <slf4j.version>2.0.13</slf4j.version>
         <logback.version>1.3.15</logback.version>
         <commons-lang3.version>3.4</commons-lang3.version>
@@ -254,6 +255,11 @@
                 <scope>test</scope>
             </dependency>
 
+            <dependency>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>${jspecify.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.lz4</groupId>
                 <artifactId>lz4-java</artifactId>


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #1350 

### Brief Description

This PR adds JSpecify `@NullMarked` annotations to all 32 public types in the `client-apis` module, enabling Kotlin consumers to receive full nullability information instead of unsafe platform types (`String!`, `Map<String?,?>!`, etc.).

### How Did You Test This Change?

- **Maven build**: `mvn clean install` — all tests pass, zero behavioral changes
- **Kotlin interop**: verified with Kotlin 2.4.10 — compiler produces `"Unnecessary safe call on a non-null receiver"` warnings on annotated getters, confirming annotations are recognized at the Java-Kotlin boundary

