### PR TITLE
[ISSUE #1362] [C#] Fix typo in csharp/LICENSE: "(properties)" -> "(i)"

### DIFF
--- a/csharp/LICENSE
+++ b/csharp/LICENSE
@@ -15,7 +15,7 @@
       "Legal Entity" shall mean the union of the acting entity and all
       other entities that control, are controlled by, or are under common
       control with that entity. For the purposes of this definition,
-      "control" means (properties) the power, direct or indirect, to cause the
+      "control" means (i) the power, direct or indirect, to cause the
       direction or management of such entity, whether by contract or
       otherwise, or (ii) ownership of fifty percent (50%) or more of the
       outstanding shares, or (iii) beneficial ownership of such entity.


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #1362

### Brief Description

Line 18 of `csharp/LICENSE` contained `(properties)` instead of `(i)` in the Apache-2.0 "control" definition. This restores the standard Apache License 2.0 wording. The corruption was inherited from the apache/rocketmq LICENSE before it was fixed there in 2021 (#2600). Only `csharp/LICENSE` is affected; the root `LICENSE` and the `cpp/`, `nodejs/`, `python/` copies are already correct.

### How Did You Test This Change?

Documentation-only change to the LICENSE text. Verified the diff touches exactly one line and that the corrected wording matches the official Apache License 2.0 text and the already-correct `LICENSE` at the repository root.