### PR TITLE
fix(rust): use mock server address in session_new test

### DIFF
--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -750,7 +750,7 @@ mod tests {
     async fn session_new() {
         let server = RocketMQMockServer::start_default().await;
         let session = Session::new(
-            &Endpoints::from_url(&format!("localhost:{}", server.address().port())).unwrap(),
+            &Endpoints::from_url(&format!("{}", server.address())).unwrap(),
             "test_client".to_string(),
             &ClientOption::default(),
         )


### PR DESCRIPTION
### Brief Description

Fix the `session::tests::session_new` unit test, which was failing with `Connection refused (os error 111)`.

Root cause: `wiremock-grpc 0.0.3-alpha3` binds its mock gRPC server to the IPv6 loopback address `[::1]`, but the test connected to `localhost:{port}`, which resolves to IPv4 `127.0.0.1` on most Linux hosts. The client therefore dialed IPv4 while the server only listened on IPv6.

Change: construct the connection address from the mock server's actual bound address (`server.address()`) instead of hardcoding `localhost`, so the test is robust regardless of which loopback family the mock binds.

### How Did You Test This Change?

- `cargo test --lib`: 89 passed / 0 failed / 1 ignored (previously 88 passed / 1 failed).
- `cargo fmt --check`: clean.
