### PR TITLE
[Node.js] Fix createDuration producing non-integer protobuf Duration seconds

### DIFF
--- a/nodejs/src/consumer/ConsumeResult.ts
+++ b/nodejs/src/consumer/ConsumeResult.ts
@@ -57,6 +57,9 @@ export class ConsumeResultSuspend extends ConsumeResult {
 
   private constructor(suspendTimeMs: number) {
     super('SUSPEND');
+    if (!Number.isInteger(suspendTimeMs)) {
+      throw new Error(`suspend time must be an integer number of milliseconds, got ${suspendTimeMs}`);
+    }
     if (suspendTimeMs < MIN_SUSPEND_TIME_MS) {
       throw new Error(`suspend time cannot be less than ${MIN_SUSPEND_TIME_MS}ms, got ${suspendTimeMs}ms`);
     }
@@ -66,9 +69,9 @@ export class ConsumeResultSuspend extends ConsumeResult {
   /**
    * Create a suspend result with the given suspend time in milliseconds.
    *
-   * @param suspendTimeMs - Suspend time in milliseconds
+   * @param suspendTimeMs - Suspend time in milliseconds, does not need to be a whole second
    * @return {ConsumeResultSuspend} ConsumeResultSuspend instance
-   * @throws {Error} if suspendTimeMs is less than 50ms
+   * @throws {Error} if suspendTimeMs is not an integer or is less than 50ms
    */
   static of(suspendTimeMs: number): ConsumeResultSuspend {
     return new ConsumeResultSuspend(suspendTimeMs);

--- a/nodejs/src/consumer/ProcessQueue.ts
+++ b/nodejs/src/consumer/ProcessQueue.ts
@@ -218,7 +218,11 @@ export class ProcessQueue {
       if (status?.code !== Code.OK) {
         await this.#ackMessageLater(messageView, attempt + 1);
       }
-    } catch {
+    } catch (err) {
+      (this.#consumer as any).logger?.warn(
+        'Failed to ack message, attempt=%d, messageId=%s, error=%s',
+        attempt, messageView.messageId, err,
+      );
       await this.#ackMessageLater(messageView, attempt + 1);
     }
   }
@@ -251,7 +255,11 @@ export class ProcessQueue {
       if (status?.code !== Code.OK) {
         await this.#changeInvisibleDurationLater(messageView, duration, attempt + 1);
       }
-    } catch {
+    } catch (err) {
+      (this.#consumer as any).logger?.warn(
+        'Failed to change invisible duration, attempt=%d, duration=%dms, messageId=%s, error=%s',
+        attempt, duration, messageView.messageId, err,
+      );
       await this.#changeInvisibleDurationLater(messageView, duration, attempt + 1);
     }
   }

--- a/nodejs/src/util/index.ts
+++ b/nodejs/src/util/index.ts
@@ -45,9 +45,12 @@ export function sign(accessSecret: string, dateTime: string) {
 }
 
 export function createDuration(ms: number) {
-  const nanos = ms % 1000 * 1000000;
+  // Duration.seconds is a protobuf int64 field, so it must be an integer;
+  // the remainder is carried by nanos. Non-integer seconds would fail
+  // serialization with 'Assertion failed'.
+  const nanos = Math.floor(ms % 1000 * 1000000);
   return new Duration()
-    .setSeconds(ms / 1000)
+    .setSeconds(Math.floor(ms / 1000))
     .setNanos(nanos);
 }
 

--- a/nodejs/test/consumer/ConsumeResult.test.ts
+++ b/nodejs/test/consumer/ConsumeResult.test.ts
@@ -35,9 +35,23 @@ describe('ConsumeResult', () => {
     assert.strictEqual(suspend.toString(), 'SUSPEND(100ms)');
   });
 
+  it('should accept non-whole-second suspend time', () => {
+    const suspend = ConsumeResultSuspend.of(2173);
+    assert.strictEqual(suspend.suspendTimeMs, 2173);
+  });
+
   it('should reject suspend time less than 50ms', () => {
     assert.throws(() => {
       ConsumeResultSuspend.of(49);
     }, /suspend time cannot be less than 50ms/);
+  });
+
+  it('should reject non-integer suspend time', () => {
+    assert.throws(() => {
+      ConsumeResultSuspend.of(100.5);
+    }, /suspend time must be an integer number of milliseconds/);
+    assert.throws(() => {
+      ConsumeResultSuspend.of(NaN);
+    }, /suspend time must be an integer number of milliseconds/);
   });
 });

--- a/nodejs/test/util/index.test.ts
+++ b/nodejs/test/util/index.test.ts
@@ -17,6 +17,7 @@
 
 import { strict as assert } from 'node:assert';
 import {
+  createDuration,
   getTimestamp,
   calculateStringSipHash24,
 } from '../../src/util';
@@ -27,6 +28,23 @@ describe('test/util/index.test.ts', () => {
       const timestamp = getTimestamp();
       assert(timestamp.seconds);
       assert(timestamp.nanos);
+    });
+  });
+
+  describe('createDuration()', () => {
+    it('should split whole seconds correctly', () => {
+      const duration = createDuration(2000);
+      assert.equal(duration.getSeconds(), 2);
+      assert.equal(duration.getNanos(), 0);
+      assert(duration.serializeBinary().length > 0);
+    });
+
+    it('should split non-whole-second milliseconds correctly', () => {
+      const duration = createDuration(2173);
+      assert.equal(duration.getSeconds(), 2);
+      assert.equal(duration.getNanos(), 173000000);
+      // protobuf Duration.seconds is int64, serialization must not throw
+      assert(duration.serializeBinary().length > 0);
     });
   });
 


### PR DESCRIPTION
### Summary

`createDuration(ms)` sets `Duration.seconds` to `ms / 1000` without flooring.
`Duration.seconds` is int64, so any non-whole-second `ms` (e.g. 2173) makes
serialization throw `Assertion failed` before the RPC leaves the client.

In the SUSPEND path, `ProcessQueue#changeInvisibleDuration` swallows the error
and retries the same invalid duration every second: the RPC never reaches the
broker, the message hangs, and nothing is logged. All `createDuration` call
sites are affected (invisible duration, long-polling and request timeouts).

### Changes

- `createDuration()`: floor seconds; nanos already carry the remainder
- `ProcessQueue`: log the swallowed exception before retrying
- `ConsumeResultSuspend.of()`: reject non-integer ms (also NaN/Infinity)
- Unit tests: `createDuration(2173)` serializes as `(2s, 173000000ns)`;
  suspend accepts 2173, rejects 100.5/NaN

### How Did You Test This Change?

Unit tests in `test/util/index.test.ts` (the original repro
`createDuration(2173).serializeBinary()`) and
`test/consumer/ConsumeResult.test.ts`. Whole-second values are unaffected.
