### PR TITLE
fix(golang): stop discarding context.WithTimeout cancel functions

### DIFF
--- a/golang/client_manager.go
+++ b/golang/client_manager.go
@@ -233,7 +233,8 @@ func (cm *defaultClientManager) handleGrpcError(rpcClient RpcClient, err error) 
 	}
 }
 func (cm *defaultClientManager) QueryRoute(ctx context.Context, endpoints *v2.Endpoints, request *v2.QueryRouteRequest, duration time.Duration) (*v2.QueryRouteResponse, error) {
-	ctx, _ = context.WithTimeout(ctx, duration)
+	ctx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
 	rpcClient, err := cm.getRpcClient(endpoints)
 	if err != nil {
 		return nil, err
@@ -244,7 +245,8 @@ func (cm *defaultClientManager) QueryRoute(ctx context.Context, endpoints *v2.En
 }
 
 func (cm *defaultClientManager) QueryAssignments(ctx context.Context, endpoints *v2.Endpoints, request *v2.QueryAssignmentRequest, duration time.Duration) (*v2.QueryAssignmentResponse, error) {
-	ctx, _ = context.WithTimeout(ctx, duration)
+	ctx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
 	rpcClient, err := cm.getRpcClient(endpoints)
 	if err != nil {
 		return nil, err
@@ -255,7 +257,8 @@ func (cm *defaultClientManager) QueryAssignments(ctx context.Context, endpoints 
 }
 
 func (cm *defaultClientManager) SendMessage(ctx context.Context, endpoints *v2.Endpoints, request *v2.SendMessageRequest, duration time.Duration) (*v2.SendMessageResponse, error) {
-	ctx, _ = context.WithTimeout(ctx, duration)
+	ctx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
 	rpcClient, err := cm.getRpcClient(endpoints)
 	if err != nil {
 		return nil, err
@@ -266,7 +269,11 @@ func (cm *defaultClientManager) SendMessage(ctx context.Context, endpoints *v2.E
 }
 
 func (cm *defaultClientManager) Telemetry(ctx context.Context, endpoints *v2.Endpoints, duration time.Duration) (v2.MessagingService_TelemetryClient, error) {
-	ctx, _ = context.WithTimeout(ctx, duration)
+	// Telemetry is a long-lived bidirectional stream that is cached in defaultClientSession and
+	// reused across calls. It must NOT be bound to a per-call timeout: doing so cancels the stream
+	// once `duration` elapses, tearing down and rebuilding the persistent stream. Like
+	// ReceiveMessage (another streaming RPC) it uses the caller's context directly; `duration` is
+	// kept only for ClientManager interface compatibility.
 	rpcClient, err := cm.getRpcClient(endpoints)
 	if err != nil {
 		return nil, err
@@ -277,7 +284,8 @@ func (cm *defaultClientManager) Telemetry(ctx context.Context, endpoints *v2.End
 }
 
 func (cm *defaultClientManager) EndTransaction(ctx context.Context, endpoints *v2.Endpoints, request *v2.EndTransactionRequest, duration time.Duration) (*v2.EndTransactionResponse, error) {
-	ctx, _ = context.WithTimeout(ctx, duration)
+	ctx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
 	rpcClient, err := cm.getRpcClient(endpoints)
 	if err != nil {
 		return nil, err
@@ -288,7 +296,8 @@ func (cm *defaultClientManager) EndTransaction(ctx context.Context, endpoints *v
 }
 
 func (cm *defaultClientManager) HeartBeat(ctx context.Context, endpoints *v2.Endpoints, request *v2.HeartbeatRequest, duration time.Duration) (*v2.HeartbeatResponse, error) {
-	ctx, _ = context.WithTimeout(ctx, duration)
+	ctx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
 	rpcClient, err := cm.getRpcClient(endpoints)
 	if err != nil {
 		return nil, err
@@ -300,7 +309,8 @@ func (cm *defaultClientManager) HeartBeat(ctx context.Context, endpoints *v2.End
 }
 
 func (cm *defaultClientManager) NotifyClientTermination(ctx context.Context, endpoints *v2.Endpoints, request *v2.NotifyClientTerminationRequest, duration time.Duration) (*v2.NotifyClientTerminationResponse, error) {
-	ctx, _ = context.WithTimeout(ctx, duration)
+	ctx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
 	rpcClient, err := cm.getRpcClient(endpoints)
 	if err != nil {
 		return nil, err
@@ -321,7 +331,8 @@ func (cm *defaultClientManager) ReceiveMessage(ctx context.Context, endpoints *v
 }
 
 func (cm *defaultClientManager) AckMessage(ctx context.Context, endpoints *v2.Endpoints, request *v2.AckMessageRequest, duration time.Duration) (*v2.AckMessageResponse, error) {
-	ctx, _ = context.WithTimeout(ctx, duration)
+	ctx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
 	rpcClient, err := cm.getRpcClient(endpoints)
 	if err != nil {
 		return nil, err
@@ -332,7 +343,8 @@ func (cm *defaultClientManager) AckMessage(ctx context.Context, endpoints *v2.En
 }
 
 func (cm *defaultClientManager) ChangeInvisibleDuration(ctx context.Context, endpoints *v2.Endpoints, request *v2.ChangeInvisibleDurationRequest, duration time.Duration) (*v2.ChangeInvisibleDurationResponse, error) {
-	ctx, _ = context.WithTimeout(ctx, duration)
+	ctx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
 	rpcClient, err := cm.getRpcClient(endpoints)
 	if err != nil {
 		return nil, err
@@ -343,7 +355,8 @@ func (cm *defaultClientManager) ChangeInvisibleDuration(ctx context.Context, end
 }
 
 func (cm *defaultClientManager) ForwardMessageToDeadLetterQueue(ctx context.Context, endpoints *v2.Endpoints, request *v2.ForwardMessageToDeadLetterQueueRequest, duration time.Duration) (*v2.ForwardMessageToDeadLetterQueueResponse, error) {
-	ctx, _ = context.WithTimeout(ctx, duration)
+	ctx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
 	rpcClient, err := cm.getRpcClient(endpoints)
 	if err != nil {
 		return nil, err
@@ -354,7 +367,8 @@ func (cm *defaultClientManager) ForwardMessageToDeadLetterQueue(ctx context.Cont
 }
 func (cm *defaultClientManager) SyncLiteSubscription(ctx context.Context, endpoints *v2.Endpoints, request *v2.SyncLiteSubscriptionRequest,
 	duration time.Duration) (*v2.SyncLiteSubscriptionResponse, error) {
-	ctx, _ = context.WithTimeout(ctx, duration)
+	ctx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
 	rpcClient, err := cm.getRpcClient(endpoints)
 	if err != nil {
 		return nil, err
@@ -365,7 +379,8 @@ func (cm *defaultClientManager) SyncLiteSubscription(ctx context.Context, endpoi
 }
 
 func (cm *defaultClientManager) RecallMessage(ctx context.Context, endpoints *v2.Endpoints, request *v2.RecallMessageRequest, duration time.Duration) (*v2.RecallMessageResponse, error) {
-	ctx, _ = context.WithTimeout(ctx, duration)
+	ctx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
 	rpcClient, err := cm.getRpcClient(endpoints)
 	if err != nil {
 		return nil, err

--- a/golang/conn.go
+++ b/golang/conn.go
@@ -141,7 +141,9 @@ func (c *clientConn) dial(target string, dopts ...grpc.DialOption) (*grpc.Client
 
 	dctx := c.ctx
 	if c.opts.DialTimeout > 0 {
-		dctx, _ = context.WithTimeout(c.ctx, c.opts.DialTimeout)
+		var cancel context.CancelFunc
+		dctx, cancel = context.WithTimeout(c.ctx, c.opts.DialTimeout)
+		defer cancel()
 	}
 	conn, err := grpc.DialContext(dctx, target, opts...)
 	if err != nil {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #1358

### Brief Description

`go vet` reports 13 `lostcancel` findings in the golang client: the 11 unary RPC wrappers in `client_manager.go`, the dial timeout in `conn.go`, and `Telemetry` all discard the cancel function returned by `context.WithTimeout`.

- For the 11 unary RPCs and the dial path this PR switches to `ctx, cancel := context.WithTimeout(...)` + `defer cancel()`, releasing the timer as soon as the call returns instead of waiting for the deadline to expire.
- `Telemetry` is different: it returns a long-lived bidirectional stream cached in `clientSettings.observer`, so a per-call timeout is not a leak but a behavior bug — the deadline kills the cached stream every `timeout` interval and forces the recv loop to rebuild it. The timeout is removed and the caller-provided context is used directly, matching how the other streaming RPC (`ReceiveMessage`) handles its context; the `duration` parameter is kept for interface compatibility.

### How Did You Test This Change?

- `go vet ./...`: lostcancel findings 13 → 0.
- `go build ./...` passes; `go test ./...` passes with no regressions (including the client recovery tests); `gofmt -l` clean.
- Branch rebased onto current master (includes #1305, which touched `client_manager.go` for close-path cleanup but did not address the `WithTimeout` call sites).
