### PR TITLE
[NodeJS] Bump version to 1.0.8

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocketmq-client-nodejs",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocketmq-client-nodejs",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.1",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rocketmq-client-nodejs",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "RocketMQ Node.js Client",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
### Summary

Bump rocketmq-client-nodejs version from 1.0.7 to 1.0.8 for the upcoming release.

### Changes

- Bump version in package.json and package-lock.json to 1.0.8

### How Did You Test This Change?

- Verified `npm run build` passes and `npm pack --dry-run` produces the expected tarball.
