### PR TITLE
feat(rust): implement LiteSimpleConsumer

### DIFF
--- a/rust/examples/lite_producer.rs
+++ b/rust/examples/lite_producer.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Configure client options
     let mut client_option = ClientOption::default();
-    client_option.set_access_url("http://localhost:8080");
+    client_option.set_access_url("127.0.0.1:8080");
 
     // Configure producer options
     let mut producer_option = ProducerOption::default();

--- a/rust/examples/lite_push_consumer.rs
+++ b/rust/examples/lite_push_consumer.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     {
         // Configure client options
         let mut client_option = ClientOption::default();
-        client_option.set_access_url("http://localhost:8080");
+        client_option.set_access_url("127.0.0.1:8080");
 
         // Configure push consumer options
         let mut option = PushConsumerOption::default();

--- a/rust/examples/lite_simple_consumer.rs
+++ b/rust/examples/lite_simple_consumer.rs
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Example demonstrating how to consume lite messages using RocketMQ Rust client.
+//!
+//! LiteSimpleConsumer provides pull-style consumption of lite topics with reduced overhead.
+//! This example shows how to subscribe to lite topics, receive messages, and ack them.
+
+use rocketmq::conf::{ClientOption, SimpleConsumerOption};
+use rocketmq::{LiteSimpleConsumer, LiteSimpleConsumerTrait, OffsetOption, OffsetPolicy};
+use std::error::Error;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // Initialize tracing for logging
+    tracing_subscriber::fmt::init();
+
+    #[cfg(not(test))]
+    {
+        // Configure client options
+        let mut client_option = ClientOption::default();
+        client_option.set_access_url("127.0.0.1:8080");
+
+        // Configure simple consumer options
+        let mut option = SimpleConsumerOption::default();
+        option.set_consumer_group("yourConsumerGroup");
+
+        // Create and start the LiteSimpleConsumer
+        // Note: bind_topic is the parent topic that lite topics belong to.
+        // It must match the parent topic used by the producer (see examples/lite_producer.rs).
+        let mut consumer =
+            LiteSimpleConsumer::new(client_option, option, "parent_topic".to_string())?;
+
+        consumer.start().await?;
+        println!("LiteSimpleConsumer started successfully");
+
+        // Subscribe to lite topics.
+        // `subscribe_lite()` defaults to consuming from the latest offset. Here we use
+        // `subscribe_lite_with_offset()` with `OffsetPolicy::Min` to consume from the earliest
+        // available offset, so that messages produced before this consumer subscribed are not missed.
+        // These methods initiate network requests and perform quota verification, so they may fail;
+        // it's important to check the result of each call.
+        let from_beginning = OffsetOption::from_policy(OffsetPolicy::Min);
+        match consumer
+            .subscribe_lite_with_offset("lite-topic-1".to_string(), from_beginning.clone())
+            .await
+        {
+            Ok(_) => println!("Subscribed to lite-topic-1"),
+            Err(e) => eprintln!("Failed to subscribe to lite-topic-1: {:?}", e),
+        }
+
+        match consumer
+            .subscribe_lite_with_offset("lite-topic-2".to_string(), from_beginning.clone())
+            .await
+        {
+            Ok(_) => println!("Subscribed to lite-topic-2"),
+            Err(e) => eprintln!("Failed to subscribe to lite-topic-2: {:?}", e),
+        }
+
+        // Get current subscribed lite topics
+        let topics = consumer.get_lite_topic_set();
+        println!("\nCurrently subscribed lite topics: {:?}", topics);
+
+        // Receive messages from the bind (parent) topic.
+        // In lite mode, messages are delivered from the aggregation topic, and each
+        // message carries a `__LITE_TOPIC` property identifying its actual lite topic.
+        let mut received = 0usize;
+        for _ in 0..5 {
+            match consumer.receive(16, Duration::from_secs(15)).await {
+                Ok(messages) => {
+                    if messages.is_empty() {
+                        println!("No messages received in this round.");
+                    }
+                    for message in messages {
+                        received += 1;
+                        println!("Received message #{}", received);
+                        println!("  Message ID: {}", message.message_id());
+                        println!("  Topic: {}", message.topic());
+                        if let Some(lite_topic) = message.lite_topic() {
+                            println!("  Lite Topic: {}", lite_topic);
+                        }
+                        println!("  Body: {:?}", String::from_utf8_lossy(message.body()));
+
+                        // Ack the message so it will not be delivered again.
+                        if let Err(e) = consumer.ack(&message).await {
+                            eprintln!("Failed to ack message {}: {:?}", message.message_id(), e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Failed to receive messages: {:?}", e);
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(3)).await;
+        }
+
+        println!("\nReceived {} messages in total.", received);
+
+        // Shutdown the consumer
+        consumer.shutdown().await?;
+        println!("LiteSimpleConsumer shutdown");
+    }
+
+    #[cfg(test)]
+    {
+        println!("This example is not available in test mode");
+    }
+
+    Ok(())
+}

--- a/rust/examples/lite_simple_consumer.rs
+++ b/rust/examples/lite_simple_consumer.rs
@@ -21,7 +21,7 @@
 //! This example shows how to subscribe to lite topics, receive messages, and ack them.
 
 use rocketmq::conf::{ClientOption, SimpleConsumerOption};
-use rocketmq::{LiteSimpleConsumer, LiteSimpleConsumerTrait, OffsetOption, OffsetPolicy};
+use rocketmq::{LiteSimpleConsumer, OffsetOption, OffsetPolicy};
 use std::error::Error;
 use std::time::Duration;
 

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -138,20 +138,29 @@ impl Client {
     /// // Both clients share the same SessionManager and telemetry session
     /// ```
     pub(crate) fn clone_for_lite_consumer(&self) -> Self {
-        // Update client type to LitePushConsumer
-        let mut new_option = self.option.clone();
-        new_option.client_type = ClientType::LitePushConsumer;
+        self.clone_for_lite_consumer_with(ClientType::LitePushConsumer, true)
+    }
 
-        // Create new settings with LitePushConsumer type and FIFO enabled
+    /// Clone a lite client for LiteSimpleConsumer (shares SessionManager, keeps fifo=false)
+    pub(crate) fn clone_for_lite_simple_consumer(&self) -> Self {
+        self.clone_for_lite_consumer_with(ClientType::LiteSimpleConsumer, false)
+    }
+
+    fn clone_for_lite_consumer_with(&self, client_type: ClientType, force_fifo: bool) -> Self {
+        // Update client type
+        let mut new_option = self.option.clone();
+        new_option.client_type = client_type.clone();
+
+        // Create new settings with the given client type
         let mut new_settings = self.settings.clone();
         if let Some(Command::Settings(ref mut settings)) = &mut new_settings.command {
-            // Set client type to LitePushConsumer
-            settings.client_type = Some(pb::ClientType::LitePushConsumer as i32);
+            settings.client_type = Some(client_type as i32);
 
-            // Ensure FIFO is enabled for LitePushConsumer
-            // This is critical for maintaining message order in lite mode
-            if let Some(pb::settings::PubSub::Subscription(ref mut sub)) = settings.pub_sub {
-                sub.fifo = Some(true);
+            // LitePushConsumer forces FIFO to maintain message order in lite mode
+            if force_fifo {
+                if let Some(pb::settings::PubSub::Subscription(ref mut sub)) = settings.pub_sub {
+                    sub.fifo = Some(true);
+                }
             }
         }
 
@@ -334,7 +343,10 @@ impl Client {
     /// Check if this is a lite consumer (LitePushConsumer or LiteSimpleConsumer)
     #[allow(dead_code)]
     pub(crate) fn is_lite_consumer(&self) -> bool {
-        matches!(self.option.client_type, ClientType::LitePushConsumer)
+        matches!(
+            self.option.client_type,
+            ClientType::LitePushConsumer | ClientType::LiteSimpleConsumer
+        )
     }
 
     /// Verify that this client shares the same SessionManager with another client
@@ -605,7 +617,7 @@ impl Client {
                 vec![pb::AckMessageEntry {
                     message_id: ack_entry.message_id(),
                     receipt_handle: ack_entry.receipt_handle(),
-                    lite_topic: None,
+                    lite_topic: ack_entry.lite_topic(),
                 }],
             )
             .await?;
@@ -648,6 +660,7 @@ impl Client {
                 ack_entry.receipt_handle(),
                 invisible_duration,
                 ack_entry.message_id(),
+                ack_entry.lite_topic(),
             )
             .await?;
         Ok(result)
@@ -660,6 +673,7 @@ impl Client {
         receipt_handle: String,
         invisible_duration: Duration,
         message_id: String,
+        lite_topic: Option<String>,
     ) -> Result<String, ClientError> {
         let request = ChangeInvisibleDurationRequest {
             group: Some(Resource {
@@ -673,7 +687,7 @@ impl Client {
             receipt_handle,
             invisible_duration: Some(invisible_duration),
             message_id,
-            lite_topic: None,
+            lite_topic,
             suspend: None,
         };
         let response = rpc_client.change_invisible_duration(request).await?;
@@ -1372,6 +1386,7 @@ pub(crate) mod tests {
                 "receipt_handle".to_string(),
                 prost_types::Duration::default(),
                 "message_id".to_string(),
+                None,
             )
             .await;
         assert!(change_invisible_duration_result.is_ok());

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -122,7 +122,7 @@
 #[cfg(not(test))]
 pub use lite_push_consumer::{LitePushConsumer, LitePushConsumerTrait};
 #[cfg(not(test))]
-pub use lite_simple_consumer::{LiteSimpleConsumer, LiteSimpleConsumerTrait};
+pub use lite_simple_consumer::LiteSimpleConsumer;
 pub use model::common::ConsumeResult;
 pub use model::transaction::Transaction;
 pub use producer::Producer;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -121,6 +121,8 @@
 // Export structs that are part of crate API.
 #[cfg(not(test))]
 pub use lite_push_consumer::{LitePushConsumer, LitePushConsumerTrait};
+#[cfg(not(test))]
+pub use lite_simple_consumer::{LiteSimpleConsumer, LiteSimpleConsumerTrait};
 pub use model::common::ConsumeResult;
 pub use model::transaction::Transaction;
 pub use producer::Producer;
@@ -148,6 +150,8 @@ mod util;
 
 #[cfg(not(test))]
 mod lite_push_consumer;
+#[cfg(not(test))]
+mod lite_simple_consumer;
 #[cfg(not(test))]
 mod lite_subscription_manager;
 mod producer;

--- a/rust/src/lite_simple_consumer.rs
+++ b/rust/src/lite_simple_consumer.rs
@@ -36,7 +36,6 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
-use async_trait::async_trait;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
@@ -47,36 +46,13 @@ use crate::conf::{ClientOption, SimpleConsumerOption};
 use crate::error::{ClientError, ErrorKind};
 use crate::lite_subscription_manager::LiteSubscriptionManager;
 use crate::model::common::{ClientType, FilterExpression};
-use crate::model::message::{AckMessageEntry, MessageView};
+use crate::model::message::MessageView;
 use crate::model::offset_option::OffsetOption;
 use crate::pb;
 use crate::simple_consumer::SimpleConsumer;
 use crate::util::build_simple_consumer_settings;
 
 const OPERATION_NEW_LITE_SIMPLE_CONSUMER: &str = "lite_simple_consumer.new";
-
-/// LiteSimpleConsumer trait defining the interface for lite simple consumers
-#[async_trait]
-pub trait LiteSimpleConsumerTrait {
-    /// Subscribe to a lite topic
-    async fn subscribe_lite(&self, lite_topic: String) -> Result<(), ClientError>;
-
-    /// Subscribe to a lite topic with offset option
-    async fn subscribe_lite_with_offset(
-        &self,
-        lite_topic: String,
-        offset_option: OffsetOption,
-    ) -> Result<(), ClientError>;
-
-    /// Unsubscribe from a lite topic
-    async fn unsubscribe_lite(&self, lite_topic: String) -> Result<(), ClientError>;
-
-    /// Get the set of subscribed lite topics
-    fn get_lite_topic_set(&self) -> HashSet<String>;
-
-    /// Get the consumer group name
-    fn get_consumer_group(&self) -> String;
-}
 
 /// LiteSimpleConsumer implementation.
 ///
@@ -95,8 +71,8 @@ pub struct LiteSimpleConsumer {
     bind_topic: String,
     lite_client: Arc<Client>,
     lite_subscription_manager: Arc<LiteSubscriptionManager>,
-    shutdown_token: Option<CancellationToken>,
-    task_tracker: Option<TaskTracker>,
+    shutdown_token: CancellationToken,
+    task_tracker: TaskTracker,
 }
 
 impl LiteSimpleConsumer {
@@ -169,8 +145,8 @@ impl LiteSimpleConsumer {
             bind_topic,
             lite_client,
             lite_subscription_manager,
-            shutdown_token: None,
-            task_tracker: None,
+            shutdown_token: CancellationToken::default(),
+            task_tracker: TaskTracker::default(),
         })
     }
 
@@ -243,9 +219,9 @@ impl LiteSimpleConsumer {
         //   - onSettingsCommand() -> super.onSettingsCommand() + liteSubscriptionManager.sync(settings)
         //   - onNotifyUnsubscribeLiteCommand() -> liteSubscriptionManager.onNotifyUnsubscribeLiteCommand()
         let shutdown_token = CancellationToken::new();
-        self.shutdown_token = Some(shutdown_token.clone());
+        self.shutdown_token = shutdown_token.clone();
         let task_tracker = TaskTracker::new();
-        self.task_tracker = Some(task_tracker.clone());
+        self.task_tracker = task_tracker.clone();
 
         let manager = Arc::clone(&self.lite_subscription_manager);
         let client_id_clone = client_id.clone();
@@ -297,7 +273,66 @@ impl LiteSimpleConsumer {
         Ok(())
     }
 
-    /// Fetch messages from the bind topic synchronously.
+    /// Subscribe to a lite topic
+    ///
+    /// Reference Java: LiteSimpleConsumerImpl.subscribeLite(String)
+    pub async fn subscribe_lite(&self, lite_topic: String) -> Result<(), ClientError> {
+        // Check if client is started (public API validation)
+        self.inner
+            .check_started("lite_simple_consumer.subscribe_lite")?;
+
+        self.lite_subscription_manager
+            .subscribe_lite(lite_topic, None)
+            .await
+    }
+
+    /// Subscribe to a lite topic with offset option
+    ///
+    /// Reference Java: LiteSimpleConsumerImpl.subscribeLite(String, OffsetOption)
+    pub async fn subscribe_lite_with_offset(
+        &self,
+        lite_topic: String,
+        offset_option: OffsetOption,
+    ) -> Result<(), ClientError> {
+        // Check if client is started (public API validation)
+        self.inner
+            .check_started("lite_simple_consumer.subscribe_lite_with_offset")?;
+
+        self.lite_subscription_manager
+            .subscribe_lite(lite_topic, Some(offset_option))
+            .await
+    }
+
+    /// Unsubscribe from a lite topic
+    ///
+    /// Reference Java: LiteSimpleConsumerImpl.unsubscribeLite(String)
+    pub async fn unsubscribe_lite(&self, lite_topic: String) -> Result<(), ClientError> {
+        // Check if client is started (public API validation)
+        self.inner
+            .check_started("lite_simple_consumer.unsubscribe_lite")?;
+
+        self.lite_subscription_manager
+            .unsubscribe_lite(lite_topic)
+            .await
+    }
+
+    /// Get the set of subscribed lite topics
+    ///
+    /// Reference Java: LiteSimpleConsumerImpl.getLiteTopicSet()
+    pub fn get_lite_topic_set(&self) -> HashSet<String> {
+        self.lite_subscription_manager.get_lite_topic_set()
+    }
+
+    /// Get the consumer group name
+    ///
+    /// Reference Java: LiteSimpleConsumerImpl.getConsumerGroup()
+    pub fn get_consumer_group(&self) -> String {
+        self.lite_subscription_manager
+            .get_consumer_group_name()
+            .to_string()
+    }
+
+    /// Fetch messages from the bind topic (aggregation topic).
     ///
     /// Reference Java: LiteSimpleConsumerImpl.receive(maxMessageNum, invisibleDuration)
     /// -> SimpleConsumerImpl.receive(getTopic(), SUB_ALL, maxMessageNum, invisibleDuration)
@@ -320,17 +355,18 @@ impl LiteSimpleConsumer {
     }
 
     /// Ack the specified message.
-    pub async fn ack(
-        &self,
-        ack_entry: &(impl AckMessageEntry + 'static),
-    ) -> Result<(), ClientError> {
+    ///
+    /// Reference Java: LiteSimpleConsumerImpl.ack(MessageView)
+    pub async fn ack(&self, ack_entry: &MessageView) -> Result<(), ClientError> {
         self.inner.ack(ack_entry).await
     }
 
     /// Change the invisible duration of a specified message.
+    ///
+    /// Reference Java: LiteSimpleConsumerImpl.changeInvisibleDuration(MessageView, Duration)
     pub async fn change_invisible_duration(
         &self,
-        ack_entry: &(impl AckMessageEntry + 'static),
+        ack_entry: &MessageView,
         invisible_duration: Duration,
     ) -> Result<String, ClientError> {
         self.inner
@@ -344,80 +380,13 @@ impl LiteSimpleConsumer {
     pub async fn shutdown(&mut self) -> Result<(), ClientError> {
         info!("Shutting down LiteSimpleConsumer...");
 
-        if let Some(token) = self.shutdown_token.take() {
-            token.cancel();
-        }
-
-        if let Some(tracker) = self.task_tracker.take() {
-            tracker.close();
-            tracker.wait().await;
-        }
+        self.shutdown_token.cancel();
+        self.task_tracker.close();
+        self.task_tracker.wait().await;
 
         self.inner.shutdown_ref().await?;
 
         info!("LiteSimpleConsumer shutdown successfully");
         Ok(())
-    }
-}
-
-#[async_trait]
-impl LiteSimpleConsumerTrait for LiteSimpleConsumer {
-    /// Subscribe to a lite topic
-    ///
-    /// Reference Java: LiteSimpleConsumerImpl.subscribeLite(String)
-    async fn subscribe_lite(&self, lite_topic: String) -> Result<(), ClientError> {
-        // Check if client is started (public API validation)
-        self.inner
-            .check_started("lite_simple_consumer.subscribe_lite")?;
-
-        self.lite_subscription_manager
-            .subscribe_lite(lite_topic, None)
-            .await
-    }
-
-    /// Subscribe to a lite topic with offset option
-    ///
-    /// Reference Java: LiteSimpleConsumerImpl.subscribeLite(String, OffsetOption)
-    async fn subscribe_lite_with_offset(
-        &self,
-        lite_topic: String,
-        offset_option: OffsetOption,
-    ) -> Result<(), ClientError> {
-        // Check if client is started (public API validation)
-        self.inner
-            .check_started("lite_simple_consumer.subscribe_lite_with_offset")?;
-
-        self.lite_subscription_manager
-            .subscribe_lite(lite_topic, Some(offset_option))
-            .await
-    }
-
-    /// Unsubscribe from a lite topic
-    ///
-    /// Reference Java: LiteSimpleConsumerImpl.unsubscribeLite(String)
-    async fn unsubscribe_lite(&self, lite_topic: String) -> Result<(), ClientError> {
-        // Check if client is started (public API validation)
-        self.inner
-            .check_started("lite_simple_consumer.unsubscribe_lite")?;
-
-        self.lite_subscription_manager
-            .unsubscribe_lite(lite_topic)
-            .await
-    }
-
-    /// Get the set of subscribed lite topics
-    ///
-    /// Reference Java: LiteSimpleConsumerImpl.getLiteTopicSet()
-    fn get_lite_topic_set(&self) -> HashSet<String> {
-        self.lite_subscription_manager.get_lite_topic_set()
-    }
-
-    /// Get the consumer group name
-    ///
-    /// Reference Java: LiteSimpleConsumerImpl.getConsumerGroup()
-    fn get_consumer_group(&self) -> String {
-        self.lite_subscription_manager
-            .get_consumer_group_name()
-            .to_string()
     }
 }

--- a/rust/src/lite_simple_consumer.rs
+++ b/rust/src/lite_simple_consumer.rs
@@ -1,0 +1,423 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! LiteSimpleConsumer - A specialized simple consumer for lite topics with reduced metadata and storage overhead.
+//!
+//! Reference Java: LiteSimpleConsumerImpl extends SimpleConsumerImpl
+//!
+//! LiteSimpleConsumer is a pull-style consumer variant for lite topics. It shares the same
+//! consumption infrastructure as SimpleConsumer (receive/ack/change invisible duration)
+//! but adds lite topic subscription management via LiteSubscriptionManager.
+//!
+//! Key design points (aligned with Java):
+//! 1. LiteSimpleConsumer wraps a SimpleConsumer for message consumption logic
+//! 2. LiteSubscriptionManager handles lite topic lifecycle (subscribe/unsubscribe/sync)
+//! 3. The lite_client is a lightweight clone of the main client for LiteSubscriptionManager RPC calls
+//! 4. Telemetry commands related to lite subscriptions (NotifyUnsubscribeLiteCommand, Settings)
+//!    are forwarded to LiteSubscriptionManager for processing
+//! 5. receive() fetches messages from the bind topic (aggregation topic); each returned
+//!    message carries a `__LITE_TOPIC` property identifying its actual lite topic
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+use tracing::{debug, error, info};
+
+use crate::client::Client;
+use crate::conf::{ClientOption, SimpleConsumerOption};
+use crate::error::{ClientError, ErrorKind};
+use crate::lite_subscription_manager::LiteSubscriptionManager;
+use crate::model::common::{ClientType, FilterExpression};
+use crate::model::message::{AckMessageEntry, MessageView};
+use crate::model::offset_option::OffsetOption;
+use crate::pb;
+use crate::simple_consumer::SimpleConsumer;
+use crate::util::build_simple_consumer_settings;
+
+const OPERATION_NEW_LITE_SIMPLE_CONSUMER: &str = "lite_simple_consumer.new";
+
+/// LiteSimpleConsumer trait defining the interface for lite simple consumers
+#[async_trait]
+pub trait LiteSimpleConsumerTrait {
+    /// Subscribe to a lite topic
+    async fn subscribe_lite(&self, lite_topic: String) -> Result<(), ClientError>;
+
+    /// Subscribe to a lite topic with offset option
+    async fn subscribe_lite_with_offset(
+        &self,
+        lite_topic: String,
+        offset_option: OffsetOption,
+    ) -> Result<(), ClientError>;
+
+    /// Unsubscribe from a lite topic
+    async fn unsubscribe_lite(&self, lite_topic: String) -> Result<(), ClientError>;
+
+    /// Get the set of subscribed lite topics
+    fn get_lite_topic_set(&self) -> HashSet<String>;
+
+    /// Get the consumer group name
+    fn get_consumer_group(&self) -> String;
+}
+
+/// LiteSimpleConsumer implementation.
+///
+/// Reference Java: LiteSimpleConsumerImpl extends SimpleConsumerImpl
+///
+/// Implementation notes:
+/// - Java's LiteSimpleConsumerImpl extends SimpleConsumerImpl, which extends ConsumerImpl extends ClientImpl.
+///   All classes share the same underlying client infrastructure.
+/// - In Rust, since Client doesn't implement Clone for shared ownership, we use clone_for_lite_simple_consumer()
+///   to create a lightweight clone for LiteSubscriptionManager. This ensures both the inner SimpleConsumer
+///   and LiteSubscriptionManager have their own Client instances sharing the same SessionManager.
+/// - receive() delegates to the inner SimpleConsumer, which selects a readable master queue
+///   (select_first_readable_queue) instead of round-robin when the client is a lite consumer.
+pub struct LiteSimpleConsumer {
+    inner: SimpleConsumer,
+    bind_topic: String,
+    lite_client: Arc<Client>,
+    lite_subscription_manager: Arc<LiteSubscriptionManager>,
+    shutdown_token: Option<CancellationToken>,
+    task_tracker: Option<TaskTracker>,
+}
+
+impl LiteSimpleConsumer {
+    /// Create a new LiteSimpleConsumer
+    ///
+    /// Reference Java:
+    /// 1. LiteSimpleConsumerBuilderImpl sets {bindTopic: SUB_ALL} as the single subscription topic
+    /// 2. LiteSimpleConsumerImpl constructor calls super(...) which creates SimpleConsumerImpl
+    /// 3. LiteSubscriptionManager is created with (thisConsumerImpl, new Resource(bindTopic), groupResource)
+    pub fn new(
+        client_option: ClientOption,
+        option: SimpleConsumerOption,
+        bind_topic: String,
+    ) -> Result<Self, ClientError> {
+        if option.consumer_group().is_empty() {
+            return Err(ClientError::new(
+                ErrorKind::Config,
+                "consumer group is required.",
+                OPERATION_NEW_LITE_SIMPLE_CONSUMER,
+            ));
+        }
+
+        if bind_topic.is_empty() {
+            return Err(ClientError::new(
+                ErrorKind::Config,
+                "bind topic is required.",
+                OPERATION_NEW_LITE_SIMPLE_CONSUMER,
+            ));
+        }
+
+        // Reference Java: LiteSimpleConsumerBuilderImpl sets the bind topic as the only
+        // topic so that the inner SimpleConsumer prefetches its route on startup.
+        let mut option_with_bind_topic = option.clone();
+        option_with_bind_topic.set_topics(vec![bind_topic.clone()]);
+
+        // Reference Java: SubscriptionSettings.toProtobuf() with clientType = LiteSimpleConsumer
+        let mut settings = build_simple_consumer_settings(&option_with_bind_topic);
+        if let Some(pb::telemetry_command::Command::Settings(ref mut s)) = settings.command {
+            s.client_type = Some(pb::ClientType::LiteSimpleConsumer as i32);
+        }
+
+        let namespace = option.namespace().to_string();
+        let consumer_group = option.consumer_group().to_string();
+
+        // Reference Java: ConsumerImpl constructor
+        // Create the main client for consumption (inner SimpleConsumer)
+        let client_option = ClientOption {
+            client_type: ClientType::LiteSimpleConsumer,
+            group: Some(consumer_group.clone()),
+            namespace: namespace.clone(),
+            ..client_option
+        };
+        let client = Client::new(client_option, settings)?;
+
+        // Reference Java: LiteSubscriptionManager(consumerImpl, new Resource(bindTopic), groupResource)
+        // clone_for_lite_simple_consumer creates a lightweight Client clone sharing the same SessionManager.
+        let lite_client = Arc::new(client.clone_for_lite_simple_consumer());
+        let lite_subscription_manager = Arc::new(LiteSubscriptionManager::new(
+            Arc::clone(&lite_client),
+            bind_topic.clone(),
+            namespace,
+            consumer_group,
+        ));
+
+        // Create inner SimpleConsumer with option_with_bind_topic
+        let inner = SimpleConsumer::new_with_client(client, option_with_bind_topic)?;
+
+        Ok(Self {
+            inner,
+            bind_topic,
+            lite_client,
+            lite_subscription_manager,
+            shutdown_token: None,
+            task_tracker: None,
+        })
+    }
+
+    /// Start the LiteSimpleConsumer
+    ///
+    /// Reference Java: LiteSimpleConsumerImpl.startUp()
+    ///
+    /// Java flow:
+    /// 1. super.startUp() -> SimpleConsumerImpl.startUp() -> ClientImpl.startUp()
+    ///    Starts the client, establishes telemetry, fetches topic routes.
+    /// 2. liteSubscriptionManager.startUp() -> syncAllLiteSubscription() + schedule periodic sync
+    pub async fn start(&mut self) -> Result<(), ClientError> {
+        let bind_topic = self
+            .lite_subscription_manager
+            .get_bind_topic_name()
+            .to_string();
+        let consumer_group = self
+            .lite_subscription_manager
+            .get_consumer_group_name()
+            .to_string();
+        let client_id = self.lite_client.client_id().to_string();
+
+        info!(
+            "Begin to start the LiteSimpleConsumer, bindTopic={}, consumerGroup={}, clientId={}",
+            bind_topic, consumer_group, client_id
+        );
+
+        // Step 1: Start inner SimpleConsumer (reference Java: super.startUp())
+        // This starts the client, establishes telemetry, and prefetches the bind topic route.
+        let (telemetry_command_tx, mut telemetry_command_rx) = mpsc::channel(16);
+        if let Err(e) = self.inner.start_with_telemetry(telemetry_command_tx).await {
+            error!(
+                "Failed to start LiteSimpleConsumer inner, bindTopic={}, clientId={}, error={:?}",
+                bind_topic, client_id, e
+            );
+            if let Err(shutdown_err) = self.shutdown().await {
+                error!(
+                    "Failed to shutdown after start failure, clientId={}, error={:?}",
+                    client_id, shutdown_err
+                );
+            }
+            return Err(ClientError::new(
+                ErrorKind::ClientInternal,
+                &format!("startUp err={:?}", e),
+                "lite_simple_consumer.start",
+            ));
+        }
+
+        // Step 2: Start lite subscription manager (reference Java: liteSubscriptionManager.startUp())
+        if let Err(e) = self.lite_subscription_manager.start().await {
+            error!(
+                "Failed to start LiteSubscriptionManager, bindTopic={}, clientId={}, error={:?}",
+                bind_topic, client_id, e
+            );
+            if let Err(shutdown_err) = self.shutdown().await {
+                error!(
+                    "Failed to shutdown after start failure, clientId={}, error={:?}",
+                    client_id, shutdown_err
+                );
+            }
+            return Err(ClientError::new(
+                ErrorKind::ClientInternal,
+                &format!("startUp err={:?}", e),
+                "lite_simple_consumer.start",
+            ));
+        }
+
+        // Step 3: Setup telemetry command handler for lite-specific commands
+        // Reference Java: LiteSimpleConsumerImpl handles:
+        //   - onSettingsCommand() -> super.onSettingsCommand() + liteSubscriptionManager.sync(settings)
+        //   - onNotifyUnsubscribeLiteCommand() -> liteSubscriptionManager.onNotifyUnsubscribeLiteCommand()
+        let shutdown_token = CancellationToken::new();
+        self.shutdown_token = Some(shutdown_token.clone());
+        let task_tracker = TaskTracker::new();
+        self.task_tracker = Some(task_tracker.clone());
+
+        let manager = Arc::clone(&self.lite_subscription_manager);
+        let client_id_clone = client_id.clone();
+        task_tracker.spawn(async move {
+            loop {
+                tokio::select! {
+                    command = telemetry_command_rx.recv() => {
+                        if let Some(command) = command {
+                            match command {
+                                // Reference Java: onNotifyUnsubscribeLiteCommand()
+                                pb::telemetry_command::Command::NotifyUnsubscribeLiteCommand(cmd) => {
+                                    let lite_topic = cmd.lite_topic;
+                                    info!(
+                                        "Received unsubscribe notification for lite topic: {}, clientId={}",
+                                        lite_topic, client_id_clone
+                                    );
+                                    manager.on_notify_unsubscribe_lite_command(lite_topic);
+                                }
+                                // Reference Java: onSettingsCommand() -> liteSubscriptionManager.sync(settings)
+                                pb::telemetry_command::Command::Settings(settings_cmd) => {
+                                    debug!(
+                                        "Received settings update from server, clientId={}",
+                                        client_id_clone
+                                    );
+                                    manager.sync_settings(&settings_cmd);
+                                }
+                                _ => {}
+                            }
+                        } else {
+                            // Channel closed, exit loop
+                            break;
+                        }
+                    }
+                    _ = shutdown_token.cancelled() => {
+                        break;
+                    }
+                }
+            }
+            info!(
+                "LiteSimpleConsumer telemetry handler stopped, clientId={}",
+                client_id_clone
+            );
+        });
+
+        info!(
+            "The LiteSimpleConsumer starts successfully, bindTopic={}, consumerGroup={}, clientId={}",
+            bind_topic, consumer_group, client_id
+        );
+        Ok(())
+    }
+
+    /// Fetch messages from the bind topic synchronously.
+    ///
+    /// Reference Java: LiteSimpleConsumerImpl.receive(maxMessageNum, invisibleDuration)
+    /// -> SimpleConsumerImpl.receive(getTopic(), SUB_ALL, maxMessageNum, invisibleDuration)
+    ///
+    /// In lite mode, the bind topic is the aggregation topic; each returned message
+    /// carries a `__LITE_TOPIC` property identifying its actual lite topic.
+    pub async fn receive(
+        &self,
+        batch_size: i32,
+        invisible_duration: Duration,
+    ) -> Result<Vec<MessageView>, ClientError> {
+        self.inner
+            .receive_with(
+                &self.bind_topic,
+                &FilterExpression::sub_all(),
+                batch_size,
+                invisible_duration,
+            )
+            .await
+    }
+
+    /// Ack the specified message.
+    pub async fn ack(
+        &self,
+        ack_entry: &(impl AckMessageEntry + 'static),
+    ) -> Result<(), ClientError> {
+        self.inner.ack(ack_entry).await
+    }
+
+    /// Change the invisible duration of a specified message.
+    pub async fn change_invisible_duration(
+        &self,
+        ack_entry: &(impl AckMessageEntry + 'static),
+        invisible_duration: Duration,
+    ) -> Result<String, ClientError> {
+        self.inner
+            .change_invisible_duration(ack_entry, invisible_duration)
+            .await
+    }
+
+    /// Shutdown the consumer.
+    ///
+    /// Reference Java: SimpleConsumerImpl.close() -> this.stopAsync().awaitTerminated()
+    pub async fn shutdown(&mut self) -> Result<(), ClientError> {
+        info!("Shutting down LiteSimpleConsumer...");
+
+        if let Some(token) = self.shutdown_token.take() {
+            token.cancel();
+        }
+
+        if let Some(tracker) = self.task_tracker.take() {
+            tracker.close();
+            tracker.wait().await;
+        }
+
+        self.inner.shutdown_ref().await?;
+
+        info!("LiteSimpleConsumer shutdown successfully");
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl LiteSimpleConsumerTrait for LiteSimpleConsumer {
+    /// Subscribe to a lite topic
+    ///
+    /// Reference Java: LiteSimpleConsumerImpl.subscribeLite(String)
+    async fn subscribe_lite(&self, lite_topic: String) -> Result<(), ClientError> {
+        // Check if client is started (public API validation)
+        self.inner
+            .check_started("lite_simple_consumer.subscribe_lite")?;
+
+        self.lite_subscription_manager
+            .subscribe_lite(lite_topic, None)
+            .await
+    }
+
+    /// Subscribe to a lite topic with offset option
+    ///
+    /// Reference Java: LiteSimpleConsumerImpl.subscribeLite(String, OffsetOption)
+    async fn subscribe_lite_with_offset(
+        &self,
+        lite_topic: String,
+        offset_option: OffsetOption,
+    ) -> Result<(), ClientError> {
+        // Check if client is started (public API validation)
+        self.inner
+            .check_started("lite_simple_consumer.subscribe_lite_with_offset")?;
+
+        self.lite_subscription_manager
+            .subscribe_lite(lite_topic, Some(offset_option))
+            .await
+    }
+
+    /// Unsubscribe from a lite topic
+    ///
+    /// Reference Java: LiteSimpleConsumerImpl.unsubscribeLite(String)
+    async fn unsubscribe_lite(&self, lite_topic: String) -> Result<(), ClientError> {
+        // Check if client is started (public API validation)
+        self.inner
+            .check_started("lite_simple_consumer.unsubscribe_lite")?;
+
+        self.lite_subscription_manager
+            .unsubscribe_lite(lite_topic)
+            .await
+    }
+
+    /// Get the set of subscribed lite topics
+    ///
+    /// Reference Java: LiteSimpleConsumerImpl.getLiteTopicSet()
+    fn get_lite_topic_set(&self) -> HashSet<String> {
+        self.lite_subscription_manager.get_lite_topic_set()
+    }
+
+    /// Get the consumer group name
+    ///
+    /// Reference Java: LiteSimpleConsumerImpl.getConsumerGroup()
+    fn get_consumer_group(&self) -> String {
+        self.lite_subscription_manager
+            .get_consumer_group_name()
+            .to_string()
+    }
+}

--- a/rust/src/model/common.rs
+++ b/rust/src/model/common.rs
@@ -37,6 +37,7 @@ pub(crate) enum ClientType {
     #[allow(dead_code)]
     PullConsumer = 4,
     LitePushConsumer = 5,
+    LiteSimpleConsumer = 6,
 }
 
 #[derive(Debug)]

--- a/rust/src/model/message.rs
+++ b/rust/src/model/message.rs
@@ -432,6 +432,8 @@ pub trait AckMessageEntry {
     fn message_id(&self) -> String;
     fn receipt_handle(&self) -> String;
     fn endpoints(&self) -> &Endpoints;
+    /// Lite topic of the message, if it is a lite message.
+    fn lite_topic(&self) -> Option<String>;
 }
 
 /// [`MessageView`] is the data model for receive message.
@@ -472,6 +474,10 @@ impl AckMessageEntry for MessageView {
 
     fn endpoints(&self) -> &Endpoints {
         &self.endpoints
+    }
+
+    fn lite_topic(&self) -> Option<String> {
+        self.lite_topic.clone()
     }
 }
 

--- a/rust/src/simple_consumer.rs
+++ b/rust/src/simple_consumer.rs
@@ -19,7 +19,8 @@ use std::time::Duration;
 
 use mockall_double::double;
 use tokio::select;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 #[double]
@@ -29,7 +30,8 @@ use crate::error::{ClientError, ErrorKind};
 use crate::model::common::{ClientType, FilterExpression};
 use crate::model::message::{AckMessageEntry, MessageView};
 use crate::util::{
-    build_endpoints_by_message_queue, build_simple_consumer_settings, select_message_queue,
+    build_endpoints_by_message_queue, build_simple_consumer_settings, select_first_readable_queue,
+    select_message_queue,
 };
 
 /// [`SimpleConsumer`] is a lightweight consumer to consume messages from RocketMQ proxy.
@@ -45,7 +47,7 @@ use crate::util::{
 pub struct SimpleConsumer {
     option: SimpleConsumerOption,
     client: Client,
-    shutdown_tx: Option<oneshot::Sender<()>>,
+    shutdown_token: Option<CancellationToken>,
 }
 
 impl SimpleConsumer {
@@ -73,31 +75,40 @@ impl SimpleConsumer {
             ..client_option
         };
         let client = Client::new(client_option, build_simple_consumer_settings(&option))?;
+        Self::new_with_client(client, option)
+    }
+
+    /// Create a SimpleConsumer from an existing client.
+    ///
+    /// Used by [`crate::LiteSimpleConsumer`] to share a client that has already
+    /// been configured with the correct [`ClientType`] and settings.
+    pub(crate) fn new_with_client(
+        client: Client,
+        option: SimpleConsumerOption,
+    ) -> Result<Self, ClientError> {
+        if option.consumer_group().is_empty() {
+            return Err(ClientError::new(
+                ErrorKind::Config,
+                "required option is missing: consumer group is empty",
+                Self::OPERATION_NEW_SIMPLE_CONSUMER,
+            ));
+        }
         Ok(SimpleConsumer {
             option,
             client,
-            shutdown_tx: None,
+            shutdown_token: None,
         })
     }
 
     /// Start the simple consumer
     pub async fn start(&mut self) -> Result<(), ClientError> {
-        if self.option.consumer_group().is_empty() {
-            return Err(ClientError::new(
-                ErrorKind::Config,
-                "required option is missing: consumer group is empty",
-                Self::OPERATION_START_SIMPLE_CONSUMER,
-            ));
-        }
         let (telemetry_command_tx, mut telemetry_command_rx) = mpsc::channel(16);
-        self.client.start(telemetry_command_tx).await?;
-        if let Some(topics) = self.option.topics() {
-            for topic in topics {
-                self.client.topic_route(topic, true).await?;
-            }
-        }
-        let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
-        self.shutdown_tx = Some(shutdown_tx);
+        self.start_with_telemetry(telemetry_command_tx).await?;
+
+        let shutdown_token = self
+            .shutdown_token
+            .clone()
+            .expect("shutdown token should have been initialized by start_with_telemetry");
         tokio::spawn(async move {
             loop {
                 select! {
@@ -105,7 +116,7 @@ impl SimpleConsumer {
                         warn!("command {:?} cannot be handled in simple consumer.", command);
                     }
 
-                    _ = &mut shutdown_rx => {
+                    _ = shutdown_token.cancelled() => {
                        break;
                     }
                 }
@@ -118,11 +129,48 @@ impl SimpleConsumer {
         Ok(())
     }
 
-    pub async fn shutdown(self) -> Result<(), ClientError> {
-        if let Some(shutdown_tx) = self.shutdown_tx {
-            let _ = shutdown_tx.send(());
-        };
+    /// Start the inner client with an external telemetry channel, without
+    /// consuming it. Used by [`crate::LiteSimpleConsumer`] so that it can
+    /// process lite-specific telemetry commands itself.
+    pub(crate) async fn start_with_telemetry(
+        &mut self,
+        telemetry_command_tx: mpsc::Sender<crate::pb::telemetry_command::Command>,
+    ) -> Result<(), ClientError> {
+        if self.option.consumer_group().is_empty() {
+            return Err(ClientError::new(
+                ErrorKind::Config,
+                "required option is missing: consumer group is empty",
+                Self::OPERATION_START_SIMPLE_CONSUMER,
+            ));
+        }
+        self.client.start(telemetry_command_tx).await?;
+        if let Some(topics) = self.option.topics() {
+            for topic in topics {
+                self.client.topic_route(topic, true).await?;
+            }
+        }
+        self.shutdown_token = Some(CancellationToken::new());
+        Ok(())
+    }
+
+    /// Check if the simple consumer has been started
+    pub(crate) fn check_started(&self, operation: &'static str) -> Result<(), ClientError> {
+        self.client.check_started(operation)
+    }
+
+    pub async fn shutdown(mut self) -> Result<(), ClientError> {
+        if let Some(shutdown_token) = self.shutdown_token.take() {
+            shutdown_token.cancel();
+        }
         self.client.shutdown().await
+    }
+
+    /// Shutdown without consuming self. Used by [`crate::LiteSimpleConsumer`].
+    pub(crate) async fn shutdown_ref(&mut self) -> Result<(), ClientError> {
+        if let Some(shutdown_token) = self.shutdown_token.take() {
+            shutdown_token.cancel();
+        }
+        self.client.shutdown_ref().await
     }
 
     /// receive messages from the specified topic
@@ -156,7 +204,11 @@ impl SimpleConsumer {
         invisible_duration: Duration,
     ) -> Result<Vec<MessageView>, ClientError> {
         let route = self.client.topic_route(topic.as_ref(), true).await?;
-        let message_queue = select_message_queue(route);
+        let message_queue = if self.client.is_lite_consumer() {
+            select_first_readable_queue(&route)?
+        } else {
+            select_message_queue(route)
+        };
         let endpoints =
             build_endpoints_by_message_queue(&message_queue, Self::OPERATION_RECEIVE_MESSAGE)?;
         let messages = self
@@ -284,10 +336,11 @@ mod tests {
         client
             .expect_ack_message()
             .returning(|_: &MessageView| Ok(AckMessageResultEntry::default()));
+        client.expect_is_lite_consumer().returning(|| false);
         let simple_consumer = SimpleConsumer {
             option: SimpleConsumerOption::default(),
             client,
-            shutdown_tx: None,
+            shutdown_token: None,
         };
 
         let messages = simple_consumer

--- a/rust/src/util.rs
+++ b/rust/src/util.rs
@@ -55,6 +55,35 @@ pub(crate) fn select_message_queue_by_message_group(
     route.queue[index as usize].clone()
 }
 
+const MASTER_BROKER_ID: i32 = 0;
+
+/// Select the first readable master queue for lite consumers.
+///
+/// Reference Java: LiteSimpleConsumerImpl.updateSubscriptionLoadBalancer
+///   -> SubscriptionLoadBalancer::isReadableMasterQueue
+pub(crate) fn select_first_readable_queue(route: &Route) -> Result<MessageQueue, ClientError> {
+    route
+        .queue
+        .iter()
+        .find(|queue| {
+            let readable = queue.permission == crate::pb::Permission::Read as i32
+                || queue.permission == crate::pb::Permission::ReadWrite as i32;
+            let master = queue
+                .broker
+                .as_ref()
+                .is_some_and(|broker| broker.id == MASTER_BROKER_ID);
+            readable && master
+        })
+        .cloned()
+        .ok_or_else(|| {
+            ClientError::new(
+                ErrorKind::NoBrokerAvailable,
+                "no readable master queue found",
+                "simple_consumer.select_queue",
+            )
+        })
+}
+
 pub(crate) fn build_endpoints_by_message_queue(
     message_queue: &MessageQueue,
     operation: &'static str,

--- a/rust/tests/lite_integration_test.rs
+++ b/rust/tests/lite_integration_test.rs
@@ -22,10 +22,10 @@
 
 #[cfg(test)]
 mod lite_tests {
-    use rocketmq::conf::{ClientOption, PushConsumerOption};
+    use rocketmq::conf::{ClientOption, PushConsumerOption, SimpleConsumerOption};
     use rocketmq::model::message::{Message, MessageBuilder};
     use rocketmq::model::offset_option::{OffsetOption, OffsetPolicy};
-    use rocketmq::{LitePushConsumer, LitePushConsumerTrait};
+    use rocketmq::{LitePushConsumer, LiteSimpleConsumer};
 
     #[test]
     fn test_lite_message_builder() {
@@ -73,5 +73,22 @@ mod lite_tests {
         // We expect an error because we're not connecting to a real server,
         // but the important thing is that it compiles
         assert!(result.is_err() || result.is_ok());
+    }
+
+    #[test]
+    fn test_lite_simple_consumer_construction() {
+        // `LiteSimpleConsumer::new` does not connect to a server; it succeeds with a
+        // parseable access URL, so the public inherent getters can be exercised directly.
+        let mut client_option = ClientOption::default();
+        client_option.set_access_url("http://localhost:8080");
+
+        let mut option = SimpleConsumerOption::default();
+        option.set_consumer_group("test_group");
+
+        let consumer = LiteSimpleConsumer::new(client_option, option, "parent_topic".to_string())
+            .expect("LiteSimpleConsumer::new should succeed with a valid config");
+
+        assert_eq!(consumer.get_consumer_group(), "test_group");
+        assert!(consumer.get_lite_topic_set().is_empty());
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #1361

### Brief Description

Port Java's `LiteSimpleConsumer` to the Rust SDK. `LiteSimpleConsumer` provides pull-style consumption of lite topics with reduced overhead.

Changes:
- Add `LiteSimpleConsumer` with inherent methods (`src/lite_simple_consumer.rs`), exported from `src/lib.rs`. No trait, matching the existing `SimpleConsumer`/`Producer`/`PushConsumer` style.
- Add `ClientType::LiteSimpleConsumer = 6` (`src/model/common.rs`).
- Add lite-topic-aware queue selection for lite consumers (`src/simple_consumer.rs`, `src/util.rs`).
- Fix ack/change-invisible-duration to pass through the message's lite topic (`src/client.rs`, `src/model/message.rs`) so acks route to the correct LMQ consume queue.
- Add `examples/lite_simple_consumer.rs`.

### How Did You Test This Change?

- End-to-end against a RocketMQ proxy (gRPC v2): the producer writes lite messages, `LiteSimpleConsumer` receives them with the correct lite topic and body, and acks them without error.
- `cargo fmt` and `cargo clippy` are clean (aside from pre-existing warnings).
- `cargo test --lib`: 88 passed; 1 pre-existing, unrelated failure in `session::tests::session_new` (mock-server dependency version mismatch).
- `cargo test --test lite_integration_test`: 4 passed, including a new construction test exercising the public inherent getters.
