### PR TITLE
Fix(nodejs): defect fixes and feature enhancements for the Node.js client

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -11,6 +11,10 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.9.1",
         "@node-rs/crc32": "^1.7.2",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "^0.57.2",
+        "@opentelemetry/resources": "^1.30.1",
+        "@opentelemetry/sdk-metrics": "^1.30.1",
         "address": "^1.2.2",
         "egg-logger": "^3.4.0",
         "google-protobuf": "^3.21.2",
@@ -1269,6 +1273,213 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.57.2.tgz",
+      "integrity": "sha512-r70B8yKR41F0EC443b5CGB4rUaOMm99I5N75QQt6sHKxYDzSEc6gm48Diz1CI1biwa5tDPznpylTrywO/pT7qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.57.2",
+        "@opentelemetry/otlp-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-transformer": "0.57.2",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/sdk-metrics": "1.30.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.57.2.tgz",
+      "integrity": "sha512-ttb9+4iKw04IMubjm3t0EZsYRNWr3kg44uUuzfo9CaccYlOh8cDooe4QObDUkvx9d5qQUrbEckhrWKfJnKhemA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/otlp-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-transformer": "0.57.2",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/sdk-metrics": "1.30.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.57.2.tgz",
+      "integrity": "sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/otlp-transformer": "0.57.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.57.2.tgz",
+      "integrity": "sha512-USn173KTWy0saqqRB5yU9xUZ2xdgb1Rdu5IosJnm9aV4hMTuFFRTUsQxbgc24QxpCHeoKzzCSnS/JzdV0oM2iQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/otlp-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-transformer": "0.57.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.2.tgz",
+      "integrity": "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/sdk-logs": "0.57.2",
+        "@opentelemetry/sdk-metrics": "1.30.1",
+        "@opentelemetry/sdk-trace-base": "1.30.1",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.2.tgz",
+      "integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
+      "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -43,13 +43,17 @@
     "egg-bin": "^6.4.2",
     "eslint": "^8.48.0",
     "eslint-config-egg": "^12.2.1",
-    "grpc-tools": "^1.12.4",
     "grpc_tools_node_protoc_ts": "^5.3.3",
+    "grpc-tools": "^1.12.4",
     "typescript": "^5.2.2"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.9.1",
     "@node-rs/crc32": "^1.7.2",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "^0.57.2",
+    "@opentelemetry/resources": "^1.30.1",
+    "@opentelemetry/sdk-metrics": "^1.30.1",
     "address": "^1.2.2",
     "egg-logger": "^3.4.0",
     "google-protobuf": "^3.21.2",

--- a/nodejs/src/client/BaseClient.ts
+++ b/nodejs/src/client/BaseClient.ts
@@ -316,7 +316,11 @@ export abstract class BaseClient {
     this.isolated.clear();
 
     this.logger.info('Shutdown the rocketmq client successfully, clientId=%s', this.clientId);
-    this.logger.close && this.logger.close();
+    // Defer closing the logger to the next macrotask: subclass shutdown()
+    // implementations (Producer / PushConsumer) emit their final log line right
+    // after super.shutdown(), and egg-logger throws "log stream had been closed"
+    // if it is used again after close().
+    setImmediate(() => this.logger.close && this.logger.close());
   }
 
   async #doHeartbeat() {

--- a/nodejs/src/client/BaseClient.ts
+++ b/nodejs/src/client/BaseClient.ts
@@ -35,10 +35,17 @@ import {
   ThreadStackTrace,
   HeartbeatRequest,
   NotifyClientTerminationRequest,
+  NotifyUnsubscribeLiteCommand,
 } from '../../proto/apache/rocketmq/v2/service_pb';
 import { createResource, getRequestDateTime, sign } from '../util';
 import { TopicRouteData, Endpoints } from '../route';
 import { ClientException, NotFoundException, StatusChecker } from '../exception';
+import {
+  CompositedMessageInterceptor,
+  GeneralMessage,
+  MessageInterceptor,
+  MessageInterceptorContext,
+} from '../hook';
 import { Settings } from './Settings';
 import { UserAgent } from './UserAgent';
 import { ILogger, getDefaultLogger } from './Logger';
@@ -69,6 +76,11 @@ export interface BaseClientOptions {
   requestTimeout?: number;
   logger?: ILogger;
   topics?: string[];
+  /**
+   * Message interceptor(s) invoked around send/receive/consume/ack hook points,
+   * mirroring the Java client's MessageInterceptor chain.
+   */
+  messageInterceptor?: MessageInterceptor | MessageInterceptor[];
 }
 
 /**
@@ -94,6 +106,7 @@ export abstract class BaseClient {
   protected readonly logger: ILogger;
   protected readonly rpcClientManager: RpcClientManager;
   readonly #telemetrySessions = new Map<string, TelemetrySession>();
+  readonly #compositedMessageInterceptor = new CompositedMessageInterceptor();
   #startupResolve?: () => void;
   #startupReject?: (err: Error) => void;
   #timers: NodeJS.Timeout[] = [];
@@ -143,6 +156,14 @@ export abstract class BaseClient {
         if (topic && topic.trim().length > 0) {
           this.topics.add(topic);
         }
+      }
+    }
+    // Register message interceptors provided by the user (allowed before startup only).
+    if (options.messageInterceptor) {
+      const interceptors = Array.isArray(options.messageInterceptor)
+        ? options.messageInterceptor : [ options.messageInterceptor ];
+      for (const interceptor of interceptors) {
+        this.addMessageInterceptor(interceptor);
       }
     }
   }
@@ -564,12 +585,11 @@ export abstract class BaseClient {
   }
 
   onRecoverOrphanedTransactionCommand(_endpoints: Endpoints, command: RecoverOrphanedTransactionCommand) {
+    // The base client does not support transactions; subclasses (e.g. Producer) override
+    // this method to recover orphaned transactional messages. Mirroring the Java client
+    // (ClientImpl#onRecoverOrphanedTransactionCommand), no reply is sent back to remote.
     this.logger.warn('Ignore orphaned transaction recovery command from remote, which is not expected, clientId=%s, command=%j',
       this.clientId, command.toObject());
-    // const telemetryCommand = new TelemetryCommand();
-    // telemetryCommand.setStatus(new Status().setCode(Code.NOT_IMPLEMENTED));
-    // telemetryCommand.setRecoverOrphanedTransactionCommand(new RecoverOrphanedTransactionCommand());
-    // this.telemetry(endpoints, telemetryCommand);
   }
 
   onVerifyMessageCommand(endpoints: Endpoints, command: VerifyMessageCommand) {
@@ -624,6 +644,18 @@ export abstract class BaseClient {
     return lines.join('\n');
   }
 
+  /**
+   * Handle the notify-unsubscribe-lite command sent by remote when a lite topic
+   * subscription must be dropped (e.g. quota violation or administrative action).
+   *
+   * The base client ignores it, mirroring Java ClientImpl#onNotifyUnsubscribeLiteCommand;
+   * lite push consumers override it to drive their lite subscription manager.
+   */
+  onNotifyUnsubscribeLiteCommand(endpoints: Endpoints, command: NotifyUnsubscribeLiteCommand) {
+    this.logger.warn('Ignore unsubscribe lite topic command from remote, which is not expected, endpoints=%s, clientId=%s, command=%j',
+      endpoints.facade, this.clientId, command.toObject());
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onReconnectEndpointsCommand(endpoints: Endpoints, _command: ReconnectEndpointsCommand) {
     this.logger.info('Received reconnect endpoints command from remote, will refresh telemetry session, endpoints=%s, clientId=%s',
@@ -640,6 +672,42 @@ export abstract class BaseClient {
    */
   getEndpoints(): Endpoints {
     return this.endpoints;
+  }
+
+  /**
+   * Add a message interceptor to the client. Interceptors can only be registered
+   * before the client is running, mirroring Java ClientImpl#addMessageInterceptor.
+   */
+  addMessageInterceptor(messageInterceptor: MessageInterceptor) {
+    if (!this.isRunning()) {
+      this.#compositedMessageInterceptor.addInterceptor(messageInterceptor);
+    }
+  }
+
+  /**
+   * Invoke the interceptor chain before a hook point is executed.
+   */
+  doBefore(context: MessageInterceptorContext, generalMessages: GeneralMessage[]) {
+    try {
+      this.#compositedMessageInterceptor.doBefore(context, generalMessages);
+    } catch (t) {
+      // Should never reach here, the composite interceptor guards each interceptor.
+      this.logger.error('[Bug] Exception raised while handling messages, clientId=%s, error=%s',
+        this.clientId, t);
+    }
+  }
+
+  /**
+   * Invoke the interceptor chain after a hook point is executed.
+   */
+  doAfter(context: MessageInterceptorContext, generalMessages: GeneralMessage[]) {
+    try {
+      this.#compositedMessageInterceptor.doAfter(context, generalMessages);
+    } catch (t) {
+      // Should never reach here, the composite interceptor guards each interceptor.
+      this.logger.error('[Bug] Exception raised while handling messages, clientId=%s, error=%s',
+        this.clientId, t);
+    }
   }
 
   /**

--- a/nodejs/src/client/BaseClient.ts
+++ b/nodejs/src/client/BaseClient.ts
@@ -37,7 +37,7 @@ import {
 } from '../../proto/apache/rocketmq/v2/service_pb';
 import { createResource, getRequestDateTime, sign } from '../util';
 import { TopicRouteData, Endpoints } from '../route';
-import { ClientException, StatusChecker } from '../exception';
+import { ClientException, NotFoundException, StatusChecker } from '../exception';
 import { Settings } from './Settings';
 import { UserAgent } from './UserAgent';
 import { ILogger, getDefaultLogger } from './Logger';
@@ -169,6 +169,11 @@ export abstract class BaseClient {
         break;
       } catch (e) {
         lastError = e as Error;
+        // Not-found errors will never succeed on retry — fail fast, aligned
+        // with the Java client which surfaces NotFoundException immediately.
+        if (e instanceof NotFoundException) {
+          throw e;
+        }
         if (attempt < maxAttempts) {
           const backoffMs = 1000 * attempt; // Simple linear backoff: 1s, 2s, 3s
           this.logger.warn('Fetch topic route failed during startup, will retry, clientId=%s, attempt=%d/%d, error=%s, backoff=%dms',

--- a/nodejs/src/client/BaseClient.ts
+++ b/nodejs/src/client/BaseClient.ts
@@ -28,6 +28,7 @@ import {
   QueryRouteRequest,
   RecoverOrphanedTransactionCommand,
   VerifyMessageCommand,
+  VerifyMessageResult,
   PrintThreadStackTraceCommand,
   ReconnectEndpointsCommand,
   TelemetryCommand,
@@ -47,6 +48,11 @@ import { TelemetrySession } from './TelemetrySession';
 import { ClientId } from './ClientId';
 
 const debug = debuglog('rocketmq-client-nodejs:client:BaseClient');
+
+// Trigger transport self-healing (D-2) after this many consecutive heartbeat failures
+const HEARTBEAT_TRANSPORT_RECOVERY_THRESHOLD = 2;
+// Minimum interval between transport-recovery attempts per endpoints
+const TRANSPORT_RECOVERY_COOLDOWN = 30 * 1000;
 
 export interface BaseClientOptions {
   sslEnabled?: boolean;
@@ -92,6 +98,10 @@ export abstract class BaseClient {
   #startupReject?: (err: Error) => void;
   #timers: NodeJS.Timeout[] = [];
   #running = false;
+  // Consecutive heartbeat failure counts keyed by endpoints facade (D-2 transport self-healing)
+  readonly #heartbeatFailureCounts = new Map<string, number>();
+  // Last transport-recovery timestamps per endpoints facade, to throttle recovery attempts
+  readonly #lastTransportRecoveryTimes = new Map<string, number>();
 
   /**
    * Get the client type.
@@ -285,15 +295,64 @@ export abstract class BaseClient {
       for (const endpoints of endpointsList) {
         try {
           await this.rpcClientManager.heartbeat(endpoints, request, this.requestTimeout);
+          // Heartbeat succeeded: the remote is reachable again, so rejoin any
+          // isolated endpoints (mirrors Java ClientImpl#doHeartbeat).
+          if (this.isolated.delete(endpoints.facade)) {
+            this.logger.info('Isolated endpoints rejoined after successful heartbeat, endpoints=%s, clientId=%s',
+              endpoints.facade, this.clientId);
+          }
+          this.#heartbeatFailureCounts.delete(endpoints.facade);
         } catch (e) {
           // Log but don't throw - heartbeat is best-effort
           this.logger.warn('Heartbeat failed for endpoints=%s, clientId=%s, error=%s',
             endpoints.facade, this.clientId, e instanceof Error ? e.message : String(e));
+          this.#onHeartbeatFailure(endpoints);
         }
       }
     } catch (e) {
       this.logger.error('Unexpected error in heartbeat, clientId=%s, error=%s',
         this.clientId, e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  /**
+   * Handle a heartbeat failure: after consecutive failures, rebuild the transport
+   * layer for the affected endpoints (evict the stale RpcClient channel and refresh
+   * the telemetry session), throttled by a per-endpoints cooldown.
+   */
+  #onHeartbeatFailure(endpoints: Endpoints) {
+    const failureCount = (this.#heartbeatFailureCounts.get(endpoints.facade) ?? 0) + 1;
+    this.#heartbeatFailureCounts.set(endpoints.facade, failureCount);
+    if (failureCount < HEARTBEAT_TRANSPORT_RECOVERY_THRESHOLD) {
+      return;
+    }
+    const now = Date.now();
+    if (now - (this.#lastTransportRecoveryTimes.get(endpoints.facade) ?? 0) < TRANSPORT_RECOVERY_COOLDOWN) {
+      debug('Transport recovery throttled by cooldown, endpoints=%s, clientId=%s',
+        endpoints.facade, this.clientId);
+      return;
+    }
+    this.#lastTransportRecoveryTimes.set(endpoints.facade, now);
+    this.logger.warn('Consecutive heartbeat failures detected, rebuilding transport layer, endpoints=%s, failureCount=%d, clientId=%s',
+      endpoints.facade, failureCount, this.clientId);
+    // 1. Evict the possibly stale RpcClient so a fresh channel is established on next use.
+    try {
+      this.rpcClientManager.evict(endpoints);
+    } catch (e) {
+      this.logger.warn('Failed to evict rpc client, endpoints=%s, clientId=%s, error=%s',
+        endpoints.facade, this.clientId, e instanceof Error ? e.message : String(e));
+    }
+    // 2. Release and drop the telemetry session, then eagerly rebuild it to re-sync settings.
+    const session = this.#telemetrySessions.get(endpoints.facade);
+    if (session) {
+      session.release();
+      this.#telemetrySessions.delete(endpoints.facade);
+    }
+    try {
+      this.getTelemetrySession(endpoints).syncSettings();
+    } catch (e) {
+      this.logger.warn('Failed to rebuild telemetry session, endpoints=%s, clientId=%s, error=%s',
+        endpoints.facade, this.clientId, e instanceof Error ? e.message : String(e));
     }
   }
 
@@ -517,21 +576,52 @@ export abstract class BaseClient {
     const obj = command.toObject();
     this.logger.warn('Ignore verify message command from remote, which is not expected, clientId=%s, command=%j',
       this.clientId, obj);
+    // Respond with VerifyMessageResult carrying the same nonce, mirroring the Java
+    // client (BaseClient#onVerifyMessageCommand), instead of echoing the command.
     const telemetryCommand = new TelemetryCommand();
     telemetryCommand.setStatus(new Status().setCode(Code.NOT_IMPLEMENTED));
-    telemetryCommand.setVerifyMessageCommand(new VerifyMessageCommand().setNonce(obj.nonce));
+    telemetryCommand.setVerifyMessageResult(new VerifyMessageResult().setNonce(obj.nonce));
     this.telemetry(endpoints, telemetryCommand);
   }
 
   onPrintThreadStackTraceCommand(endpoints: Endpoints, command: PrintThreadStackTraceCommand) {
     const obj = command.toObject();
-    this.logger.warn('Ignore orphaned transaction recovery command from remote, which is not expected, clientId=%s, command=%j',
+    this.logger.info('Received print thread stack trace command from remote, clientId=%s, command=%j',
       this.clientId, obj);
-    const nonce = obj.nonce;
     const telemetryCommand = new TelemetryCommand();
-    telemetryCommand.setThreadStackTrace(new ThreadStackTrace().setThreadStackTrace('mock stack').setNonce(nonce));
+    telemetryCommand.setThreadStackTrace(new ThreadStackTrace()
+      .setThreadStackTrace(this.#buildProcessDiagnostics())
+      .setNonce(obj.nonce));
     telemetryCommand.setStatus(new Status().setCode(Code.OK));
     this.telemetry(endpoints, telemetryCommand);
+  }
+
+  /**
+   * Build Node.js process diagnostics in place of Java-style thread stack traces.
+   * Java sends per-thread stacks via ThreadMXBean; Node.js is single-threaded per
+   * process, so we expose the closest equivalent runtime snapshot.
+   */
+  #buildProcessDiagnostics(): string {
+    const mem = process.memoryUsage();
+    const formatBytes = (bytes: number) => `${(bytes / 1024 / 1024).toFixed(2)}MB`;
+    const lines = [
+      `Process: pid=${process.pid}, node=${process.version}, platform=${process.platform}, arch=${process.arch}`,
+      `Uptime: ${process.uptime().toFixed(3)}s`,
+      `Memory: rss=${formatBytes(mem.rss)}, heapUsed=${formatBytes(mem.heapUsed)}, ` +
+        `heapTotal=${formatBytes(mem.heapTotal)}, external=${formatBytes(mem.external)}, ` +
+        `arrayBuffers=${formatBytes(mem.arrayBuffers)}`,
+    ];
+    try {
+      const activeHandles = (process as unknown as { _getActiveHandles?: () => object[] })._getActiveHandles?.() ?? [];
+      lines.push(`Active handles: ${activeHandles.length}`);
+      for (const handle of activeHandles.slice(0, 20)) {
+        const name = handle?.constructor?.name ?? typeof handle;
+        lines.push(`  - ${name}`);
+      }
+    } catch {
+      // active handles are best-effort
+    }
+    return lines.join('\n');
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/nodejs/src/client/BaseClient.ts
+++ b/nodejs/src/client/BaseClient.ts
@@ -45,6 +45,7 @@ import {
   GeneralMessage,
   MessageInterceptor,
   MessageInterceptorContext,
+  MessageMeterInterceptor,
 } from '../hook';
 import { Settings } from './Settings';
 import { UserAgent } from './UserAgent';
@@ -53,6 +54,8 @@ import { SessionCredentials } from './SessionCredentials';
 import { RpcClientManager } from './RpcClientManager';
 import { TelemetrySession } from './TelemetrySession';
 import { ClientId } from './ClientId';
+import { ClientMeterManager } from '../metrics';
+import { Metric } from '../metrics/Metric';
 
 const debug = debuglog('rocketmq-client-nodejs:client:BaseClient');
 
@@ -107,6 +110,7 @@ export abstract class BaseClient {
   protected readonly rpcClientManager: RpcClientManager;
   readonly #telemetrySessions = new Map<string, TelemetrySession>();
   readonly #compositedMessageInterceptor = new CompositedMessageInterceptor();
+  protected readonly clientMeterManager: ClientMeterManager;
   #startupResolve?: () => void;
   #startupReject?: (err: Error) => void;
   #timers: NodeJS.Timeout[] = [];
@@ -151,6 +155,12 @@ export abstract class BaseClient {
     // Default request timeout is 3000ms
     this.requestTimeout = options.requestTimeout ?? 3000;
     this.rpcClientManager = new RpcClientManager(this, this.logger);
+    // Wire the metrics pipeline: a dedicated meter manager plus an interceptor
+    // that records the four RocketMQ histograms around the SEND/RECEIVE/CONSUME
+    // hook points. Mirrors Java's ClientImpl#initClientMeterManager.
+    this.clientMeterManager = new ClientMeterManager(this.clientId, () => this.getRequestMetadata(), this.logger);
+    this.addMessageInterceptor(
+      new MessageMeterInterceptor(this.clientMeterManager, this.clientId, () => this.getConsumerGroup()));
     if (options.topics) {
       for (const topic of options.topics) {
         if (topic && topic.trim().length > 0) {
@@ -295,6 +305,10 @@ export abstract class BaseClient {
 
     // 4. Close RPC connections
     this.rpcClientManager.close();
+
+    // 4.5 Close the metrics export pipeline (flushes pending exports and releases
+    // the OTLP/gRPC channel). Mirrors ClientImpl#shutdown's meter manager close.
+    await this.clientMeterManager.shutdown();
 
     // 5. Clear caches
     this.topicRouteCache.clear();
@@ -529,6 +543,15 @@ export abstract class BaseClient {
     return metadata;
   }
 
+  /**
+   * Consumer group of this client, used as a metric attribute for consumer
+   * histograms/gauges. Producers have no consumer group, so the base
+   * implementation returns undefined; Consumer overrides this.
+   */
+  getConsumerGroup(): string | undefined {
+    return undefined;
+  }
+
   protected abstract getSettings(): Settings;
 
   /**
@@ -577,8 +600,8 @@ export abstract class BaseClient {
   onSettingsCommand(_endpoints: Endpoints, settings: SettingsPB) {
     this.logger.info('Received settings command, clientId=%s, settings=%j',
       this.clientId, settings.toObject());
-    // final Metric metric = new Metric(settings.getMetric());
-    // clientMeterManager.reset(metric);
+    const metric = new Metric(settings.getMetric());
+    this.clientMeterManager.reset(metric);
     this.getSettings().sync(settings);
     this.logger.info('Sync settings=%j, clientId=%s', this.getSettings(), this.clientId);
     this.#startupResolve && this.#startupResolve();

--- a/nodejs/src/client/RpcClient.ts
+++ b/nodejs/src/client/RpcClient.ts
@@ -53,6 +53,16 @@ import {
 } from '../../proto/apache/rocketmq/v2/service_pb';
 import { Endpoints } from '../route';
 
+// Channel options mirroring the Java client's Netty channel configuration:
+// keepalive probing plus unbounded message sizes (Java defaults to Integer.MAX_VALUE).
+const GRPC_CHANNEL_OPTIONS = {
+  'grpc.keepalive_time_ms': 300000, // 5 minutes, same as Java DEFAULT_KEEP_ALIVE_TIME_MILLIS
+  'grpc.keepalive_timeout_ms': 30000, // 30 seconds, same as Java DEFAULT_KEEP_ALIVE_TIMEOUT_MILLIS
+  'grpc.keepalive_permit_without_calls': 1,
+  'grpc.max_send_message_length': 2 ** 31 - 1,
+  'grpc.max_receive_message_length': 2 ** 31 - 1,
+};
+
 export class RpcClient {
   #client: MessagingServiceClient;
   #activityTime = Date.now();
@@ -60,7 +70,7 @@ export class RpcClient {
   constructor(endpoints: Endpoints, sslEnabled: boolean) {
     const address = endpoints.getGrpcTarget();
     const grpcCredentials = sslEnabled ? ChannelCredentials.createSsl() : ChannelCredentials.createInsecure();
-    this.#client = new MessagingServiceClient(address, grpcCredentials);
+    this.#client = new MessagingServiceClient(address, grpcCredentials, GRPC_CHANNEL_OPTIONS);
   }
 
   #getAndActivityRpcClient() {

--- a/nodejs/src/client/RpcClientManager.ts
+++ b/nodejs/src/client/RpcClientManager.ts
@@ -37,7 +37,10 @@ const RPC_CLIENT_MAX_IDLE_DURATION = 30 * 60000; // 30 minutes
 const RPC_CLIENT_IDLE_CHECK_PERIOD = 60000;
 
 export class RpcClientManager {
-  #rpcClients = new Map<Endpoints, RpcClient>();
+  // Keyed by endpoints.facade (string) instead of the Endpoints object itself:
+  // Endpoints instances are recreated on every route fetch, so object keys would
+  // leak duplicate RpcClients for logically identical endpoints.
+  #rpcClients = new Map<string, RpcClient>();
   #baseClient: BaseClient;
   #logger: ILogger;
   #clearIdleRpcClientsTimer: NodeJS.Timeout;
@@ -55,24 +58,40 @@ export class RpcClientManager {
   }
 
   #clearIdleRpcClients() {
-    for (const [ endpoints, rpcClient ] of this.#rpcClients.entries()) {
+    for (const [ facade, rpcClient ] of this.#rpcClients.entries()) {
       const idleDuration = rpcClient.idleDuration();
       if (idleDuration > RPC_CLIENT_MAX_IDLE_DURATION) {
         rpcClient.close();
-        this.#rpcClients.delete(endpoints);
+        this.#rpcClients.delete(facade);
         this.#logger.info('[RpcClientManager] Rpc client has been idle for a long time, endpoints=%s, idleDuration=%s, clientId=%s',
-          endpoints, idleDuration, RPC_CLIENT_MAX_IDLE_DURATION, this.#baseClient.clientId);
+          facade, idleDuration, RPC_CLIENT_MAX_IDLE_DURATION, this.#baseClient.clientId);
       }
     }
   }
 
   #getRpcClient(endpoints: Endpoints) {
-    let rpcClient = this.#rpcClients.get(endpoints);
+    const facade = endpoints.facade;
+    let rpcClient = this.#rpcClients.get(facade);
     if (!rpcClient) {
       rpcClient = new RpcClient(endpoints, this.#baseClient.sslEnabled);
-      this.#rpcClients.set(endpoints, rpcClient);
+      this.#rpcClients.set(facade, rpcClient);
     }
     return rpcClient;
+  }
+
+  /**
+   * Close and remove the RPC client bound to the given endpoints (e.g. after
+   * consecutive heartbeat failures), so a fresh channel is established on next use.
+   */
+  evict(endpoints: Endpoints) {
+    const facade = endpoints.facade;
+    const rpcClient = this.#rpcClients.get(facade);
+    if (rpcClient) {
+      rpcClient.close();
+      this.#rpcClients.delete(facade);
+      this.#logger.info('[RpcClientManager] Rpc client evicted, endpoints=%s, clientId=%s',
+        facade, this.#baseClient.clientId);
+    }
   }
 
   close() {
@@ -82,12 +101,12 @@ export class RpcClientManager {
     }
 
     // Close all RPC clients and clear the map
-    for (const [ endpoints, rpcClient ] of this.#rpcClients.entries()) {
+    for (const [ facade, rpcClient ] of this.#rpcClients.entries()) {
       try {
         rpcClient.close();
       } catch (e) {
         this.#logger.warn('Failed to close RPC client for endpoints=%s, clientId=%s, error=%s',
-          endpoints.facade, this.#baseClient.clientId, e instanceof Error ? e.message : String(e));
+          facade, this.#baseClient.clientId, e instanceof Error ? e.message : String(e));
       }
     }
     this.#rpcClients.clear();

--- a/nodejs/src/client/TelemetrySession.ts
+++ b/nodejs/src/client/TelemetrySession.ts
@@ -27,6 +27,8 @@ export class TelemetrySession {
   #logger: ILogger;
   #stream: ClientDuplexStream<TelemetryCommand, TelemetryCommand>;
   #isRefreshing = false;
+  #released = false;
+  #reconnectTimer?: NodeJS.Timeout;
 
   constructor(baseClient: BaseClient, endpoints: Endpoints, logger: ILogger) {
     this.#endpoints = endpoints;
@@ -38,8 +40,20 @@ export class TelemetrySession {
   }
 
   release() {
+    if (this.#released) {
+      return;
+    }
+    this.#released = true;
+    if (this.#reconnectTimer) {
+      clearTimeout(this.#reconnectTimer);
+      this.#reconnectTimer = undefined;
+    }
     this.#logger.info('Begin to release telemetry session, endpoints=%s, clientId=%s',
       this.#endpoints, this.#baseClient.clientId);
+    this.#closeStream();
+  }
+
+  #closeStream() {
     try {
       this.#stream.end();
       this.#stream.removeAllListeners();
@@ -144,21 +158,35 @@ export class TelemetrySession {
     }
   }
 
+  /**
+   * Schedule a telemetry stream renewal. The timer is tracked so that it can
+   * be cancelled on release(), and a pending timer doubles as a guard to
+   * prevent error/end events from scheduling duplicate reconnects.
+   */
+  #scheduleRenewStream() {
+    if (this.#released || this.#reconnectTimer) {
+      return;
+    }
+    this.#reconnectTimer = setTimeout(() => {
+      this.#reconnectTimer = undefined;
+      if (this.#released) {
+        return;
+      }
+      this.#renewStream(false);
+    }, 1000);
+  }
+
   #onError(err: Error) {
     this.#logger.error('Exception raised from stream response observer, endpoints=%s, clientId=%s, error=%s',
       this.#endpoints, this.#baseClient.clientId, err);
-    this.release();
-    setTimeout(() => {
-      this.#renewStream(false);
-    }, 1000);
+    this.#closeStream();
+    this.#scheduleRenewStream();
   }
 
   #onEnd() {
     this.#logger.info('Receive completion for stream response observer, endpoints=%s, clientId=%s',
       this.#endpoints, this.#baseClient.clientId);
-    this.release();
-    setTimeout(() => {
-      this.#renewStream(false);
-    }, 1000);
+    this.#closeStream();
+    this.#scheduleRenewStream();
   }
 }

--- a/nodejs/src/client/TelemetrySession.ts
+++ b/nodejs/src/client/TelemetrySession.ts
@@ -148,6 +148,12 @@ export class TelemetrySession {
         this.#baseClient.onReconnectEndpointsCommand(endpoints, command.getReconnectEndpointsCommand()!);
         break;
       }
+      case TelemetryCommand.CommandCase.NOTIFY_UNSUBSCRIBE_LITE_COMMAND: {
+        this.#logger.info('Receive notify unsubscribe lite command from remote, endpoints=%s, clientId=%s',
+          endpoints, clientId);
+        this.#baseClient.onNotifyUnsubscribeLiteCommand(endpoints, command.getNotifyUnsubscribeLiteCommand()!);
+        break;
+      }
       default: {
         const commandObj = command.toObject();
         this.#logger.warn('Receive unrecognized command from remote, endpoints=%s, commandCase=%j, command=%j, clientId=%s',

--- a/nodejs/src/consumer/ConsumeService.ts
+++ b/nodejs/src/consumer/ConsumeService.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 import { MessageView } from '../message';
+import { MessageInterceptor } from '../hook';
 import { ConsumeResult } from './ConsumeResult';
 import { ConsumeTask } from './ConsumeTask';
 import { MessageListener } from './MessageListener';
@@ -23,12 +24,17 @@ import type { ProcessQueue } from './ProcessQueue';
 export abstract class ConsumeService {
   protected readonly clientId: string;
   readonly #messageListener: MessageListener;
+  readonly #messageInterceptor?: MessageInterceptor;
+  readonly #consumerGroup?: string;
   #aborted = false;
   #pendingTimers: Set<NodeJS.Timeout> = new Set();
 
-  constructor(clientId: string, messageListener: MessageListener) {
+  constructor(clientId: string, messageListener: MessageListener,
+    messageInterceptor?: MessageInterceptor, consumerGroup?: string) {
     this.clientId = clientId;
     this.#messageListener = messageListener;
+    this.#messageInterceptor = messageInterceptor;
+    this.#consumerGroup = consumerGroup;
   }
 
   abstract consume(pq: ProcessQueue, messageViews: MessageView[]): void;
@@ -37,7 +43,8 @@ export abstract class ConsumeService {
     if (this.#aborted) {
       return ConsumeResult.FAILURE;
     }
-    const task = new ConsumeTask(this.clientId, this.#messageListener, messageView);
+    const task = new ConsumeTask(this.clientId, this.#messageListener, messageView,
+      this.#messageInterceptor, this.#consumerGroup);
     if (delay <= 0) {
       return this.#executeTask(task);
     }

--- a/nodejs/src/consumer/ConsumeTask.ts
+++ b/nodejs/src/consumer/ConsumeTask.ts
@@ -16,24 +16,64 @@
  */
 
 import { MessageView } from '../message';
+import {
+  Attribute,
+  AttributeKey,
+  MessageHookPoints,
+  MessageHookPointsStatus,
+  MessageInterceptor,
+  MessageInterceptorContextImpl,
+} from '../hook';
 import { ConsumeResult } from './ConsumeResult';
 import { MessageListener } from './MessageListener';
+
+// Context keys exposed to interceptors, mirroring the Java ConsumeTask keys.
+export const REMOTE_ADDR_CONTEXT_KEY = AttributeKey.create<string>('remote_address');
+export const MESSAGE_VIEW_CONTEXT_KEY = AttributeKey.create<MessageView>('message_view');
+export const CONSUMER_GROUP_CONTEXT_KEY = AttributeKey.create<string>('consumer_group');
+export const CONSUME_ERROR_CONTEXT_KEY = AttributeKey.create<unknown>('consume_error');
 
 export class ConsumeTask {
   readonly #messageListener: MessageListener;
   readonly #messageView: MessageView;
+  readonly #consumerGroup?: string;
+  readonly #messageInterceptor?: MessageInterceptor;
 
-  constructor(_clientId: string, messageListener: MessageListener, messageView: MessageView) {
+  constructor(_clientId: string, messageListener: MessageListener, messageView: MessageView,
+    messageInterceptor?: MessageInterceptor, consumerGroup?: string) {
     this.#messageListener = messageListener;
     this.#messageView = messageView;
+    this.#messageInterceptor = messageInterceptor;
+    this.#consumerGroup = consumerGroup;
   }
 
   async call(): Promise<ConsumeResult> {
+    const generalMessages = [ this.#messageView ];
+    let context = new MessageInterceptorContextImpl(MessageHookPoints.CONSUME);
+    context.putAttribute(MESSAGE_VIEW_CONTEXT_KEY, Attribute.create(this.#messageView));
+    if (this.#consumerGroup) {
+      context.putAttribute(CONSUMER_GROUP_CONTEXT_KEY, Attribute.create(this.#consumerGroup));
+    }
+    let throwable: unknown;
+    let consumeResult: ConsumeResult;
+    if (this.#messageInterceptor) {
+      this.#messageInterceptor.doBefore(context, generalMessages);
+    }
     try {
-      return await this.#messageListener.consume(this.#messageView);
+      consumeResult = await this.#messageListener.consume(this.#messageView);
     } catch (e) {
       // Message listener raised an exception while consuming messages
-      return ConsumeResult.FAILURE;
+      throwable = e;
+      consumeResult = ConsumeResult.FAILURE;
     }
+    const status = consumeResult === ConsumeResult.SUCCESS ? MessageHookPointsStatus.OK : MessageHookPointsStatus.ERROR;
+    context = MessageInterceptorContextImpl.withStatus(context, status);
+    if (throwable) {
+      context.putAttribute(CONSUME_ERROR_CONTEXT_KEY, Attribute.create(throwable));
+    }
+    if (this.#messageInterceptor) {
+      this.#messageInterceptor.doAfter(context, generalMessages);
+    }
+    return consumeResult;
   }
 }

--- a/nodejs/src/consumer/Consumer.ts
+++ b/nodejs/src/consumer/Consumer.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Message, Status } from '../../proto/apache/rocketmq/v2/definition_pb';
+import { Code, Message, Status } from '../../proto/apache/rocketmq/v2/definition_pb';
 import {
   AckMessageRequest,
   ChangeInvisibleDurationRequest,
@@ -27,6 +27,11 @@ import { MessageQueue } from '../route';
 import { StatusChecker } from '../exception';
 import { BaseClient, BaseClientOptions } from '../client';
 import { createDuration, createResource } from '../util';
+import {
+  MessageHookPoints,
+  MessageHookPointsStatus,
+  MessageInterceptorContextImpl,
+} from '../hook';
 import { FilterExpression } from './FilterExpression';
 
 export interface ConsumerOptions extends BaseClientOptions {
@@ -91,10 +96,18 @@ export abstract class Consumer extends BaseClient {
       }
 
       const messages = messageList.map(message => new MessageView(message, mq, transportDeliveryTimestamp));
+      // RECEIVE hook point, mirroring Java ProcessQueueImpl.
+      const context = new MessageInterceptorContextImpl(MessageHookPoints.RECEIVE, MessageHookPointsStatus.OK);
+      this.doBefore(context, messages);
+      this.doAfter(MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.OK), messages);
       return messages;
     } catch (err) {
       this.logger.error('Failed to receive messages, topic=%s, endpoints=%s, clientId=%s, error=%s',
         request.getMessageQueue()?.getTopic()?.getName(), endpoints, (this as any).clientId, err);
+      // RECEIVE hook point with error status.
+      const context = new MessageInterceptorContextImpl(MessageHookPoints.RECEIVE);
+      this.doBefore(context, []);
+      this.doAfter(MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.ERROR), []);
       throw err;
     }
   }
@@ -107,11 +120,23 @@ export abstract class Consumer extends BaseClient {
     request.addEntries()
       .setMessageId(messageView.messageId)
       .setReceiptHandle(messageView.receiptHandle);
-    const res = await this.rpcClientManager.ackMessage(endpoints, request, this.requestTimeout);
-    // FIXME: handle fail ack
-    const response = res.toObject();
-    StatusChecker.check(response.status);
-    return response.entriesList;
+    // ACK hook point, mirroring Java ConsumerImpl#ackMessage.
+    const context = new MessageInterceptorContextImpl(MessageHookPoints.ACK);
+    const generalMessages = [ messageView ];
+    this.doBefore(context, generalMessages);
+    let hookStatus = MessageHookPointsStatus.OK;
+    try {
+      const res = await this.rpcClientManager.ackMessage(endpoints, request, this.requestTimeout);
+      // FIXME: handle fail ack
+      const response = res.toObject();
+      hookStatus = response.status?.code === Code.OK ? MessageHookPointsStatus.OK : MessageHookPointsStatus.ERROR;
+      StatusChecker.check(response.status);
+      this.doAfter(MessageInterceptorContextImpl.withStatus(context, hookStatus), generalMessages);
+      return response.entriesList;
+    } catch (err) {
+      this.doAfter(MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.ERROR), generalMessages);
+      throw err;
+    }
   }
 
   protected async invisibleDuration(messageView: MessageView, invisibleDuration: number) {
@@ -122,10 +147,22 @@ export abstract class Consumer extends BaseClient {
       .setInvisibleDuration(createDuration(invisibleDuration))
       .setMessageId(messageView.messageId);
 
-    const res = await this.rpcClientManager.changeInvisibleDuration(messageView.endpoints, request, this.requestTimeout);
-    const response = res.toObject();
-    StatusChecker.check(response.status);
-    return response.receiptHandle;
+    // CHANGE_INVISIBLE_DURATION hook point, mirroring Java ConsumerImpl#changeInvisibleDuration.
+    const context = new MessageInterceptorContextImpl(MessageHookPoints.CHANGE_INVISIBLE_DURATION);
+    const generalMessages = [ messageView ];
+    this.doBefore(context, generalMessages);
+    let hookStatus = MessageHookPointsStatus.OK;
+    try {
+      const res = await this.rpcClientManager.changeInvisibleDuration(messageView.endpoints, request, this.requestTimeout);
+      const response = res.toObject();
+      hookStatus = response.status?.code === Code.OK ? MessageHookPointsStatus.OK : MessageHookPointsStatus.ERROR;
+      StatusChecker.check(response.status);
+      this.doAfter(MessageInterceptorContextImpl.withStatus(context, hookStatus), generalMessages);
+      return response.receiptHandle;
+    } catch (err) {
+      this.doAfter(MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.ERROR), generalMessages);
+      throw err;
+    }
   }
 
   /**

--- a/nodejs/src/consumer/Consumer.ts
+++ b/nodejs/src/consumer/Consumer.ts
@@ -28,6 +28,7 @@ import { StatusChecker } from '../exception';
 import { BaseClient, BaseClientOptions } from '../client';
 import { createDuration, createResource } from '../util';
 import {
+  GeneralMessage,
   MessageHookPoints,
   MessageHookPointsStatus,
   MessageInterceptorContextImpl,
@@ -178,9 +179,27 @@ export abstract class Consumer extends BaseClient {
     return res;
   }
 
-  async forwardMessageToDeadLetterQueueViaRpc(endpoints: any, request: any, timeout: number) {
-    const res = await this.rpcClientManager.forwardMessageToDeadLetterQueue(endpoints, request, timeout);
-    return res;
+  /**
+   * Forward the message to the dead letter queue, mirroring Java
+   * PushConsumerImpl#forwardMessageToDeadLetterQueue. The FORWARD_TO_DLQ hook
+   * point is triggered around every RPC attempt.
+   */
+  async forwardMessageToDeadLetterQueueViaRpc(endpoints: any, request: any, timeout: number,
+    messageView: MessageView) {
+    // FORWARD_TO_DLQ hook point, mirroring Java PushConsumerImpl#forwardMessageToDeadLetterQueue.
+    const context = new MessageInterceptorContextImpl(MessageHookPoints.FORWARD_TO_DLQ);
+    const generalMessages: GeneralMessage[] = [ messageView ];
+    this.doBefore(context, generalMessages);
+    try {
+      const response = await this.rpcClientManager.forwardMessageToDeadLetterQueue(endpoints, request, timeout);
+      const hookStatus = response.getStatus()?.getCode() === Code.OK ?
+        MessageHookPointsStatus.OK : MessageHookPointsStatus.ERROR;
+      this.doAfter(MessageInterceptorContextImpl.withStatus(context, hookStatus), generalMessages);
+      return response;
+    } catch (err) {
+      this.doAfter(MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.ERROR), generalMessages);
+      throw err;
+    }
   }
 
   /**

--- a/nodejs/src/consumer/FifoConsumeService.ts
+++ b/nodejs/src/consumer/FifoConsumeService.ts
@@ -16,6 +16,7 @@
  */
 
 import { MessageView } from '../message';
+import { MessageInterceptor } from '../hook';
 import { ConsumeService } from './ConsumeService';
 import { MessageListener } from './MessageListener';
 import type { ProcessQueue } from './ProcessQueue';
@@ -25,8 +26,9 @@ export class FifoConsumeService extends ConsumeService {
   readonly #enableFifoConsumeAccelerator: boolean;
   readonly #logger: ILogger;
 
-  constructor(clientId: string, messageListener: MessageListener, enableFifoConsumeAccelerator?: boolean) {
-    super(clientId, messageListener);
+  constructor(clientId: string, messageListener: MessageListener, enableFifoConsumeAccelerator?: boolean,
+    messageInterceptor?: MessageInterceptor, consumerGroup?: string) {
+    super(clientId, messageListener, messageInterceptor, consumerGroup);
     this.#enableFifoConsumeAccelerator = enableFifoConsumeAccelerator ?? false;
     this.#logger = getDefaultLogger();
   }

--- a/nodejs/src/consumer/LiteFifoConsumeService.ts
+++ b/nodejs/src/consumer/LiteFifoConsumeService.ts
@@ -16,6 +16,7 @@
  */
 
 import { MessageView } from '../message';
+import { MessageInterceptor } from '../hook';
 import { ConsumeResultSuspend } from './ConsumeResult';
 import { FifoConsumeService } from './FifoConsumeService';
 import { MessageListener } from './MessageListener';
@@ -37,8 +38,9 @@ import { ILogger, getDefaultLogger } from '../client/Logger';
 export class LiteFifoConsumeService extends FifoConsumeService {
   readonly #logger: ILogger;
 
-  constructor(clientId: string, messageListener: MessageListener, enableFifoConsumeAccelerator?: boolean) {
-    super(clientId, messageListener, enableFifoConsumeAccelerator);
+  constructor(clientId: string, messageListener: MessageListener, enableFifoConsumeAccelerator?: boolean,
+    messageInterceptor?: MessageInterceptor, consumerGroup?: string) {
+    super(clientId, messageListener, enableFifoConsumeAccelerator, messageInterceptor, consumerGroup);
     this.#logger = getDefaultLogger();
   }
 

--- a/nodejs/src/consumer/LitePushConsumerImpl.ts
+++ b/nodejs/src/consumer/LitePushConsumerImpl.ts
@@ -278,4 +278,15 @@ export class LitePushConsumerImpl extends PushConsumer implements LitePushConsum
   getRequestTimeout(): number {
     return this.requestTimeout;
   }
+
+  /**
+   * Get all route endpoints across cached topic routes (protected access for
+   * internal use), so lite subscriptions can be synced to every broker-side proxy.
+   *
+   * @internal
+   */
+  getTotalRouteEndpoints(): Endpoints[] {
+    // BaseClient exposes this as protected; re-expose publicly for LiteSubscriptionManager.
+    return super.getTotalRouteEndpoints();
+  }
 }

--- a/nodejs/src/consumer/LitePushConsumerImpl.ts
+++ b/nodejs/src/consumer/LitePushConsumerImpl.ts
@@ -95,10 +95,11 @@ export class LitePushConsumerImpl extends PushConsumer implements LitePushConsum
         'Create lite FIFO consume service, consumerGroup=%s, clientId=%s, enableFifoConsumeAccelerator=%s',
         this.consumerGroup, this.clientId, this.#enableFifoConsumeAccelerator,
       );
-      return new LiteFifoConsumeService(this.clientId, this.#messageListener, this.#enableFifoConsumeAccelerator);
+      return new LiteFifoConsumeService(this.clientId, this.#messageListener, this.#enableFifoConsumeAccelerator,
+        this, this.consumerGroup);
     }
     this.logger.info('Create lite standard consume service, consumerGroup=%s, clientId=%s', this.consumerGroup, this.clientId);
-    return new LiteStandardConsumeService(this.clientId, this.#messageListener);
+    return new LiteStandardConsumeService(this.clientId, this.#messageListener, this, this.consumerGroup);
   }
 
   /**
@@ -218,9 +219,12 @@ export class LitePushConsumerImpl extends PushConsumer implements LitePushConsum
    * <p>This method is called when the server sends a notification to unsubscribe
    * from a lite topic, typically due to quota violations or administrative actions.</p>
    *
+   * @param endpoints - The remote endpoints which sent the command
    * @param command - The unsubscribe command from the server
    */
-  onNotifyUnsubscribeLiteCommand(command: NotifyUnsubscribeLiteCommand) {
+  onNotifyUnsubscribeLiteCommand(endpoints: Endpoints, command: NotifyUnsubscribeLiteCommand) {
+    this.logger.info('Received notify unsubscribe lite command, liteTopic=%s, endpoints=%s, clientId=%s',
+      command.getLiteTopic(), endpoints.facade, this.clientId);
     this.liteSubscriptionManager.onNotifyUnsubscribeLiteCommand(command);
   }
 

--- a/nodejs/src/consumer/LiteStandardConsumeService.ts
+++ b/nodejs/src/consumer/LiteStandardConsumeService.ts
@@ -16,6 +16,7 @@
  */
 
 import { MessageView } from '../message';
+import { MessageInterceptor } from '../hook';
 import { ConsumeService } from './ConsumeService';
 import { MessageListener } from './MessageListener';
 import type { ProcessQueue } from './ProcessQueue';
@@ -31,8 +32,9 @@ import { ILogger, getDefaultLogger } from '../client/Logger';
 export class LiteStandardConsumeService extends ConsumeService {
   readonly #logger: ILogger;
 
-  constructor(clientId: string, messageListener: MessageListener) {
-    super(clientId, messageListener);
+  constructor(clientId: string, messageListener: MessageListener,
+    messageInterceptor?: MessageInterceptor, consumerGroup?: string) {
+    super(clientId, messageListener, messageInterceptor, consumerGroup);
     this.#logger = getDefaultLogger();
   }
 

--- a/nodejs/src/consumer/LiteSubscriptionManager.ts
+++ b/nodejs/src/consumer/LiteSubscriptionManager.ts
@@ -19,7 +19,6 @@ import { Code, LiteSubscriptionAction } from '../../proto/apache/rocketmq/v2/def
 import {
   NotifyUnsubscribeLiteCommand,
   SyncLiteSubscriptionRequest,
-  SyncLiteSubscriptionResponse,
 } from '../../proto/apache/rocketmq/v2/service_pb';
 import { ClientException } from '../exception';
 import { Resource } from '../route';
@@ -259,20 +258,26 @@ export class LiteSubscriptionManager {
     }
 
     try {
-      // Call RPC client using public methods from LitePushConsumerImpl
-      const response: SyncLiteSubscriptionResponse = await this.consumerImpl.getRpcClientManager().syncLiteSubscription(
-        this.consumerImpl.getEndpoints(),
-        request,
-        this.consumerImpl.getRequestTimeout(),
-      );
+      // Sync the lite subscription to every route endpoint (not just the client's
+      // configured endpoints), mirroring the Java client which pushes subscriptions
+      // to all proxies serving the topic route.
+      const rpcClientManager = this.consumerImpl.getRpcClientManager();
+      const timeout = this.consumerImpl.getRequestTimeout();
+      const endpointsList = this.consumerImpl.getTotalRouteEndpoints();
+      const targets = endpointsList.length > 0 ? endpointsList : [ this.consumerImpl.getEndpoints() ];
+      const responses = await Promise.all(targets.map(endpoints =>
+        rpcClientManager.syncLiteSubscription(endpoints, request, timeout),
+      ));
 
-      // Handle response status
-      const status = response.getStatus();
-      if (status && status.getCode() !== Code.OK) {
-        throw new ClientException(
-          status.getCode(),
-          `Failed to sync lite subscription: ${status.getMessage()}`,
-        );
+      // Handle response statuses
+      for (let i = 0; i < responses.length; i++) {
+        const status = responses[i].getStatus();
+        if (status && status.getCode() !== Code.OK) {
+          throw new ClientException(
+            status.getCode(),
+            `Failed to sync lite subscription to endpoints=${targets[i].facade}: ${status.getMessage()}`,
+          );
+        }
       }
 
       if (logger.info) {

--- a/nodejs/src/consumer/ProcessQueue.ts
+++ b/nodejs/src/consumer/ProcessQueue.ts
@@ -23,6 +23,7 @@ import { TooManyRequestsException } from '../exception';
 import { ConsumeResult, ConsumeResultSuspend } from './ConsumeResult';
 import { FilterExpression } from './FilterExpression';
 import type { PushConsumer } from './PushConsumer';
+import { Semaphore } from '../util/Semaphore';
 
 const ACK_MESSAGE_FAILURE_BACKOFF_DELAY = 1000;
 const CHANGE_INVISIBLE_DURATION_FAILURE_BACKOFF_DELAY = 1000;
@@ -31,6 +32,7 @@ const FORWARD_MESSAGE_TO_DLQ_FAILURE_BACKOFF_DELAY = 1000;
 const RECEIVING_FLOW_CONTROL_BACKOFF_DELAY = 20;
 const RECEIVING_FAILURE_BACKOFF_DELAY = 1000;
 const RECEIVING_BACKOFF_DELAY_WHEN_CACHE_IS_FULL = 1000;
+const RECEIVING_BACKOFF_DELAY_WHEN_PERMITS_EXHAUSTED = 20;
 
 export class ProcessQueue {
   readonly #consumer: PushConsumer;
@@ -42,15 +44,26 @@ export class ProcessQueue {
   #activityTime = Date.now();
   #cacheFullTime = 0;
   #aborted = false;
+  // Bounds in-flight messages per queue; mirrors Java ProcessQueueImpl permits.
+  readonly #semaphore: Semaphore;
 
   constructor(consumer: PushConsumer, mq: MessageQueue, filterExpression: FilterExpression) {
     this.#consumer = consumer;
     this.#mq = mq;
     this.#filterExpression = filterExpression;
+    this.#semaphore = new Semaphore(consumer.getPushConsumerSettings().getConsumeConcurrentlyMax());
   }
 
   getMessageQueue(): MessageQueue {
     return this.#mq;
+  }
+
+  /**
+   * Topic of the underlying message queue, used as a metric attribute when
+   * aggregating the consumer gauges.
+   */
+  get topic(): string {
+    return this.#mq.topic.name;
   }
 
   drop(): void {
@@ -77,9 +90,23 @@ export class ProcessQueue {
       return;
     }
     for (const messageView of messageList) {
+      // Each in-flight message consumes one permit. The reception batch size is
+      // already bounded by availablePermits, so tryAcquire should always succeed;
+      // if it does not (defensive), stop caching to avoid over-committing.
+      if (!this.#semaphore.tryAcquire()) {
+        break;
+      }
       this.#cachedMessages.push(messageView);
       this.#cachedMessagesBytes += messageView.body.length;
     }
+  }
+
+  /**
+   * Number of consumption permits still available on this process queue. When it
+   * reaches zero the receive loop applies backpressure (see #receiveMessageImmediately).
+   */
+  availablePermits(): number {
+    return this.#semaphore.availablePermits;
   }
 
   #getReceptionBatchSize(): number {
@@ -87,7 +114,10 @@ export class ProcessQueue {
       this.#consumer.cacheMessageCountThresholdPerQueue() - this.cachedMessagesCount(),
       1,
     );
-    return Math.min(bufferSize, this.#consumer.getPushConsumerSettings().getReceiveBatchSize());
+    // Bound the batch by the remaining consumption permits, mirroring Java's
+    // Math.max(consumeConcurrentlyMax - inflight, 1).
+    const permitSize = Math.max(this.#semaphore.availablePermits, 1);
+    return Math.min(bufferSize, permitSize, this.#consumer.getPushConsumerSettings().getReceiveBatchSize());
   }
 
   fetchMessageImmediately(): void {
@@ -132,6 +162,13 @@ export class ProcessQueue {
 
   #receiveMessageImmediately(attemptId?: string): void {
     if (this.#aborted) return;
+    // Apply backpressure: when every consumption permit is in use (i.e. the
+    // maximum number of messages is in-flight), stop fetching until messages are
+    // settled and permits are released. Mirrors Java's tryAcquirePermit gate.
+    if (this.#semaphore.availablePermits <= 0) {
+      this.#receiveMessageLater(RECEIVING_BACKOFF_DELAY_WHEN_PERMITS_EXHAUSTED, attemptId);
+      return;
+    }
     attemptId = attemptId ?? this.#generateAttemptId();
     try {
       const batchSize = this.#getReceptionBatchSize();
@@ -368,6 +405,9 @@ export class ProcessQueue {
     if (index !== -1) {
       this.#cachedMessages.splice(index, 1);
       this.#cachedMessagesBytes -= messageView.body.length;
+      // Return the consumption permit held by this now-settled message, so the
+      // receive loop can fetch again (backpressure release).
+      this.#semaphore.release();
     }
   }
 

--- a/nodejs/src/consumer/ProcessQueue.ts
+++ b/nodejs/src/consumer/ProcessQueue.ts
@@ -326,6 +326,7 @@ export class ProcessQueue {
         endpoints,
         this.#consumer.wrapForwardMessageToDeadLetterQueueRequest(messageView),
         this.#consumer.requestTimeoutValue,
+        messageView,
       );
       const status = response.getStatus();
       if (!status) {

--- a/nodejs/src/consumer/PushConsumer.ts
+++ b/nodejs/src/consumer/PushConsumer.ts
@@ -38,6 +38,7 @@ import { ConsumeService } from './ConsumeService';
 import { StandardConsumeService } from './StandardConsumeService';
 import { FifoConsumeService } from './FifoConsumeService';
 import { ProcessQueue } from './ProcessQueue';
+import { PushConsumerGaugeObserver } from './PushConsumerGaugeObserver';
 import { Assignment } from './Assignment';
 import { Assignments } from './Assignments';
 import { MessageListener } from './MessageListener';
@@ -53,6 +54,12 @@ export interface PushConsumerOptions extends ConsumerOptions {
   maxCacheMessageSizeInBytes?: number;
   longPollingTimeout?: number;
   enableFifoConsumeAccelerator?: boolean;
+  /**
+   * Max number of messages in-flight per process queue. Mirrors Java's
+   * consumeConcurrentlyMax (default 32) and backs the ProcessQueue semaphore
+   * that applies consumption backpressure.
+   */
+  consumeConcurrentlyMax?: number;
 }
 
 class ConsumeMetrics {
@@ -98,9 +105,16 @@ export class PushConsumer extends Consumer {
     this.#inflightRequestCountInterceptor = new InflightRequestCountInterceptor();
     this.addMessageInterceptor(this.#inflightRequestCountInterceptor);
 
+    // Register the consumer gauge observer so cached message count/bytes are
+    // exported to the broker. The provider reads the process-queue table lazily
+    // at scrape time, so registering here (before any queue exists) is safe.
+    this.clientMeterManager.setGaugeObserver(
+      new PushConsumerGaugeObserver(() => this.processQueues(), this.clientId, this.consumerGroup));
+
     this.#pushSubscriptionSettings = new PushSubscriptionSettings(
       options.namespace, this.clientId, this.getClientType(), this.endpoints,
       this.consumerGroup, this.requestTimeout, this.#subscriptionExpressions,
+      options.longPollingTimeout, options.consumeConcurrentlyMax,
     );
   }
 
@@ -425,6 +439,14 @@ export class PushConsumer extends Consumer {
 
   getQueueSize(): number {
     return this.#processQueueTable.size;
+  }
+
+  /**
+   * All live process queues, used by the consumer gauge observer to aggregate
+   * cached message count/bytes. Reads the private table lazily at scrape time.
+   */
+  processQueues(): ProcessQueue[] {
+    return [ ...this.#processQueueTable.values() ].map(entry => entry.pq);
   }
 
   cacheMessageBytesThresholdPerQueue(): number {

--- a/nodejs/src/consumer/PushConsumer.ts
+++ b/nodejs/src/consumer/PushConsumer.ts
@@ -168,7 +168,20 @@ export class PushConsumer extends Consumer {
     // Every received message is cached before consumption and evicted from
     // the cache once its consumption chain settles, so empty caches on all
     // process queues mean consumption has fully quiesced.
+    // Bound the wait with the same timeout as the inflight-receive drain
+    // (request timeout + long-polling timeout) so shutdown cannot hang forever
+    // on a stuck consumption chain.
+    const maxWaitingTime = this.requestTimeoutValue
+      + this.getPushConsumerSettings().getLongPollingTimeout();
+    const endTime = Date.now() + maxWaitingTime;
     while ([ ...this.#processQueueTable.values() ].some(({ pq }) => pq.cachedMessagesCount() > 0)) {
+      if (Date.now() > endTime) {
+        const remaining = [ ...this.#processQueueTable.values() ]
+          .reduce((count, { pq }) => count + pq.cachedMessagesCount(), 0);
+        this.logger.warn('Timeout waiting for the cached messages to be consumed, clientId=%s, '
+          + 'remainingCachedMessages=%d', this.clientId, remaining);
+        return;
+      }
       await this.sleep(100);
     }
   }

--- a/nodejs/src/consumer/PushConsumer.ts
+++ b/nodejs/src/consumer/PushConsumer.ts
@@ -41,6 +41,7 @@ import { ProcessQueue } from './ProcessQueue';
 import { Assignment } from './Assignment';
 import { Assignments } from './Assignments';
 import { MessageListener } from './MessageListener';
+import { InflightRequestCountInterceptor } from '../hook';
 
 const ASSIGNMENT_SCAN_SCHEDULE_DELAY = 1000;
 const ASSIGNMENT_SCAN_SCHEDULE_PERIOD = 5000;
@@ -71,6 +72,7 @@ export class PushConsumer extends Consumer {
   readonly #enableFifoConsumeAccelerator: boolean;
   readonly #processQueueTable = new Map<string /* mq key */, { mq: MessageQueue; pq: ProcessQueue }>();
   readonly #metrics = new ConsumeMetrics();
+  readonly #inflightRequestCountInterceptor: InflightRequestCountInterceptor;
   #consumeService!: ConsumeService;
   #scanAssignmentTimer?: NodeJS.Timeout;
   #inflightReceiveRequestCount = 0;
@@ -91,6 +93,10 @@ export class PushConsumer extends Consumer {
     this.#maxCacheMessageCount = options.maxCacheMessageCount ?? 1024;
     this.#maxCacheMessageSizeInBytes = options.maxCacheMessageSizeInBytes ?? 64 * 1024 * 1024;
     this.#enableFifoConsumeAccelerator = options.enableFifoConsumeAccelerator ?? false;
+
+    // Built-in interceptor tracking in-flight receive requests, mirroring Java PushConsumerImpl.
+    this.#inflightRequestCountInterceptor = new InflightRequestCountInterceptor();
+    this.addMessageInterceptor(this.#inflightRequestCountInterceptor);
 
     this.#pushSubscriptionSettings = new PushSubscriptionSettings(
       options.namespace, this.clientId, this.getClientType(), this.endpoints,
@@ -230,11 +236,22 @@ export class PushConsumer extends Consumer {
     // No-op for push consumer; assignments are queried separately
   }
 
+  /**
+   * Get the count of in-flight receive requests tracked by the built-in
+   * {@link InflightRequestCountInterceptor}, mirroring Java PushConsumerImpl.
+   */
+  protected getInflightReceiveRequestCountFromInterceptor(): number {
+    return this.#inflightRequestCountInterceptor.getInflightReceiveRequestCount();
+  }
+
   protected createConsumeService(): ConsumeService {
+    // `this` implements MessageInterceptor (doBefore/doAfter delegating to the
+    // composited interceptor chain), mirroring Java PushConsumerImpl.
     if (this.#pushSubscriptionSettings.isFifo()) {
-      return new FifoConsumeService(this.clientId, this.#messageListener, this.#enableFifoConsumeAccelerator);
+      return new FifoConsumeService(this.clientId, this.#messageListener, this.#enableFifoConsumeAccelerator,
+        this, this.consumerGroup);
     }
-    return new StandardConsumeService(this.clientId, this.#messageListener);
+    return new StandardConsumeService(this.clientId, this.#messageListener, this, this.consumerGroup);
   }
 
   async subscribe(topic: string, filterExpression: FilterExpression) {

--- a/nodejs/src/consumer/PushConsumerGaugeObserver.ts
+++ b/nodejs/src/consumer/PushConsumerGaugeObserver.ts
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Attributes } from '@opentelemetry/api';
+import { ProcessQueue } from './ProcessQueue';
+import { GaugeEnum } from '../metrics/GaugeEnum';
+import { GaugeObserver } from '../metrics/GaugeObserver';
+import { MetricLabels } from '../metrics/MetricLabels';
+
+/**
+ * Aggregates the per-process-queue cache statistics of a push consumer into the
+ * two RocketMQ consumer gauges, mirroring the GaugeObserver implementation held
+ * by org.apache.rocketmq.client.java.impl.consumer.PushConsumerImpl.
+ */
+export class PushConsumerGaugeObserver implements GaugeObserver {
+  constructor(
+    private readonly processQueuesProvider: () => ProcessQueue[],
+    private readonly clientId: string,
+    private readonly consumerGroup: string,
+  ) {
+  }
+
+  getGauges(): GaugeEnum[] {
+    return [ GaugeEnum.CONSUMER_CACHED_MESSAGES, GaugeEnum.CONSUMER_CACHED_BYTES ];
+  }
+
+  getValues(gauge: GaugeEnum): Map<Attributes, number> {
+    const result = new Map<Attributes, number>();
+    const byTopic = new Map<string, number>();
+    for (const pq of this.processQueuesProvider()) {
+      const increment = gauge === GaugeEnum.CONSUMER_CACHED_MESSAGES
+        ? pq.cachedMessagesCount()
+        : pq.cachedMessageBytes();
+      byTopic.set(pq.topic, (byTopic.get(pq.topic) ?? 0) + increment);
+    }
+    for (const [ topic, value ] of byTopic) {
+      const attributes: Attributes = {
+        [MetricLabels.TOPIC]: topic,
+        [MetricLabels.CLIENT_ID]: this.clientId,
+        [MetricLabels.CONSUMER_GROUP]: this.consumerGroup,
+      };
+      result.set(attributes, value);
+    }
+    return result;
+  }
+}

--- a/nodejs/src/consumer/PushSubscriptionSettings.ts
+++ b/nodejs/src/consumer/PushSubscriptionSettings.ts
@@ -34,6 +34,7 @@ export class PushSubscriptionSettings extends Settings {
   #fifo = false;
   #receiveBatchSize = 32;
   #longPollingTimeout = 30000; // ms
+  #consumeConcurrentlyMax = 32; // mirrors Java PushConsumerSettings default
 
   constructor(
     namespace: string,
@@ -44,12 +45,16 @@ export class PushSubscriptionSettings extends Settings {
     requestTimeout: number,
     subscriptionExpressions: Map<string, FilterExpression>,
     longPollingTimeout?: number,
+    consumeConcurrentlyMax?: number,
   ) {
     super(namespace, clientId, clientType, accessPoint, requestTimeout);
     this.#group = consumerGroup;
     this.#subscriptionExpressions = subscriptionExpressions;
     if (longPollingTimeout !== undefined) {
       this.#longPollingTimeout = longPollingTimeout;
+    }
+    if (consumeConcurrentlyMax !== undefined) {
+      this.#consumeConcurrentlyMax = consumeConcurrentlyMax;
     }
   }
 
@@ -59,6 +64,16 @@ export class PushSubscriptionSettings extends Settings {
 
   getReceiveBatchSize(): number {
     return this.#receiveBatchSize;
+  }
+
+  /**
+   * Maximum number of messages that may be in-flight (fetched but not yet
+   * settled) per process queue. The Node client previously had no equivalent of
+   * the Java {@code ProcessQueueImpl} permit, so consumption could grow
+   * unbounded; this bounds it and feeds the {@link ProcessQueue} semaphore.
+   */
+  getConsumeConcurrentlyMax(): number {
+    return this.#consumeConcurrentlyMax;
   }
 
   getLongPollingTimeout(): number {
@@ -99,6 +114,12 @@ export class PushSubscriptionSettings extends Settings {
       if (longPollingTimeout) {
         this.#longPollingTimeout = longPollingTimeout.getSeconds() * 1000 +
           Math.floor(longPollingTimeout.getNanos() / 1000000);
+      }
+      // consumeConcurrentlyMax is absent from the generated proto in this fork;
+      // guard the accessor so we keep the default (32) until the field lands.
+      const consumeConcurrentlyMax = (subscription as { getConsumeConcurrentlyMax?: () => number | null }).getConsumeConcurrentlyMax?.();
+      if (typeof consumeConcurrentlyMax === 'number' && consumeConcurrentlyMax > 0) {
+        this.#consumeConcurrentlyMax = consumeConcurrentlyMax;
       }
     }
     const backoffPolicy = settings.getBackoffPolicy();

--- a/nodejs/src/consumer/PushSubscriptionSettings.ts
+++ b/nodejs/src/consumer/PushSubscriptionSettings.ts
@@ -21,9 +21,10 @@ import {
   Subscription,
   RetryPolicy as RetryPolicyPB,
 } from '../../proto/apache/rocketmq/v2/definition_pb';
+import { Duration } from 'google-protobuf/google/protobuf/duration_pb';
 import { Endpoints } from '../route';
 import { Settings, UserAgent } from '../client';
-import { ExponentialBackoffRetryPolicy, RetryPolicy } from '../retry';
+import { CustomizedBackoffRetryPolicy, ExponentialBackoffRetryPolicy, RetryPolicy } from '../retry';
 import { createDuration, createResource } from '../util';
 import { FilterExpression } from './FilterExpression';
 
@@ -102,20 +103,29 @@ export class PushSubscriptionSettings extends Settings {
     }
     const backoffPolicy = settings.getBackoffPolicy();
     if (backoffPolicy) {
+      // Convert protobuf Duration (seconds + nanos) to milliseconds without
+      // losing sub-second precision.
+      const toMillis = (duration?: Duration) =>
+        duration ? duration.getSeconds() * 1000 + duration.getNanos() / 1e6 : 0;
       switch (backoffPolicy.getStrategyCase()) {
         case RetryPolicyPB.StrategyCase.EXPONENTIAL_BACKOFF: {
-          const exponential = backoffPolicy.getExponentialBackoff()!.toObject();
+          const exponential = backoffPolicy.getExponentialBackoff()!;
           this.retryPolicy = new ExponentialBackoffRetryPolicy(
             backoffPolicy.getMaxAttempts(),
-            exponential.initial?.seconds,
-            exponential.max?.seconds,
-            exponential.multiplier,
+            toMillis(exponential.getInitial()),
+            toMillis(exponential.getMax()),
+            exponential.getMultiplier(),
           );
           break;
         }
-        case RetryPolicyPB.StrategyCase.CUSTOMIZED_BACKOFF:
-          // CustomizedBackoffRetryPolicy not yet implemented in Node.js
+        case RetryPolicyPB.StrategyCase.CUSTOMIZED_BACKOFF: {
+          const customizedBackoff = backoffPolicy.getCustomizedBackoff()!;
+          const durations = customizedBackoff.getNextList().map((duration: Duration) => toMillis(duration));
+          if (durations.length > 0) {
+            this.retryPolicy = new CustomizedBackoffRetryPolicy(durations, backoffPolicy.getMaxAttempts());
+          }
           break;
+        }
         default:
           break;
       }

--- a/nodejs/src/consumer/SimpleConsumer.ts
+++ b/nodejs/src/consumer/SimpleConsumer.ts
@@ -134,6 +134,9 @@ export class SimpleConsumer extends Consumer {
   }
 
   async receive(maxMessageNum = 10, invisibleDuration = 15000) {
+    if (!this.isRunning()) {
+      throw new Error('Simple consumer is not running, please call startup() first or check shutdown state');
+    }
     if (maxMessageNum <= 0) {
       throw new Error(`maxMessageNum must be greater than 0, but got ${maxMessageNum}`);
     }
@@ -177,10 +180,16 @@ export class SimpleConsumer extends Consumer {
   }
 
   async ack(message: MessageView) {
+    if (!this.isRunning()) {
+      throw new Error('Simple consumer is not running, cannot ack message');
+    }
     await this.ackMessage(message);
   }
 
   async changeInvisibleDuration(message: MessageView, invisibleDuration: number) {
+    if (!this.isRunning()) {
+      throw new Error('Simple consumer is not running, cannot change invisible duration');
+    }
     const response = await this.invisibleDuration(message, invisibleDuration);
     // Refresh receipt handle manually
     (message as any).receiptHandle = response;

--- a/nodejs/src/consumer/StandardConsumeService.ts
+++ b/nodejs/src/consumer/StandardConsumeService.ts
@@ -16,6 +16,7 @@
  */
 
 import { MessageView } from '../message';
+import { MessageInterceptor } from '../hook';
 import { ConsumeService } from './ConsumeService';
 import { MessageListener } from './MessageListener';
 import type { ProcessQueue } from './ProcessQueue';
@@ -25,8 +26,9 @@ export class StandardConsumeService extends ConsumeService {
   private readonly logger = getDefaultLogger();
 
   // eslint-disable-next-line @typescript-eslint/no-useless-constructor
-  constructor(clientId: string, messageListener: MessageListener) {
-    super(clientId, messageListener);
+  constructor(clientId: string, messageListener: MessageListener,
+    messageInterceptor?: MessageInterceptor, consumerGroup?: string) {
+    super(clientId, messageListener, messageInterceptor, consumerGroup);
   }
 
   consume(pq: ProcessQueue, messageViews: MessageView[]): void {

--- a/nodejs/src/exception/PayloadEmptyException.ts
+++ b/nodejs/src/exception/PayloadEmptyException.ts
@@ -15,6 +15,11 @@
  * limitations under the License.
  */
 
-export * from './CustomizedBackoffRetryPolicy';
-export * from './ExponentialBackoffRetryPolicy';
-export * from './RetryPolicy';
+import { ClientException } from './ClientException';
+
+export class PayloadEmptyException extends ClientException {
+  constructor(code: number, message: string, requestId?: string) {
+    super(code, message, requestId);
+    this.name = 'PayloadEmptyException';
+  }
+}

--- a/nodejs/src/exception/StatusChecker.ts
+++ b/nodejs/src/exception/StatusChecker.ts
@@ -19,8 +19,10 @@ import { Status, Code } from '../../proto/apache/rocketmq/v2/definition_pb';
 import { BadRequestException } from './BadRequestException';
 import { ForbiddenException } from './ForbiddenException';
 import { InternalErrorException } from './InternalErrorException';
+import { LiteSubscriptionQuotaExceededException } from './LiteSubscriptionQuotaExceededException';
 import { LiteTopicQuotaExceededException } from './LiteTopicQuotaExceededException';
 import { NotFoundException } from './NotFoundException';
+import { PayloadEmptyException } from './PayloadEmptyException';
 import { PayloadTooLargeException } from './PayloadTooLargeException';
 import { PaymentRequiredException } from './PaymentRequiredException';
 import { ProxyTimeoutException } from './ProxyTimeoutException';
@@ -44,6 +46,7 @@ export class StatusChecker {
       case Code.ILLEGAL_MESSAGE_KEY:
       case Code.ILLEGAL_MESSAGE_GROUP:
       case Code.ILLEGAL_MESSAGE_PROPERTY_KEY:
+      case Code.ILLEGAL_LITE_TOPIC:
       case Code.INVALID_TRANSACTION_ID:
       case Code.ILLEGAL_MESSAGE_ID:
       case Code.ILLEGAL_FILTER_EXPRESSION:
@@ -71,6 +74,8 @@ export class StatusChecker {
       case Code.PAYLOAD_TOO_LARGE:
       case Code.MESSAGE_BODY_TOO_LARGE:
         throw new PayloadTooLargeException(status.code, status.message, requestId);
+      case Code.MESSAGE_BODY_EMPTY:
+        throw new PayloadEmptyException(status.code, status.message, requestId);
       case Code.TOO_MANY_REQUESTS:
         throw new TooManyRequestsException(status.code, status.message, requestId);
       case Code.REQUEST_HEADER_FIELDS_TOO_LARGE:
@@ -90,6 +95,8 @@ export class StatusChecker {
         throw new UnsupportedException(status.code, status.message, requestId);
       case Code.LITE_TOPIC_QUOTA_EXCEEDED:
         throw new LiteTopicQuotaExceededException(status.code, status.message || '', requestId);
+      case Code.LITE_SUBSCRIPTION_QUOTA_EXCEEDED:
+        throw new LiteSubscriptionQuotaExceededException(status.code, requestId ?? null, status.message || '');
       default:
         throw new UnsupportedException(status.code, status.message, requestId);
     }

--- a/nodejs/src/exception/index.ts
+++ b/nodejs/src/exception/index.ts
@@ -22,6 +22,7 @@ export * from './InternalErrorException';
 export * from './LiteSubscriptionQuotaExceededException';
 export * from './LiteTopicQuotaExceededException';
 export * from './NotFoundException';
+export * from './PayloadEmptyException';
 export * from './PayloadTooLargeException';
 export * from './PaymentRequiredException';
 export * from './ProxyTimeoutException';

--- a/nodejs/src/hook/Attribute.ts
+++ b/nodejs/src/hook/Attribute.ts
@@ -15,11 +15,22 @@
  * limitations under the License.
  */
 
-export * from './consumer';
-export * from './exception';
-export * from './hook';
-export * from './message';
-export * from './producer';
-export * from './retry';
-export * from './route';
-export * from './client';
+/**
+ * Immutable value holder shared through a {@link MessageInterceptorContext},
+ * mirroring org.apache.rocketmq.client.java.hook.Attribute.
+ */
+export class Attribute<T> {
+  readonly #value: T;
+
+  private constructor(value: T) {
+    this.#value = value;
+  }
+
+  static create<T>(value: T): Attribute<T> {
+    return new Attribute(value);
+  }
+
+  get(): T {
+    return this.#value;
+  }
+}

--- a/nodejs/src/hook/AttributeKey.ts
+++ b/nodejs/src/hook/AttributeKey.ts
@@ -15,11 +15,28 @@
  * limitations under the License.
  */
 
-export * from './consumer';
-export * from './exception';
-export * from './hook';
-export * from './message';
-export * from './producer';
-export * from './retry';
-export * from './route';
-export * from './client';
+/**
+ * Typed key of a context attribute, mirroring
+ * org.apache.rocketmq.client.java.hook.AttributeKey.
+ *
+ * The type parameter is only used for compile-time typing of the associated value.
+ */
+export class AttributeKey<T> {
+  readonly name: string;
+  /**
+   * Never assigned at runtime; it only carries the value type for compile-time typing.
+   */
+  readonly typeHint?: T;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  static create<T>(name: string): AttributeKey<T> {
+    return new AttributeKey<T>(name);
+  }
+
+  toString() {
+    return `AttributeKey(${this.name})`;
+  }
+}

--- a/nodejs/src/hook/CompositedMessageInterceptor.ts
+++ b/nodejs/src/hook/CompositedMessageInterceptor.ts
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Attribute } from './Attribute';
+import { AttributeKey } from './AttributeKey';
+import { MessageHookPointsStatus } from './MessageHookPointsStatus';
+import { MessageInterceptorContext } from './MessageInterceptorContext';
+import { MessageInterceptorContextImpl } from './MessageInterceptorContextImpl';
+import { GeneralMessage, MessageInterceptor } from './MessageInterceptor';
+
+// Key under which per-interceptor attributes are stashed between doBefore and doAfter.
+const INTERCEPTOR_ATTRIBUTES_KEY = AttributeKey
+  .create<Map<number, Map<AttributeKey<any>, Attribute<any>>>>('composited_interceptor_attributes');
+
+/**
+ * Composite interceptor which delegates to a chain of interceptors: doBefore runs
+ * in registration order while doAfter runs in reverse order, mirroring
+ * org.apache.rocketmq.client.java.hook.CompositedMessageInterceptor.
+ */
+export class CompositedMessageInterceptor implements MessageInterceptor {
+  readonly #interceptors: MessageInterceptor[] = [];
+
+  constructor(interceptors: MessageInterceptor[] = []) {
+    this.#interceptors.push(...interceptors);
+  }
+
+  addInterceptor(interceptor: MessageInterceptor) {
+    this.#interceptors.push(interceptor);
+  }
+
+  get size() {
+    return this.#interceptors.length;
+  }
+
+  doBefore(context0: MessageInterceptorContext, messages: GeneralMessage[]) {
+    const attributeMap = new Map<number, Map<AttributeKey<any>, Attribute<any>>>();
+    for (let index = 0; index < this.#interceptors.length; index++) {
+      const context = new MessageInterceptorContextImpl(context0.getMessageHookPoints(), context0.getStatus());
+      // Share the attributes accumulated by the caller and previous interceptors.
+      for (const [ key, value ] of context0.getAttributes()) {
+        context.putAttribute(key, value);
+      }
+      try {
+        this.#interceptors[index].doBefore(context, messages);
+      } catch (t) {
+        // Interceptors must never break the message pipeline.
+        // eslint-disable-next-line no-console
+        console.error(
+          '[CompositedMessageInterceptor] Exception raised while handling messages before hook point=%s, error=%s',
+          context0.getMessageHookPoints(), t);
+      }
+      attributeMap.set(index, context.getAttributes());
+    }
+    context0.putAttribute(INTERCEPTOR_ATTRIBUTES_KEY, Attribute.create(attributeMap));
+    // Propagate attributes collected by the first interceptor to the caller context.
+    const firstAttributes = attributeMap.get(0);
+    if (firstAttributes) {
+      for (const [ key, value ] of firstAttributes) {
+        context0.putAttribute(key, value);
+      }
+    }
+  }
+
+  doAfter(context0: MessageInterceptorContext, messages: GeneralMessage[]) {
+    const attributeMap = context0.getAttribute(INTERCEPTOR_ATTRIBUTES_KEY)?.get()
+      ?? new Map<number, Map<AttributeKey<any>, Attribute<any>>>();
+    for (let index = this.#interceptors.length - 1; index >= 0; index--) {
+      const attributes = attributeMap.get(index);
+      const context = new MessageInterceptorContextImpl(
+        context0.getMessageHookPoints(), context0.getStatus() ?? MessageHookPointsStatus.OK, attributes);
+      for (const [ key, value ] of context0.getAttributes()) {
+        context.putAttribute(key, value);
+      }
+      try {
+        this.#interceptors[index].doAfter(context, messages);
+      } catch (t) {
+        // eslint-disable-next-line no-console
+        console.error(
+          '[CompositedMessageInterceptor] Exception raised while handling messages after hook point=%s, error=%s',
+          context0.getMessageHookPoints(), t);
+      }
+    }
+  }
+}

--- a/nodejs/src/hook/InflightRequestCountInterceptor.ts
+++ b/nodejs/src/hook/InflightRequestCountInterceptor.ts
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MessageHookPoints } from './MessageHookPoints';
+import { MessageInterceptorContext } from './MessageInterceptorContext';
+import { GeneralMessage, MessageInterceptor } from './MessageInterceptor';
+
+/**
+ * Interceptor which counts the in-flight receive requests, mirroring
+ * org.apache.rocketmq.client.java.hook.InflightRequestCountInterceptor.
+ */
+export class InflightRequestCountInterceptor implements MessageInterceptor {
+  #inflightReceiveRequestCount = 0;
+
+  doBefore(context: MessageInterceptorContext, _messages: GeneralMessage[]) {
+    if (context.getMessageHookPoints() === MessageHookPoints.RECEIVE) {
+      this.#inflightReceiveRequestCount++;
+    }
+  }
+
+  doAfter(context: MessageInterceptorContext, _messages: GeneralMessage[]) {
+    if (context.getMessageHookPoints() === MessageHookPoints.RECEIVE) {
+      this.#inflightReceiveRequestCount--;
+    }
+  }
+
+  getInflightReceiveRequestCount(): number {
+    return this.#inflightReceiveRequestCount;
+  }
+}

--- a/nodejs/src/hook/MessageHookPoints.ts
+++ b/nodejs/src/hook/MessageHookPoints.ts
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Hook points at which {@link MessageInterceptor}s are invoked, mirroring
+ * org.apache.rocketmq.client.java.hook.MessageHookPoints.
+ */
+export enum MessageHookPoints {
+  /**
+   * The hook point of message publishing.
+   */
+  SEND = 'SEND',
+  /**
+   * The hook point of message reception.
+   */
+  RECEIVE = 'RECEIVE',
+  /**
+   * The hook point of message consumption.
+   */
+  CONSUME = 'CONSUME',
+  /**
+   * The hook point of message ack acknowledgement.
+   */
+  ACK = 'ACK',
+  /**
+   * The hook point of message changing invisible duration.
+   */
+  CHANGE_INVISIBLE_DURATION = 'CHANGE_INVISIBLE_DURATION',
+  /**
+   * The hook point of message transaction commit.
+   */
+  COMMIT_TRANSACTION = 'COMMIT_TRANSACTION',
+  /**
+   * The hook point of message transaction rollback.
+   */
+  ROLLBACK_TRANSACTION = 'ROLLBACK_TRANSACTION',
+  /**
+   * The hook point of forwarding message to DLQ.
+   */
+  FORWARD_TO_DLQ = 'FORWARD_TO_DLQ',
+}

--- a/nodejs/src/hook/MessageHookPointsStatus.ts
+++ b/nodejs/src/hook/MessageHookPointsStatus.ts
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-export * from './consumer';
-export * from './exception';
-export * from './hook';
-export * from './message';
-export * from './producer';
-export * from './retry';
-export * from './route';
-export * from './client';
+/**
+ * Status of a hook point invocation, mirroring
+ * org.apache.rocketmq.client.java.hook.MessageHookPointsStatus.
+ */
+export enum MessageHookPointsStatus {
+  OK = 'OK',
+  ERROR = 'ERROR',
+}

--- a/nodejs/src/hook/MessageInterceptor.ts
+++ b/nodejs/src/hook/MessageInterceptor.ts
@@ -15,11 +15,21 @@
  * limitations under the License.
  */
 
-export * from './consumer';
-export * from './exception';
-export * from './hook';
-export * from './message';
-export * from './producer';
-export * from './retry';
-export * from './route';
-export * from './client';
+import { MessageView } from '../message/MessageView';
+import { MessageInterceptorContext } from './MessageInterceptorContext';
+
+/**
+ * Message passed to interceptors: either an outgoing message or a received one,
+ * mirroring org.apache.rocketmq.client.java.message.GeneralMessage.
+ */
+export type GeneralMessage = MessageView | { topic: string };
+
+/**
+ * Interface for intercepting ingoing/outgoing message before/after they are
+ * dispatched by client, mirroring
+ * org.apache.rocketmq.client.java.hook.MessageInterceptor.
+ */
+export interface MessageInterceptor {
+  doBefore(context: MessageInterceptorContext, messages: GeneralMessage[]): void;
+  doAfter(context: MessageInterceptorContext, messages: GeneralMessage[]): void;
+}

--- a/nodejs/src/hook/MessageInterceptorContext.ts
+++ b/nodejs/src/hook/MessageInterceptorContext.ts
@@ -15,11 +15,19 @@
  * limitations under the License.
  */
 
-export * from './consumer';
-export * from './exception';
-export * from './hook';
-export * from './message';
-export * from './producer';
-export * from './retry';
-export * from './route';
-export * from './client';
+import { Attribute } from './Attribute';
+import { AttributeKey } from './AttributeKey';
+import { MessageHookPoints } from './MessageHookPoints';
+import { MessageHookPointsStatus } from './MessageHookPointsStatus';
+
+/**
+ * Context carried through the message interceptor chain, mirroring
+ * org.apache.rocketmq.client.java.hook.MessageInterceptorContext.
+ */
+export interface MessageInterceptorContext {
+  getMessageHookPoints(): MessageHookPoints;
+  getStatus(): MessageHookPointsStatus | undefined;
+  putAttribute<T>(key: AttributeKey<T>, value: Attribute<T>): void;
+  getAttribute<T>(key: AttributeKey<T>): Attribute<T> | undefined;
+  getAttributes(): Map<AttributeKey<any>, Attribute<any>>;
+}

--- a/nodejs/src/hook/MessageInterceptorContextImpl.ts
+++ b/nodejs/src/hook/MessageInterceptorContextImpl.ts
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Attribute } from './Attribute';
+import { AttributeKey } from './AttributeKey';
+import { MessageHookPoints } from './MessageHookPoints';
+import { MessageHookPointsStatus } from './MessageHookPointsStatus';
+import { MessageInterceptorContext } from './MessageInterceptorContext';
+
+/**
+ * Default {@link MessageInterceptorContext} implementation, mirroring
+ * org.apache.rocketmq.client.java.hook.MessageInterceptorContextImpl.
+ */
+export class MessageInterceptorContextImpl implements MessageInterceptorContext {
+  readonly #messageHookPoints: MessageHookPoints;
+  readonly #status: MessageHookPointsStatus | undefined;
+  readonly #attributes: Map<AttributeKey<any>, Attribute<any>>;
+
+  constructor(messageHookPoints: MessageHookPoints,
+    status?: MessageHookPointsStatus,
+    attributes?: Map<AttributeKey<any>, Attribute<any>>) {
+    this.#messageHookPoints = messageHookPoints;
+    this.#status = status;
+    this.#attributes = new Map(attributes ?? []);
+  }
+
+  /**
+   * Derive a new context from an existing one with the given status, e.g. once the
+   * outcome of the intercepted operation is known.
+   */
+  static withStatus(context: MessageInterceptorContext, status: MessageHookPointsStatus) {
+    return new MessageInterceptorContextImpl(context.getMessageHookPoints(), status, context.getAttributes());
+  }
+
+  getMessageHookPoints(): MessageHookPoints {
+    return this.#messageHookPoints;
+  }
+
+  getStatus(): MessageHookPointsStatus | undefined {
+    return this.#status;
+  }
+
+  putAttribute<T>(key: AttributeKey<T>, value: Attribute<T>) {
+    this.#attributes.set(key, value);
+  }
+
+  getAttribute<T>(key: AttributeKey<T>): Attribute<T> | undefined {
+    return this.#attributes.get(key) as Attribute<T> | undefined;
+  }
+
+  getAttributes(): Map<AttributeKey<any>, Attribute<any>> {
+    return this.#attributes;
+  }
+}

--- a/nodejs/src/hook/MessageMeterInterceptor.ts
+++ b/nodejs/src/hook/MessageMeterInterceptor.ts
@@ -1,0 +1,162 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Attributes } from '@opentelemetry/api';
+import { Attribute, AttributeKey, MessageHookPoints, MessageHookPointsStatus, MessageInterceptor, MessageInterceptorContext } from './';
+import { GeneralMessage } from './MessageInterceptor';
+import { MetricLabels } from '../metrics/MetricLabels';
+import { InvocationStatus } from '../metrics/InvocationStatus';
+import { HistogramEnum } from '../metrics/HistogramEnum';
+import { ClientMeterManager } from '../metrics/ClientMeterManager';
+
+/**
+ * Minimal message shape required to compute metric attributes / latencies.
+ * Covers both the producer's PublishingMessage (cast to GeneralMessage) and the
+ * consumer's MessageView (which implements GeneralMessage).
+ */
+type MetricMessage = {
+  topic: string;
+  transportDeliveryTimestamp?: Date;
+  decodeTimestamp?: Date;
+};
+
+/**
+ * Records the four RocketMQ histograms around the SEND / RECEIVE / CONSUME hook
+ * points, mirroring org.apache.rocketmq.client.java.metrics.MessageMeterInterceptor.
+ *
+ * Unlike Java (which wires an AuthInterceptor + IpNameResolverFactory onto the
+ * export channel), the Node client signs each export request via a per-call
+ * metadata provider (see {@link ClientMeterManager}), so no auth plumbing is
+ * needed here.
+ */
+export class MessageMeterInterceptor implements MessageInterceptor {
+  static readonly SEND_STOPWATCH_KEY = AttributeKey.create<number>('send_stopwatch');
+  static readonly CONSUME_STOPWATCH_KEY = AttributeKey.create<number>('consume_stopwatch');
+
+  constructor(
+    private readonly meterManager: ClientMeterManager,
+    private readonly clientId: string,
+    private readonly getConsumerGroup: () => string | undefined,
+  ) {
+  }
+
+  doBefore(context: MessageInterceptorContext, messages: GeneralMessage[]): void {
+    if (!this.meterManager.isEnabled()) {
+      return;
+    }
+    switch (context.getMessageHookPoints()) {
+      case MessageHookPoints.SEND:
+        context.putAttribute(MessageMeterInterceptor.SEND_STOPWATCH_KEY, Attribute.create(Date.now()));
+        break;
+      case MessageHookPoints.CONSUME: {
+        const consumerGroup = this.getConsumerGroup();
+        if (!consumerGroup) {
+          break;
+        }
+        const message = messages[0] as MetricMessage | undefined;
+        if (!message || !message.decodeTimestamp) {
+          break;
+        }
+        const latency = Date.now() - message.decodeTimestamp.getTime();
+        const attributes = this.#consumerAttributes(message.topic, consumerGroup);
+        this.meterManager.record(HistogramEnum.AWAIT_TIME, attributes, latency);
+        context.putAttribute(MessageMeterInterceptor.CONSUME_STOPWATCH_KEY, Attribute.create(Date.now()));
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  doAfter(context: MessageInterceptorContext, messages: GeneralMessage[]): void {
+    if (!this.meterManager.isEnabled()) {
+      return;
+    }
+    const status = context.getStatus();
+    const invocationStatus = status === MessageHookPointsStatus.OK ? InvocationStatus.SUCCESS : InvocationStatus.FAILURE;
+    switch (context.getMessageHookPoints()) {
+      case MessageHookPoints.SEND: {
+        const attr = context.getAttribute(MessageMeterInterceptor.SEND_STOPWATCH_KEY);
+        if (!attr) {
+          break;
+        }
+        const message = messages[0] as MetricMessage | undefined;
+        if (!message) {
+          break;
+        }
+        const cost = Date.now() - attr.get();
+        const attributes: Attributes = {
+          [MetricLabels.TOPIC]: message.topic,
+          [MetricLabels.CLIENT_ID]: this.clientId,
+          [MetricLabels.INVOCATION_STATUS]: invocationStatus.name,
+        };
+        this.meterManager.record(HistogramEnum.SEND_COST_TIME, attributes, cost);
+        break;
+      }
+      case MessageHookPoints.RECEIVE: {
+        const consumerGroup = this.getConsumerGroup();
+        if (!consumerGroup) {
+          break;
+        }
+        const message = messages[0] as MetricMessage | undefined;
+        if (!message || !message.transportDeliveryTimestamp) {
+          break;
+        }
+        const latency = Date.now() - message.transportDeliveryTimestamp.getTime();
+        if (latency < 0) {
+          break;
+        }
+        const attributes = this.#consumerAttributes(message.topic, consumerGroup);
+        this.meterManager.record(HistogramEnum.DELIVERY_LATENCY, attributes, latency);
+        break;
+      }
+      case MessageHookPoints.CONSUME: {
+        const consumerGroup = this.getConsumerGroup();
+        if (!consumerGroup) {
+          break;
+        }
+        const attr = context.getAttribute(MessageMeterInterceptor.CONSUME_STOPWATCH_KEY);
+        if (!attr) {
+          break;
+        }
+        const message = messages[0] as MetricMessage | undefined;
+        if (!message) {
+          break;
+        }
+        const cost = Date.now() - attr.get();
+        const attributes: Attributes = {
+          [MetricLabels.TOPIC]: message.topic,
+          [MetricLabels.CLIENT_ID]: this.clientId,
+          [MetricLabels.CONSUMER_GROUP]: consumerGroup,
+          [MetricLabels.INVOCATION_STATUS]: invocationStatus.name,
+        };
+        this.meterManager.record(HistogramEnum.PROCESS_TIME, attributes, cost);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  #consumerAttributes(topic: string, consumerGroup: string): Attributes {
+    return {
+      [MetricLabels.TOPIC]: topic,
+      [MetricLabels.CLIENT_ID]: this.clientId,
+      [MetricLabels.CONSUMER_GROUP]: consumerGroup,
+    };
+  }
+}

--- a/nodejs/src/hook/index.ts
+++ b/nodejs/src/hook/index.ts
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-export * from './consumer';
-export * from './exception';
-export * from './hook';
-export * from './message';
-export * from './producer';
-export * from './retry';
-export * from './route';
-export * from './client';
+export * from './Attribute';
+export * from './AttributeKey';
+export * from './CompositedMessageInterceptor';
+export * from './InflightRequestCountInterceptor';
+export * from './MessageHookPoints';
+export * from './MessageHookPointsStatus';
+export * from './MessageInterceptor';
+export * from './MessageInterceptorContext';
+export * from './MessageInterceptorContextImpl';

--- a/nodejs/src/metrics/ClientMeter.ts
+++ b/nodejs/src/metrics/ClientMeter.ts
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Attributes, Histogram, Meter } from '@opentelemetry/api';
+import { MeterProvider as SdkMeterProvider } from '@opentelemetry/sdk-metrics';
+import { Endpoints } from '../route';
+import { HistogramEnum } from './HistogramEnum';
+import { Metric } from './Metric';
+
+/**
+ * Wraps an OpenTelemetry {@link Meter} and records the four RocketMQ histograms.
+ * When metrics are disabled it is a no-op instance, mirroring
+ * org.apache.rocketmq.client.java.metrics.ClientMeter.
+ */
+export class ClientMeter {
+  readonly enabled: boolean;
+  private readonly meter?: Meter;
+  private readonly endpoints?: Endpoints;
+  private readonly provider?: SdkMeterProvider;
+  private readonly histogramMap = new Map<HistogramEnum, Histogram>();
+
+  constructor(meter: Meter | null, endpoints: Endpoints | null, provider: SdkMeterProvider | null) {
+    this.enabled = meter != null && endpoints != null && provider != null;
+    this.meter = meter ?? undefined;
+    this.endpoints = endpoints ?? undefined;
+    this.provider = provider ?? undefined;
+  }
+
+  static disabledInstance(): ClientMeter {
+    return new ClientMeter(null, null, null);
+  }
+
+  record(histogramEnum: HistogramEnum, attributes: Attributes, value: number) {
+    if (!this.enabled || !this.meter) {
+      return;
+    }
+    let histogram = this.histogramMap.get(histogramEnum);
+    if (!histogram) {
+      histogram = this.meter.createHistogram(histogramEnum);
+      this.histogramMap.set(histogramEnum, histogram);
+    }
+    histogram.record(value, attributes);
+  }
+
+  async shutdown() {
+    if (!this.enabled || !this.provider) {
+      return;
+    }
+    try {
+      await this.provider.shutdown();
+    } catch (t) {
+      // best-effort shutdown, ignore
+    }
+  }
+
+  /**
+   * Returns true if the supplied metric switch is already satisfied by this
+   * meter (so a rebuild is unnecessary), mirroring ClientMeter#satisfy.
+   */
+  satisfy(metric: Metric): boolean {
+    if (this.enabled && metric.on && this.endpoints != null && metric.endpoints != null
+      && this.endpoints.equals(metric.endpoints)) {
+      return true;
+    }
+    return !this.enabled && !metric.on;
+  }
+}

--- a/nodejs/src/metrics/ClientMeterManager.ts
+++ b/nodejs/src/metrics/ClientMeterManager.ts
@@ -1,0 +1,145 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Attributes, Meter } from '@opentelemetry/api';
+import {
+  MeterProvider as SdkMeterProvider,
+  PeriodicExportingMetricReader,
+  View,
+} from '@opentelemetry/sdk-metrics';
+import { Resource } from '@opentelemetry/resources';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-grpc';
+import { ChannelCredentials, Metadata } from '@grpc/grpc-js';
+import { ILogger } from '../client/Logger';
+import { ClientMeter } from './ClientMeter';
+import { GaugeObserver } from './GaugeObserver';
+import { EmptyGaugeObserver } from './EmptyGaugeObserver';
+import { HistogramEnum, buildHistogramView } from './HistogramEnum';
+import { Metric } from './Metric';
+
+const METRIC_EXPORTER_RPC_TIMEOUT = 5000;
+const METRIC_READER_INTERVAL = 60000;
+const METRIC_INSTRUMENTATION_NAME = 'org.apache.rocketmq.message';
+
+/**
+ * Owns the OpenTelemetry metric pipeline for a single client. On every settings
+ * command it lazily (re)builds an SdkMeterProvider that exports the four
+ * RocketMQ histograms plus the consumer gauges to the broker-supplied metric
+ * endpoints over OTLP/gRPC, mirroring
+ * org.apache.rocketmq.client.java.metrics.ClientMeterManager.
+ */
+export class ClientMeterManager {
+  private readonly clientId: string;
+  private readonly metadataProvider: () => Metadata;
+  private readonly logger: ILogger;
+  private clientMeter: ClientMeter;
+  private gaugeObserver: GaugeObserver = EmptyGaugeObserver.EMPTY;
+
+  constructor(clientId: string, metadataProvider: () => Metadata, logger: ILogger) {
+    this.clientId = clientId;
+    this.metadataProvider = metadataProvider;
+    this.logger = logger;
+    this.clientMeter = ClientMeter.disabledInstance();
+  }
+
+  setGaugeObserver(gaugeObserver: GaugeObserver) {
+    this.gaugeObserver = gaugeObserver;
+  }
+
+  record(histogramEnum: HistogramEnum, attributes: Attributes, value: number) {
+    this.clientMeter.record(histogramEnum, attributes, value);
+  }
+
+  isEnabled(): boolean {
+    return this.clientMeter.enabled;
+  }
+
+  async shutdown() {
+    await this.clientMeter.shutdown();
+  }
+
+  async reset(metric: Metric): Promise<void> {
+    try {
+      if (this.clientMeter.satisfy(metric)) {
+        this.logger.info('Metric settings is satisfied by the current message meter, metric=%j, clientId=%s',
+          metric, this.clientId);
+        return;
+      }
+      if (!metric.on || !metric.endpoints) {
+        this.logger.info('Metric is off, clientId=%s', this.clientId);
+        await this.clientMeter.shutdown();
+        this.clientMeter = ClientMeter.disabledInstance();
+        return;
+      }
+      const endpoints = metric.endpoints;
+      // Use the first address as the OTLP/gRPC target. The exporter's URL is
+      // normalized to "host:port" internally, which gRPC-js resolves through
+      // its default DNS resolver (a single IP works fine; the custom `ip`
+      // resolver is used for the primary RPC channels).
+      const address = endpoints.addressesList[0];
+      const url = `http://${address.host}:${address.port}`;
+      const exporter = new OTLPMetricExporter({
+        url,
+        credentials: ChannelCredentials.createInsecure(),
+        timeoutMillis: METRIC_EXPORTER_RPC_TIMEOUT,
+        // Per-request signing mirrors the Java client's AuthInterceptor. The
+        // d.ts types this field as `Metadata`, but the runtime (and the
+        // exporter's own merge logic in otlp-grpc-exporter-base) expects a
+        // function returning freshly-signed Metadata.
+        metadata: (() => this.metadataProvider()) as unknown as Metadata,
+      });
+
+      const reader = new PeriodicExportingMetricReader({
+        exporter,
+        exportIntervalMillis: METRIC_READER_INTERVAL,
+        exportTimeoutMillis: METRIC_EXPORTER_RPC_TIMEOUT,
+      });
+
+      const views: View[] = [
+        new View(buildHistogramView(HistogramEnum.SEND_COST_TIME)),
+        new View(buildHistogramView(HistogramEnum.DELIVERY_LATENCY)),
+        new View(buildHistogramView(HistogramEnum.AWAIT_TIME)),
+        new View(buildHistogramView(HistogramEnum.PROCESS_TIME)),
+      ];
+
+      const provider: SdkMeterProvider = new SdkMeterProvider({
+        resource: Resource.empty(),
+        readers: [ reader ],
+        views,
+      });
+
+      const meter: Meter = provider.getMeter(METRIC_INSTRUMENTATION_NAME);
+
+      const existedClientMeter = this.clientMeter;
+      this.clientMeter = new ClientMeter(meter, endpoints, provider);
+      await existedClientMeter.shutdown();
+      this.logger.info('Metrics is on, endpoints=%s, clientId=%s', endpoints, this.clientId);
+
+      const gauges = this.gaugeObserver.getGauges();
+      for (const gauge of gauges) {
+        meter.createObservableGauge(gauge).addCallback(observableResult => {
+          const values = this.gaugeObserver.getValues(gauge);
+          for (const [ attributes, value ] of values) {
+            observableResult.observe(value, attributes);
+          }
+        });
+      }
+    } catch (t) {
+      this.logger.error('Exception raised when resetting message meter, clientId=%s, error=%s', this.clientId, t);
+    }
+  }
+}

--- a/nodejs/src/metrics/EmptyGaugeObserver.ts
+++ b/nodejs/src/metrics/EmptyGaugeObserver.ts
@@ -15,13 +15,22 @@
  * limitations under the License.
  */
 
-export * from './Attribute';
-export * from './AttributeKey';
-export * from './CompositedMessageInterceptor';
-export * from './InflightRequestCountInterceptor';
-export * from './MessageHookPoints';
-export * from './MessageHookPointsStatus';
-export * from './MessageInterceptor';
-export * from './MessageInterceptorContext';
-export * from './MessageInterceptorContextImpl';
-export * from './MessageMeterInterceptor';
+import { Attributes } from '@opentelemetry/api';
+import { GaugeEnum } from './GaugeEnum';
+import { GaugeObserver } from './GaugeObserver';
+
+/**
+ * Default no-op gauge observer used before a consumer registers a real one,
+ * mirroring org.apache.rocketmq.client.java.metrics.EmptyGaugeObserver.
+ */
+export class EmptyGaugeObserver implements GaugeObserver {
+  static readonly EMPTY: EmptyGaugeObserver = new EmptyGaugeObserver();
+
+  getGauges(): GaugeEnum[] {
+    return [];
+  }
+
+  getValues(): Map<Attributes, number> {
+    return new Map();
+  }
+}

--- a/nodejs/src/metrics/GaugeEnum.ts
+++ b/nodejs/src/metrics/GaugeEnum.ts
@@ -15,13 +15,19 @@
  * limitations under the License.
  */
 
-export * from './Attribute';
-export * from './AttributeKey';
-export * from './CompositedMessageInterceptor';
-export * from './InflightRequestCountInterceptor';
-export * from './MessageHookPoints';
-export * from './MessageHookPointsStatus';
-export * from './MessageInterceptor';
-export * from './MessageInterceptorContext';
-export * from './MessageInterceptorContextImpl';
-export * from './MessageMeterInterceptor';
+/**
+ * The two consumer gauges exported by the RocketMQ client, mirroring
+ * org.apache.rocketmq.client.java.metrics.GaugeEnum.
+ */
+export enum GaugeEnum {
+  /**
+   * Cached message count of push consumer.
+   * Labels: topic, client_id, consumer_group.
+   */
+  CONSUMER_CACHED_MESSAGES = 'rocketmq_consumer_cached_messages',
+  /**
+   * Cached message bytes of push consumer.
+   * Labels: topic, client_id, consumer_group.
+   */
+  CONSUMER_CACHED_BYTES = 'rocketmq_consumer_cached_bytes',
+}

--- a/nodejs/src/metrics/GaugeObserver.ts
+++ b/nodejs/src/metrics/GaugeObserver.ts
@@ -15,13 +15,18 @@
  * limitations under the License.
  */
 
-export * from './Attribute';
-export * from './AttributeKey';
-export * from './CompositedMessageInterceptor';
-export * from './InflightRequestCountInterceptor';
-export * from './MessageHookPoints';
-export * from './MessageHookPointsStatus';
-export * from './MessageInterceptor';
-export * from './MessageInterceptorContext';
-export * from './MessageInterceptorContextImpl';
-export * from './MessageMeterInterceptor';
+import { Attributes } from '@opentelemetry/api';
+import { GaugeEnum } from './GaugeEnum';
+
+/**
+ * Supplies the live values observed by the periodic metric reader for each
+ * consumer gauge, mirroring org.apache.rocketmq.client.java.metrics.GaugeObserver.
+ *
+ * The map key is the attribute set (topic / client_id / consumer_group) and the
+ * value is the observed gauge reading.
+ */
+export interface GaugeObserver {
+  getGauges(): GaugeEnum[];
+
+  getValues(gauge: GaugeEnum): Map<Attributes, number>;
+}

--- a/nodejs/src/metrics/HistogramEnum.ts
+++ b/nodejs/src/metrics/HistogramEnum.ts
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ExplicitBucketHistogramAggregation, InstrumentType, ViewOptions } from '@opentelemetry/sdk-metrics';
+
+/**
+ * The four histograms exported by the RocketMQ client, mirroring
+ * org.apache.rocketmq.client.java.metrics.HistogramEnum. The bucket
+ * boundaries (in milliseconds) are copied verbatim from the Java client.
+ */
+export enum HistogramEnum {
+  /**
+   * Cost time of successful api calls of message publishing.
+   * Labels: topic, client_id, invocation_status.
+   */
+  SEND_COST_TIME = 'rocketmq_send_cost_time',
+  /**
+   * Latency of message delivery from remote.
+   * Labels: topic, client_id, consumer_group.
+   */
+  DELIVERY_LATENCY = 'rocketmq_delivery_latency',
+  /**
+   * Await time of message consumption.
+   * Labels: topic, client_id, consumer_group.
+   */
+  AWAIT_TIME = 'rocketmq_await_time',
+  /**
+   * Process time of message consumption.
+   * Labels: topic, client_id, consumer_group, invocation_status.
+   */
+  PROCESS_TIME = 'rocketmq_process_time',
+}
+
+/**
+ * Explicit bucket boundaries (milliseconds) for each histogram, identical to
+ * the Java client's Aggregation.explicitBucketHistogram(...) calls.
+ */
+export const HISTOGRAM_BUCKETS: Record<HistogramEnum, number[]> = {
+  [HistogramEnum.SEND_COST_TIME]: [ 1.0, 5.0, 10.0, 20.0, 50.0, 200.0, 500.0 ],
+  [HistogramEnum.DELIVERY_LATENCY]: [ 1.0, 5.0, 10.0, 20.0, 50.0, 200.0, 500.0 ],
+  [HistogramEnum.AWAIT_TIME]: [ 1.0, 5.0, 20.0, 100.0, 1000.0, 5 * 1000.0, 10 * 1000.0 ],
+  [HistogramEnum.PROCESS_TIME]: [ 1.0, 5.0, 10.0, 100.0, 1000.0, 10 * 1000.0, 60 * 1000.0 ],
+};
+
+/**
+ * Build the OpenTelemetry view that forces the given histogram onto the exact
+ * explicit-bucket aggregation used by the Java client.
+ */
+export function buildHistogramView(histogramEnum: HistogramEnum): ViewOptions {
+  return {
+    instrumentName: histogramEnum,
+    instrumentType: InstrumentType.HISTOGRAM,
+    aggregation: new ExplicitBucketHistogramAggregation(HISTOGRAM_BUCKETS[histogramEnum]),
+  };
+}

--- a/nodejs/src/metrics/InvocationStatus.ts
+++ b/nodejs/src/metrics/InvocationStatus.ts
@@ -15,13 +15,14 @@
  * limitations under the License.
  */
 
-export * from './Attribute';
-export * from './AttributeKey';
-export * from './CompositedMessageInterceptor';
-export * from './InflightRequestCountInterceptor';
-export * from './MessageHookPoints';
-export * from './MessageHookPointsStatus';
-export * from './MessageInterceptor';
-export * from './MessageInterceptorContext';
-export * from './MessageInterceptorContextImpl';
-export * from './MessageMeterInterceptor';
+/**
+ * Outcome of an instrumented operation (send / consume), mirroring
+ * org.apache.rocketmq.client.java.metrics.InvocationStatus.
+ */
+export class InvocationStatus {
+  static readonly SUCCESS = new InvocationStatus('success');
+  static readonly FAILURE = new InvocationStatus('failure');
+
+  private constructor(readonly name: string) {
+  }
+}

--- a/nodejs/src/metrics/Metric.ts
+++ b/nodejs/src/metrics/Metric.ts
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Endpoints } from '../route';
+import { Metric as MetricPB } from '../../proto/apache/rocketmq/v2/definition_pb';
+
+/**
+ * Local view of the metric switch received from the broker via the telemetry
+ * settings command, mirroring org.apache.rocketmq.client.java.metrics.Metric.
+ *
+ * Metrics are only considered enabled when both the `on` flag is set AND a
+ * valid endpoints is present.
+ */
+export class Metric {
+  readonly endpoints: Endpoints | null;
+  readonly on: boolean;
+
+  constructor(metric: MetricPB | undefined | null) {
+    if (metric && metric.hasEndpoints() && metric.getOn()) {
+      // Endpoints expects the plain AsObject shape, so unwrap the proto message.
+      this.endpoints = new Endpoints(metric.getEndpoints()!.toObject());
+      this.on = true;
+    } else {
+      this.endpoints = null;
+      this.on = false;
+    }
+  }
+}

--- a/nodejs/src/metrics/MetricLabels.ts
+++ b/nodejs/src/metrics/MetricLabels.ts
@@ -15,13 +15,17 @@
  * limitations under the License.
  */
 
-export * from './Attribute';
-export * from './AttributeKey';
-export * from './CompositedMessageInterceptor';
-export * from './InflightRequestCountInterceptor';
-export * from './MessageHookPoints';
-export * from './MessageHookPointsStatus';
-export * from './MessageInterceptor';
-export * from './MessageInterceptorContext';
-export * from './MessageInterceptorContextImpl';
-export * from './MessageMeterInterceptor';
+/**
+ * Canonical attribute (label) keys attached to every RocketMQ metric,
+ * mirroring org.apache.rocketmq.client.java.metrics.MetricLabels.
+ */
+export class MetricLabels {
+  static readonly TOPIC = 'topic';
+  static readonly CLIENT_ID = 'client_id';
+  static readonly CONSUMER_GROUP = 'consumer_group';
+  static readonly INVOCATION_STATUS = 'invocation_status';
+
+  private constructor() {
+    // constant holder
+  }
+}

--- a/nodejs/src/metrics/index.ts
+++ b/nodejs/src/metrics/index.ts
@@ -15,13 +15,12 @@
  * limitations under the License.
  */
 
-export * from './Attribute';
-export * from './AttributeKey';
-export * from './CompositedMessageInterceptor';
-export * from './InflightRequestCountInterceptor';
-export * from './MessageHookPoints';
-export * from './MessageHookPointsStatus';
-export * from './MessageInterceptor';
-export * from './MessageInterceptorContext';
-export * from './MessageInterceptorContextImpl';
-export * from './MessageMeterInterceptor';
+export * from './MetricLabels';
+export * from './InvocationStatus';
+export * from './HistogramEnum';
+export * from './GaugeEnum';
+export * from './GaugeObserver';
+export * from './EmptyGaugeObserver';
+export * from './Metric';
+export * from './ClientMeter';
+export * from './ClientMeterManager';

--- a/nodejs/src/producer/Producer.ts
+++ b/nodejs/src/producer/Producer.ts
@@ -50,6 +50,12 @@ import { Transaction } from './Transaction';
 import { createResource } from '../util';
 import { RecallReceipt } from './RecallReceipt';
 import { RecallMessageRequest } from '../../proto/apache/rocketmq/v2/service_pb';
+import {
+  GeneralMessage,
+  MessageHookPoints,
+  MessageHookPointsStatus,
+  MessageInterceptorContextImpl,
+} from '../hook';
 
 export interface ProducerOptions extends BaseClientOptions {
   topic?: string | string[];
@@ -241,7 +247,18 @@ export class Producer extends BaseClient {
     // Prepare the candidate message queue(s) for retry-sending in advance.
     const candidates = messageGroup ? [ loadBalancer.takeMessageQueueByMessageGroup(messageGroup) ] :
       this.#takeMessageQueues(loadBalancer);
-    return await this.#send0(topic, messageType, candidates, pubMessages, 1);
+    // SEND hook point, mirroring Java ProducerImpl#send.
+    const context = new MessageInterceptorContextImpl(MessageHookPoints.SEND);
+    const generalMessages = pubMessages as unknown as GeneralMessage[];
+    this.doBefore(context, generalMessages);
+    try {
+      const receipts = await this.#send0(topic, messageType, candidates, pubMessages, 1);
+      this.doAfter(MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.OK), generalMessages);
+      return receipts;
+    } catch (err) {
+      this.doAfter(MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.ERROR), generalMessages);
+      throw err;
+    }
   }
 
   #wrapSendMessageRequest(pubMessages: PublishingMessage[], mq: MessageQueue) {

--- a/nodejs/src/producer/Producer.ts
+++ b/nodejs/src/producer/Producer.ts
@@ -120,11 +120,25 @@ export class Producer extends BaseClient {
       .setTopic(createResource(message.topic).setResourceNamespace(this.namespace))
       .setResolution(resolution)
       .setSource(source);
-    const response = await this.rpcClientManager.endTransaction(endpoints, request, this.requestTimeout);
-    StatusChecker.check(response.getStatus()?.toObject());
+    // COMMIT_TRANSACTION / ROLLBACK_TRANSACTION hook point, mirroring Java ProducerImpl#endTransaction.
+    const messageHookPoints = resolution === TransactionResolution.COMMIT ?
+      MessageHookPoints.COMMIT_TRANSACTION : MessageHookPoints.ROLLBACK_TRANSACTION;
+    const context = new MessageInterceptorContextImpl(messageHookPoints);
+    const generalMessages: GeneralMessage[] = [ message ];
+    this.doBefore(context, generalMessages);
+    try {
+      const response = await this.rpcClientManager.endTransaction(endpoints, request, this.requestTimeout);
+      const statusObj = response.getStatus()?.toObject();
+      const hookStatus = statusObj?.code === Code.OK ? MessageHookPointsStatus.OK : MessageHookPointsStatus.ERROR;
+      StatusChecker.check(statusObj);
+      this.doAfter(MessageInterceptorContextImpl.withStatus(context, hookStatus), generalMessages);
 
-    this.logger.debug?.('End transaction successfully, messageId=%s, transactionId=%s, resolution=%s, source=%s, clientId=%s',
-      messageId, transactionId, resolutionStr, sourceStr, this.clientId);
+      this.logger.debug?.('End transaction successfully, messageId=%s, transactionId=%s, resolution=%s, source=%s, clientId=%s',
+        messageId, transactionId, resolutionStr, sourceStr, this.clientId);
+    } catch (err) {
+      this.doAfter(MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.ERROR), generalMessages);
+      throw err;
+    }
   }
 
   async onRecoverOrphanedTransactionCommand(endpoints: Endpoints, command: RecoverOrphanedTransactionCommand) {

--- a/nodejs/src/producer/PublishingLoadBalancer.ts
+++ b/nodejs/src/producer/PublishingLoadBalancer.ts
@@ -78,8 +78,14 @@ export class PublishingLoadBalancer {
   }
 
   takeMessageQueueByMessageGroup(messageGroup: string) {
-    const hashCode = calculateStringSipHash24(messageGroup);
-    const index = parseInt(`${hashCode % BigInt(this.#messageQueues.length)}`);
+    // SipHash-2-4 returns an unsigned 64-bit value in JS (readBigUInt64BE), while
+    // Java's String.hashCode-style paths use signed semantics. Interpret the hash as
+    // a signed 64-bit integer and apply floorMod so the result is always non-negative,
+    // exactly matching Java LongMath.mod(hashCode, size) — otherwise FIFO messages
+    // with "negative" hashes route to different queues than the Java client.
+    const hashCode = BigInt.asIntN(64, calculateStringSipHash24(messageGroup));
+    const size = this.#messageQueues.length;
+    const index = Number(((hashCode % BigInt(size)) + BigInt(size)) % BigInt(size));
     return this.#messageQueues[index];
   }
 

--- a/nodejs/src/retry/CustomizedBackoffRetryPolicy.ts
+++ b/nodejs/src/retry/CustomizedBackoffRetryPolicy.ts
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from 'node:assert';
+import { Duration } from 'google-protobuf/google/protobuf/duration_pb';
+import {
+  RetryPolicy as RetryPolicyPB,
+  CustomizedBackoff,
+} from '../../proto/apache/rocketmq/v2/definition_pb';
+import { createDuration } from '../util';
+import { RetryPolicy } from './RetryPolicy';
+
+/**
+ * Backoff policy whose durations are customized by the server side,
+ * mirroring Java's CustomizedBackoffRetryPolicy: the Nth attempt waits
+ * durations[N - 1], and once attempts run past the list, the last
+ * duration applies.
+ */
+export class CustomizedBackoffRetryPolicy implements RetryPolicy {
+  #maxAttempts: number;
+  // Backoff durations in milliseconds.
+  #durations: number[];
+
+  constructor(durations: number[], maxAttempts: number) {
+    assert(Array.isArray(durations) && durations.length > 0, 'durations must not be empty');
+    this.#durations = durations;
+    this.#maxAttempts = maxAttempts;
+  }
+
+  getMaxAttempts(): number {
+    return this.#maxAttempts;
+  }
+
+  getNextAttemptDelay(attempt: number): number {
+    assert(attempt > 0, 'attempt must be positive');
+    return attempt > this.#durations.length
+      ? this.#durations[this.#durations.length - 1]
+      : this.#durations[attempt - 1];
+  }
+
+  inheritBackoff(retryPolicy: RetryPolicyPB): RetryPolicy {
+    assert(retryPolicy.getStrategyCase() === RetryPolicyPB.StrategyCase.CUSTOMIZED_BACKOFF,
+      'strategy must be customized backoff');
+    return new CustomizedBackoffRetryPolicy(
+      CustomizedBackoffRetryPolicy.durationsToMillis(retryPolicy.getCustomizedBackoff()!),
+      this.#maxAttempts);
+  }
+
+  toProtobuf(): RetryPolicyPB {
+    const customizedBackoff = new CustomizedBackoff();
+    for (const duration of this.#durations) {
+      customizedBackoff.addNext(createDuration(duration));
+    }
+    return new RetryPolicyPB()
+      .setMaxAttempts(this.#maxAttempts)
+      .setCustomizedBackoff(customizedBackoff);
+  }
+
+  /**
+   * Convert the protobuf CustomizedBackoff durations (seconds + nanos) to
+   * milliseconds without losing sub-second precision.
+   */
+  static durationsToMillis(customizedBackoff: CustomizedBackoff): number[] {
+    return customizedBackoff.getNextList().map((duration: Duration) =>
+      duration.getSeconds() * 1000 + duration.getNanos() / 1e6);
+  }
+}

--- a/nodejs/src/retry/ExponentialBackoffRetryPolicy.ts
+++ b/nodejs/src/retry/ExponentialBackoffRetryPolicy.ts
@@ -16,16 +16,16 @@
  */
 
 import assert from 'node:assert';
-import { Duration } from 'google-protobuf/google/protobuf/duration_pb';
 import {
   RetryPolicy as RetryPolicyPB,
   ExponentialBackoff,
 } from '../../proto/apache/rocketmq/v2/definition_pb';
+import { createDuration } from '../util';
 import { RetryPolicy } from './RetryPolicy';
 
 export class ExponentialBackoffRetryPolicy implements RetryPolicy {
   #maxAttempts: number;
-  // seconds
+  // milliseconds
   #initialBackoff: number;
   #maxBackoff: number;
   #backoffMultiplier: number;
@@ -58,9 +58,14 @@ export class ExponentialBackoffRetryPolicy implements RetryPolicy {
     assert(retryPolicy.getStrategyCase() === RetryPolicyPB.StrategyCase.EXPONENTIAL_BACKOFF,
       'strategy must be exponential backoff');
     const backoff = retryPolicy.getExponentialBackoff()!.toObject();
+    // Convert protobuf Duration (seconds + nanos) to milliseconds without
+    // losing sub-second precision (e.g. an initial backoff of 0.5s used to
+    // be truncated to plain 0, causing immediate retries).
+    const toMillis = (duration?: { seconds?: number; nanos?: number }) =>
+      duration ? (duration.seconds ?? 0) * 1000 + (duration.nanos ?? 0) / 1e6 : 0;
     return new ExponentialBackoffRetryPolicy(this.#maxAttempts,
-      backoff.initial?.seconds,
-      backoff.max?.seconds,
+      toMillis(backoff.initial),
+      toMillis(backoff.max),
       backoff.multiplier);
   }
 
@@ -69,8 +74,8 @@ export class ExponentialBackoffRetryPolicy implements RetryPolicy {
       .setMaxAttempts(this.#maxAttempts)
       .setExponentialBackoff(
         new ExponentialBackoff()
-          .setInitial(new Duration().setSeconds(this.#initialBackoff))
-          .setMax(new Duration().setSeconds(this.#maxBackoff))
+          .setInitial(createDuration(this.#initialBackoff))
+          .setMax(createDuration(this.#maxBackoff))
           .setMultiplier(this.#backoffMultiplier));
   }
 }

--- a/nodejs/src/retry/RetryPolicy.ts
+++ b/nodejs/src/retry/RetryPolicy.ts
@@ -32,7 +32,7 @@ export interface RetryPolicy {
    * Get await time after current attempts, the attempt index starts at 1.
    *
    * @param attempt current attempt.
-   * @return await time in seconds.
+   * @return await time in milliseconds.
    */
   getNextAttemptDelay(attempt: number): number;
 

--- a/nodejs/src/route/Endpoints.ts
+++ b/nodejs/src/route/Endpoints.ts
@@ -18,6 +18,9 @@
 import { isIPv4, isIPv6 } from 'node:net';
 import { hashCodeOfString } from '../util';
 import { Address, AddressScheme, Endpoints as EndpointsPB } from '../../proto/apache/rocketmq/v2/definition_pb';
+// Side-effect import: registers the custom `ip` name resolver (shuffle + multi-address
+// load balancing), mirroring the Java client's IpNameResolverFactory.
+import './IpNameResolver';
 
 const DEFAULT_PORT = 80;
 
@@ -91,9 +94,11 @@ export class Endpoints {
     }).join(',');
     switch (this.scheme) {
       case AddressScheme.IPV4:
-        return `ipv4:${targets}`;
       case AddressScheme.IPV6:
-        return `ipv6:${targets}`;
+        // Route IP addresses through the custom `ip` resolver registered in
+        // IpNameResolver, which shuffles the address list for multi-proxy load
+        // balancing (equivalent to Java's IpNameResolverFactory).
+        return `ip:${targets}`;
       case AddressScheme.DOMAIN_NAME:
         return `dns:${targets}`;
       default:

--- a/nodejs/src/route/Endpoints.ts
+++ b/nodejs/src/route/Endpoints.ts
@@ -35,7 +35,33 @@ export class Endpoints {
       const splits = endpoints.split(';');
       this.addressesList = [];
       for (const endpoint of splits) {
-        const [ host, port ] = endpoint.split(':');
+        // Strip the optional http:// or https:// prefix, mirroring the Java client.
+        const candidate = endpoint.trim().replace(/^https?:\/\//, '');
+        let host: string;
+        let port: number;
+        if (candidate.startsWith('[')) {
+          // Bracketed IPv6 address, e.g. [::1]:10911 or [fe80::1]
+          const match = candidate.match(/^\[([^\]]+)\](?::(\d+))?$/);
+          if (!match) {
+            throw new TypeError(`Invalid IPv6 endpoint: ${endpoint}`);
+          }
+          host = match[1];
+          port = match[2] ? parseInt(match[2], 10) : DEFAULT_PORT;
+        } else if (isIPv6(candidate)) {
+          // Bare IPv6 address without brackets, e.g. ::1
+          host = candidate;
+          port = DEFAULT_PORT;
+        } else {
+          // IPv4 address or domain name, e.g. 127.0.0.1:10911, example.com:80
+          const index = candidate.lastIndexOf(':');
+          if (index > 0) {
+            host = candidate.substring(0, index);
+            port = parseInt(candidate.substring(index + 1), 10) || DEFAULT_PORT;
+          } else {
+            host = candidate;
+            port = DEFAULT_PORT;
+          }
+        }
         if (isIPv4(host)) {
           this.scheme = AddressScheme.IPV4;
         } else if (isIPv6(host)) {
@@ -43,7 +69,7 @@ export class Endpoints {
         } else {
           this.scheme = AddressScheme.DOMAIN_NAME;
         }
-        this.addressesList.push({ host, port: parseInt(port) || DEFAULT_PORT });
+        this.addressesList.push({ host, port });
       }
     } else {
       this.scheme = endpoints.scheme;

--- a/nodejs/src/route/Endpoints.ts
+++ b/nodejs/src/route/Endpoints.ts
@@ -78,8 +78,27 @@ export class Endpoints {
     this.facade = this.addressesList.map(addr => `${addr.host}:${addr.port}`).join(',');
   }
 
+  /**
+   * gRPC target with resolver scheme prefix, mirroring the Java client:
+   * - IPv4 addresses:  ipv4:127.0.0.1:10911,127.0.0.2:10912
+   * - IPv6 addresses:  ipv6:[::1]:10911,[fe80::1]:10912 (brackets required by grpc-js)
+   * - Domain names:    dns:example.com:8080,example.org:8081
+   */
   getGrpcTarget() {
-    return this.facade;
+    const targets = this.addressesList.map(addr => {
+      const host = this.scheme === AddressScheme.IPV6 ? `[${addr.host}]` : addr.host;
+      return `${host}:${addr.port}`;
+    }).join(',');
+    switch (this.scheme) {
+      case AddressScheme.IPV4:
+        return `ipv4:${targets}`;
+      case AddressScheme.IPV6:
+        return `ipv6:${targets}`;
+      case AddressScheme.DOMAIN_NAME:
+        return `dns:${targets}`;
+      default:
+        return targets;
+    }
   }
 
   toString() {

--- a/nodejs/src/route/IpNameResolver.ts
+++ b/nodejs/src/route/IpNameResolver.ts
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { experimental, Metadata, status as Status, ChannelOptions } from '@grpc/grpc-js';
+
+/**
+ * Custom gRPC name resolver registered under the `ip` scheme, mirroring the Java
+ * client's `IpNameResolverFactory`.
+ *
+ * The Java resolver converts each socket address into its own
+ * `EquivalentAddressGroup` and then {@code Collections.shuffle}s the list, so the
+ * gRPC load balancer starts from a random address instead of always the first
+ * one. RocketMQ proxies are typically deployed as multiple endpoints behind one
+ * `Endpoints`, and shuffling spreads clients across them.
+ *
+ * grpc-js models an `EquivalentAddressGroup` as a single `Endpoint` carrying one
+ * or more equivalent `SubchannelAddress`es, so we emit one `Endpoint` per address
+ * and shuffle the array — exactly the Java semantics.
+ */
+const DEFAULT_PORT = 80;
+
+/**
+ * Fisher–Yates shuffle (pure, does not mutate the input array).
+ */
+function shuffle<T>(input: readonly T[]): T[] {
+  const arr = input.slice();
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const tmp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = tmp;
+  }
+  return arr;
+}
+
+class IpResolver {
+  private readonly listener: experimental.ResolverListener;
+  private endpoints: experimental.Endpoint[] = [];
+  private error: { code: Status; details: string; metadata: Metadata } | null = null;
+  private hasReturnedResult = false;
+
+  constructor(target: experimental.GrpcUri, listener: experimental.ResolverListener, _channelOptions: ChannelOptions) {
+    this.listener = listener;
+    const pathList = (target.path || '').split(',').map(s => s.trim()).filter(Boolean);
+    const addresses: experimental.SubchannelAddress[] = [];
+    for (const path of pathList) {
+      const hostPort = experimental.splitHostPort(path);
+      if (!hostPort) {
+        this.error = {
+          code: Status.UNAVAILABLE,
+          details: `Failed to parse ip address: ${path}`,
+          metadata: new Metadata(),
+        };
+        return;
+      }
+      addresses.push({
+        host: hostPort.host,
+        port: hostPort.port ?? DEFAULT_PORT,
+      });
+    }
+    this.endpoints = shuffle(addresses).map(address => ({ addresses: [address] }));
+  }
+
+  updateResolution(): void {
+    if (this.hasReturnedResult) {
+      return;
+    }
+    this.hasReturnedResult = true;
+    // Defer the callback to the next tick, mirroring the built-in ip resolver so
+    // listeners are never invoked synchronously from the constructor path.
+    process.nextTick(() => {
+      if (this.error) {
+        this.listener(
+          experimental.statusOrFromError(this.error),
+          {},
+          null,
+          '',
+        );
+      } else {
+        this.listener(
+          experimental.statusOrFromValue(this.endpoints),
+          {},
+          null,
+          '',
+        );
+      }
+    });
+  }
+
+  destroy(): void {
+    this.hasReturnedResult = false;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  static getDefaultAuthority(target: experimental.GrpcUri): string {
+    return (target.path || '').split(',')[0] || 'localhost';
+  }
+}
+
+// Register the resolver so that gRPC targets prefixed with `ip:` are handled by
+// this class. Registration is idempotent at module-load time.
+experimental.registerResolver('ip', IpResolver);
+
+export { IpResolver };

--- a/nodejs/src/util/Semaphore.ts
+++ b/nodejs/src/util/Semaphore.ts
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A counting semaphore used to throttle the number of messages that can be
+ * in-flight (fetched but not yet settled) on a single {@link ProcessQueue}.
+ *
+ * This mirrors the permit model of the Java client's
+ * {@code ProcessQueueImpl#acquirePermit()}/{@code releasePermit()}, where the
+ * permit count is bounded by {@code consumeConcurrentlyMax} and exhaustion
+ * applies backpressure by stopping further message fetches until permits are
+ * released (i.e. messages are acked / nacked).
+ */
+export class Semaphore {
+  #permits: number;
+  readonly #waiters: Array<() => void> = [];
+
+  constructor(permits: number) {
+    if (!Number.isInteger(permits) || permits < 0) {
+      throw new RangeError(`permits must be a non-negative integer, got ${permits}`);
+    }
+    this.#permits = permits;
+  }
+
+  /** Current number of available permits. */
+  get availablePermits(): number {
+    return this.#permits;
+  }
+
+  /**
+   * Non-blocking acquisition: takes one permit if available and returns true,
+   * otherwise leaves the semaphore unchanged and returns false.
+   */
+  tryAcquire(): boolean {
+    if (this.#permits > 0) {
+      this.#permits--;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Acquire a single permit. Resolves immediately when one is available;
+   * otherwise queues the caller until a permit is released.
+   */
+  acquire(): Promise<void> {
+    if (this.#permits > 0) {
+      this.#permits--;
+      return Promise.resolve();
+    }
+    return new Promise<void>(resolve => {
+      this.#waiters.push(resolve);
+    });
+  }
+
+  /**
+   * Release a single permit. Hands it to a pending acquirer if any, otherwise
+   * increments the available count.
+   */
+  release(): void {
+    const waiter = this.#waiters.shift();
+    if (waiter) {
+      waiter();
+    } else {
+      this.#permits++;
+    }
+  }
+}

--- a/nodejs/test/consumer/ProcessQueue.test.ts
+++ b/nodejs/test/consumer/ProcessQueue.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert';
+import { ProcessQueue } from '../../src/consumer/ProcessQueue';
+import { FilterExpression } from '../../src/consumer/FilterExpression';
+import { Code } from '../../proto/apache/rocketmq/v2/definition_pb';
+
+function makeConsumer(consumeConcurrentlyMax: number): any {
+  return {
+    getPushConsumerSettings: () => ({ getConsumeConcurrentlyMax: () => consumeConcurrentlyMax }),
+    getRetryPolicy: () => ({ getNextAttemptDelay: () => 0 }),
+    requestTimeoutValue: 3000,
+    changeInvisibleDurationViaRpc: () => Promise.resolve({
+      getStatus: () => ({ toObject: () => ({ code: Code.OK }) }),
+    }),
+    wrapChangeInvisibleDurationRequest: () => ({}),
+    getConsumerGroup: () => 'cg',
+    clientId: 'client',
+    logger: { info: () => {}, debug: () => {}, warn: () => {}, error: () => {} },
+    getConsumeService: () => ({ consume: () => {} }),
+    cacheMessageCountThresholdPerQueue: () => 1024,
+    cacheMessageBytesThresholdPerQueue: () => 1024 * 1024,
+  };
+}
+
+function makeMessage(id: string): any {
+  return {
+    messageId: id,
+    body: '',
+    endpoints: {},
+    deliveryAttempt: 1,
+    topic: { name: 't' },
+    liteTopic: '',
+  };
+}
+
+const mq: any = { topic: { name: 't' }, broker: { name: 'b' }, queueId: 0 };
+
+describe('ProcessQueue consumption permit (backpressure)', () => {
+  it('caps cached messages by consumeConcurrentlyMax and reports availablePermits', () => {
+    const pq = new ProcessQueue(makeConsumer(2), mq, new FilterExpression('*'));
+    pq.cacheMessages([makeMessage('a'), makeMessage('b'), makeMessage('c')]);
+    // Only two permits exist, so only two messages are cached.
+    assert.strictEqual(pq.cachedMessagesCount(), 2);
+    assert.strictEqual(pq.availablePermits(), 0);
+  });
+
+  it('releases a permit when a message is settled (discarded/nacked)', async () => {
+    const pq = new ProcessQueue(makeConsumer(2), mq, new FilterExpression('*'));
+    const a = makeMessage('a');
+    pq.cacheMessages([a, makeMessage('b')]);
+    assert.strictEqual(pq.availablePermits(), 0);
+    // discardMessage -> nack -> (async) evict -> release permit
+    pq.discardMessage(a);
+    await new Promise(r => setTimeout(r, 30));
+    assert.strictEqual(pq.availablePermits(), 1);
+  });
+
+  it('releases nothing for an unknown message (no double release)', async () => {
+    const pq = new ProcessQueue(makeConsumer(2), mq, new FilterExpression('*'));
+    const a = makeMessage('a');
+    pq.cacheMessages([a]);
+    assert.strictEqual(pq.availablePermits(), 1);
+    pq.discardMessage(makeMessage('z')); // not in cache
+    await new Promise(r => setTimeout(r, 30));
+    // Only the originally cached message holds a permit; the unknown one is a no-op.
+    assert.strictEqual(pq.availablePermits(), 1);
+    pq.discardMessage(a);
+    await new Promise(r => setTimeout(r, 30));
+    assert.strictEqual(pq.availablePermits(), 2);
+  });
+});

--- a/nodejs/test/consumer/SimpleConsumer.test.ts
+++ b/nodejs/test/consumer/SimpleConsumer.test.ts
@@ -99,7 +99,7 @@ describe('test/consumer/SimpleConsumer.test.ts', () => {
         endpoints,
         namespace,
         sessionCredentials,
-        consumerGroup: `nodejs-unittest-group-${randomUUID()}`,
+        consumerGroup: 'nodejs-unittest-group',
         subscriptions: new Map().set(topic, new FilterExpression(tag)),
       });
       await simpleConsumer.startup();

--- a/nodejs/test/defect-fixes.test.ts
+++ b/nodejs/test/defect-fixes.test.ts
@@ -31,7 +31,9 @@ import {
   ExponentialBackoffRetryPolicy,
   CustomizedBackoffRetryPolicy,
 } from '../src/retry';
-import { Endpoints } from '../src/route';
+import { Endpoints, TopicRouteData } from '../src/route';
+import { PublishingLoadBalancer } from '../src/producer';
+import { calculateStringSipHash24 } from '../src/util';
 import {
   StatusChecker,
   BadRequestException,
@@ -40,6 +42,14 @@ import {
 } from '../src/exception';
 import { Code, RetryPolicy as RetryPolicyPB, ExponentialBackoff, CustomizedBackoff } from '../proto/apache/rocketmq/v2/definition_pb';
 import { Status } from '../proto/apache/rocketmq/v2/definition_pb';
+import {
+  MessageQueue as MessageQueuePB,
+  Broker as BrokerPB,
+  Resource as ResourcePB,
+  Endpoints as EndpointsPB,
+  Permission,
+  AddressScheme,
+} from '../proto/apache/rocketmq/v2/definition_pb';
 
 function statusOf(code: Code): Status.AsObject {
   return { code, message: 'mock message', requestId: '' } as unknown as Status.AsObject;
@@ -152,5 +162,80 @@ describe('StatusChecker mappings vs Java', () => {
     assert.throws(
       () => StatusChecker.check(statusOf(Code.LITE_SUBSCRIPTION_QUOTA_EXCEEDED)),
       LiteSubscriptionQuotaExceededException);
+  });
+});
+
+describe('Endpoints.getGrpcTarget with resolver scheme (B-1)', () => {
+  it('should prefix ipv4: scheme for IPv4 addresses', () => {
+    assert.strictEqual(new Endpoints('127.0.0.1:10911').getGrpcTarget(), 'ipv4:127.0.0.1:10911');
+  });
+
+  it('should prefix ipv4: scheme for multiple IPv4 addresses', () => {
+    const target = new Endpoints('127.0.0.1:8081;127.0.0.2:8082').getGrpcTarget();
+    assert.strictEqual(target, 'ipv4:127.0.0.1:8081,127.0.0.2:8082');
+  });
+
+  it('should prefix ipv6: scheme with brackets for IPv6 addresses', () => {
+    assert.strictEqual(new Endpoints('[::1]:10911').getGrpcTarget(), 'ipv6:[::1]:10911');
+  });
+
+  it('should prefix dns: scheme for domain names', () => {
+    assert.strictEqual(new Endpoints('example.com:8080').getGrpcTarget(), 'dns:example.com:8080');
+  });
+});
+
+describe('takeMessageQueueByMessageGroup floorMod semantics (C-1)', () => {
+  // One queue (queueId=0, the writable master queue) per broker across queueCount brokers,
+  // since PublishingLoadBalancer only keeps queues with queueId === MASTER_BROKER_ID (0).
+  // The returned queue is identified by its broker endpoints port (10911 + expected index).
+  function buildLoadBalancer(queueCount: number): PublishingLoadBalancer {
+    const pbs = [];
+    for (let i = 0; i < queueCount; i++) {
+      const endpointsPb = new EndpointsPB();
+      endpointsPb.setScheme(AddressScheme.IPV4);
+      endpointsPb.addAddresses().setHost('127.0.0.1').setPort(10911 + i);
+      const brokerPb = new BrokerPB();
+      brokerPb.setName('broker-' + i);
+      brokerPb.setId(0);
+      brokerPb.setEndpoints(endpointsPb);
+      const mqPb = new MessageQueuePB();
+      mqPb.setId(0);
+      mqPb.setTopic(new ResourcePB().setName('topic'));
+      mqPb.setBroker(brokerPb);
+      mqPb.setPermission(Permission.READ_WRITE);
+      pbs.push(mqPb);
+    }
+    return new PublishingLoadBalancer(new TopicRouteData(pbs));
+  }
+
+  it('should always yield a non-negative index matching Java LongMath.mod', () => {
+    const loadBalancer = buildLoadBalancer(8);
+    const groups = ['group-a', 'fifo-group', 'group-中文', 'x', 'order-12345', ''];
+    for (const group of groups) {
+      const mq = loadBalancer.takeMessageQueueByMessageGroup(group);
+      assert.ok(mq, 'should resolve a message queue for group=' + group);
+      // Expected index under floorMod semantics: ((signed hash % size) + size) % size
+      const signedHash = BigInt.asIntN(64, calculateStringSipHash24(group));
+      const expectedIndex = Number(((signedHash % 8n) + 8n) % 8n);
+      assert.strictEqual(mq.broker.endpoints.facade, '127.0.0.1:' + (10911 + expectedIndex));
+    }
+  });
+
+  it('should match Java floorMod for hashes that are negative when interpreted signed', () => {
+    // Find a message group whose SipHash-2-4 has its high bit set (negative as int64)
+    let negativeGroup: string | undefined;
+    for (let i = 0; i < 10000; i++) {
+      const candidate = 'probe-' + i;
+      if (BigInt.asIntN(64, calculateStringSipHash24(candidate)) < 0n) {
+        negativeGroup = candidate;
+        break;
+      }
+    }
+    assert.ok(negativeGroup, 'expected to find a negative hash among probes');
+    const loadBalancer = buildLoadBalancer(4);
+    const mq = loadBalancer.takeMessageQueueByMessageGroup(negativeGroup!);
+    const signedHash = BigInt.asIntN(64, calculateStringSipHash24(negativeGroup!));
+    const expectedIndex = Number(((signedHash % 4n) + 4n) % 4n);
+    assert.strictEqual(mq.broker.endpoints.facade, '127.0.0.1:' + (10911 + expectedIndex));
   });
 });

--- a/nodejs/test/defect-fixes.test.ts
+++ b/nodejs/test/defect-fixes.test.ts
@@ -32,7 +32,10 @@ import {
   CustomizedBackoffRetryPolicy,
 } from '../src/retry';
 import { Endpoints, TopicRouteData } from '../src/route';
-import { PublishingLoadBalancer } from '../src/producer';
+import { Producer, PublishingLoadBalancer } from '../src/producer';
+import { Consumer } from '../src/consumer';
+import { Message } from '../src/message';
+import { Settings } from '../src/client';
 import { calculateStringSipHash24 } from '../src/util';
 import {
   Attribute,
@@ -50,8 +53,13 @@ import {
   PayloadEmptyException,
   LiteSubscriptionQuotaExceededException,
 } from '../src/exception';
-import { Code, RetryPolicy as RetryPolicyPB, ExponentialBackoff, CustomizedBackoff } from '../proto/apache/rocketmq/v2/definition_pb';
+import { Code, RetryPolicy as RetryPolicyPB, ExponentialBackoff, CustomizedBackoff, TransactionResolution,
+} from '../proto/apache/rocketmq/v2/definition_pb';
 import { Status } from '../proto/apache/rocketmq/v2/definition_pb';
+import {
+  HeartbeatRequest,
+  NotifyClientTerminationRequest,
+} from '../proto/apache/rocketmq/v2/service_pb';
 import {
   MessageQueue as MessageQueuePB,
   Broker as BrokerPB,
@@ -199,7 +207,7 @@ describe('takeMessageQueueByMessageGroup floorMod semantics (C-1)', () => {
   // since PublishingLoadBalancer only keeps queues with queueId === MASTER_BROKER_ID (0).
   // The returned queue is identified by its broker endpoints port (10911 + expected index).
   function buildLoadBalancer(queueCount: number): PublishingLoadBalancer {
-    const pbs = [];
+    const pbs: MessageQueuePB[] = [];
     for (let i = 0; i < queueCount; i++) {
       const endpointsPb = new EndpointsPB();
       endpointsPb.setScheme(AddressScheme.IPV4);
@@ -279,6 +287,141 @@ describe('Telemetry command dispatch vs Java (J-1)', () => {
     assert.strictEqual(received.length, 1);
     assert.strictEqual(received[0].liteTopic, 'lite-topic-1');
     assert.strictEqual(received[0].facade, '127.0.0.1:8081');
+  });
+});
+
+describe('Transaction hook points vs Java (K-2)', () => {
+  function createProducer(events: string[]) {
+    const producer = new Producer({
+      endpoints: '127.0.0.1:8081',
+      namespace: '',
+      topics: [ 'TopicTestForTransaction' ],
+      messageInterceptor: {
+        doBefore: context => {
+          events.push(`before:${MessageHookPoints[context.getMessageHookPoints()]}`);
+        },
+        doAfter: context => {
+          events.push(`after:${MessageHookPoints[context.getMessageHookPoints()]}:${MessageHookPointsStatus[context.getStatus()]}`);
+        },
+      },
+    } as any);
+    return producer;
+  }
+
+  function stubEndTransaction(producer: Producer, status: Status.AsObject) {
+    (producer as any).rpcClientManager = {
+      endTransaction: async () => ({
+        getStatus: () => ({
+          getCode: () => status.code,
+          toObject: () => status,
+        }),
+      }),
+    };
+  }
+
+  it('should trigger COMMIT_TRANSACTION on commit and ROLLBACK_TRANSACTION on rollback', async () => {
+    const commitEvents: string[] = [];
+    const producer = createProducer(commitEvents);
+    stubEndTransaction(producer, statusOf(Code.OK));
+    await producer.endTransaction(new Endpoints('127.0.0.1:8081'),
+      new Message({ topic: 'TopicTestForTransaction', body: Buffer.from('body') }),
+      'message-id', 'transaction-id', TransactionResolution.COMMIT);
+    assert.deepStrictEqual(commitEvents, [
+      'before:COMMIT_TRANSACTION', 'after:COMMIT_TRANSACTION:OK',
+    ]);
+
+    const rollbackEvents: string[] = [];
+    const rollbackProducer = createProducer(rollbackEvents);
+    stubEndTransaction(rollbackProducer, statusOf(Code.OK));
+    await rollbackProducer.endTransaction(new Endpoints('127.0.0.1:8081'),
+      new Message({ topic: 'TopicTestForTransaction', body: Buffer.from('body') }),
+      'message-id', 'transaction-id', TransactionResolution.ROLLBACK);
+    assert.deepStrictEqual(rollbackEvents, [
+      'before:ROLLBACK_TRANSACTION', 'after:ROLLBACK_TRANSACTION:OK',
+    ]);
+  });
+
+  it('should mark the transaction hook as ERROR when the RPC fails', async () => {
+    const events: string[] = [];
+    const producer = createProducer(events);
+    (producer as any).rpcClientManager = {
+      endTransaction: async () => {
+        throw new Error('end transaction failed');
+      },
+    };
+    await assert.rejects(async () => {
+      await producer.endTransaction(new Endpoints('127.0.0.1:8081'),
+        new Message({ topic: 'TopicTestForTransaction', body: Buffer.from('body') }),
+        'message-id', 'transaction-id', TransactionResolution.COMMIT);
+    });
+    assert.deepStrictEqual(events, [
+      'before:COMMIT_TRANSACTION', 'after:COMMIT_TRANSACTION:ERROR',
+    ]);
+  });
+});
+
+describe('FORWARD_TO_DLQ hook point vs Java (K-3)', () => {
+  class HookTestConsumer extends Consumer {
+    protected getSettings(): Settings {
+      return {} as Settings;
+    }
+    protected wrapHeartbeatRequest(): HeartbeatRequest {
+      return new HeartbeatRequest();
+    }
+    protected wrapNotifyClientTerminationRequest(): NotifyClientTerminationRequest {
+      return new NotifyClientTerminationRequest();
+    }
+  }
+
+  function createConsumer(events: string[]) {
+    return new HookTestConsumer({
+      endpoints: '127.0.0.1:8081',
+      namespace: '',
+      consumerGroup: 'TestGroup',
+      messageInterceptor: {
+        doBefore: context => {
+          events.push(`before:${MessageHookPoints[context.getMessageHookPoints()]}`);
+        },
+        doAfter: context => {
+          events.push(`after:${MessageHookPoints[context.getMessageHookPoints()]}:${MessageHookPointsStatus[context.getStatus()]}`);
+        },
+      },
+    } as any);
+  }
+
+  it('should trigger FORWARD_TO_DLQ with the status carried out of the response', async () => {
+    const okEvents: string[] = [];
+    const okConsumer = createConsumer(okEvents);
+    (okConsumer as any).rpcClientManager = {
+      forwardMessageToDeadLetterQueue: async () => ({ getStatus: () => ({ getCode: () => Code.OK }) }),
+    };
+    await okConsumer.forwardMessageToDeadLetterQueueViaRpc(new Endpoints('127.0.0.1:8081'), {}, 3000,
+      { topic: 'TopicTest' } as any);
+    assert.deepStrictEqual(okEvents, [ 'before:FORWARD_TO_DLQ', 'after:FORWARD_TO_DLQ:OK' ]);
+
+    const errEvents: string[] = [];
+    const errConsumer = createConsumer(errEvents);
+    (errConsumer as any).rpcClientManager = {
+      forwardMessageToDeadLetterQueue: async () => ({ getStatus: () => ({ getCode: () => Code.INTERNAL_ERROR }) }),
+    };
+    await errConsumer.forwardMessageToDeadLetterQueueViaRpc(new Endpoints('127.0.0.1:8081'), {}, 3000,
+      { topic: 'TopicTest' } as any);
+    assert.deepStrictEqual(errEvents, [ 'before:FORWARD_TO_DLQ', 'after:FORWARD_TO_DLQ:ERROR' ]);
+  });
+
+  it('should mark FORWARD_TO_DLQ as ERROR when the RPC throws', async () => {
+    const events: string[] = [];
+    const consumer = createConsumer(events);
+    (consumer as any).rpcClientManager = {
+      forwardMessageToDeadLetterQueue: async () => {
+        throw new Error('forward failed');
+      },
+    };
+    await assert.rejects(async () => {
+      await consumer.forwardMessageToDeadLetterQueueViaRpc(new Endpoints('127.0.0.1:8081'), {}, 3000,
+        { topic: 'TopicTest' } as any);
+    });
+    assert.deepStrictEqual(events, [ 'before:FORWARD_TO_DLQ', 'after:FORWARD_TO_DLQ:ERROR' ]);
   });
 });
 

--- a/nodejs/test/defect-fixes.test.ts
+++ b/nodejs/test/defect-fixes.test.ts
@@ -35,6 +35,16 @@ import { Endpoints, TopicRouteData } from '../src/route';
 import { PublishingLoadBalancer } from '../src/producer';
 import { calculateStringSipHash24 } from '../src/util';
 import {
+  Attribute,
+  AttributeKey,
+  CompositedMessageInterceptor,
+  InflightRequestCountInterceptor,
+  MessageHookPoints,
+  MessageHookPointsStatus,
+  MessageInterceptor,
+  MessageInterceptorContextImpl,
+} from '../src/hook';
+import {
   StatusChecker,
   BadRequestException,
   PayloadEmptyException,
@@ -237,5 +247,93 @@ describe('takeMessageQueueByMessageGroup floorMod semantics (C-1)', () => {
     const signedHash = BigInt.asIntN(64, calculateStringSipHash24(negativeGroup!));
     const expectedIndex = Number(((signedHash % 4n) + 4n) % 4n);
     assert.strictEqual(mq.broker.endpoints.facade, '127.0.0.1:' + (10911 + expectedIndex));
+  });
+});
+
+describe('Telemetry command dispatch vs Java (J-1)', () => {
+  it('should dispatch NOTIFY_UNSUBSCRIBE_LITE_COMMAND to the client', () => {
+    const { EventEmitter } = require('node:events');
+    const { TelemetryCommand, NotifyUnsubscribeLiteCommand } = require('../proto/apache/rocketmq/v2/service_pb');
+    const { TelemetrySession } = require('../src/client/TelemetrySession');
+
+    const received: Array<{ liteTopic: string; facade: string }> = [];
+    const stream = new EventEmitter();
+    stream.write = () => true;
+    stream.end = () => undefined;
+    stream.removeAllListeners = () => stream;
+
+    const fakeClient = {
+      clientId: 'fake-client-id',
+      createTelemetryStream: () => stream,
+      onNotifyUnsubscribeLiteCommand(endpoints: any, command: any) {
+        received.push({ liteTopic: command.getLiteTopic(), facade: endpoints.facade });
+      },
+    };
+    new TelemetrySession(fakeClient, new Endpoints('127.0.0.1:8081'),
+      { info() {}, warn() {}, error() {}, debug() {} });
+
+    const telemetryCommand = new TelemetryCommand();
+    telemetryCommand.setNotifyUnsubscribeLiteCommand(new NotifyUnsubscribeLiteCommand().setLiteTopic('lite-topic-1'));
+    stream.emit('data', telemetryCommand);
+
+    assert.strictEqual(received.length, 1);
+    assert.strictEqual(received[0].liteTopic, 'lite-topic-1');
+    assert.strictEqual(received[0].facade, '127.0.0.1:8081');
+  });
+});
+
+describe('Message interceptor chain (J-3)', () => {
+  it('should run doBefore in order and doAfter in reverse order', () => {
+    const calls: string[] = [];
+    const mk = (name: string): MessageInterceptor => ({
+      doBefore: () => { calls.push('before-' + name); },
+      doAfter: () => { calls.push('after-' + name); },
+    });
+    const composited = new CompositedMessageInterceptor([ mk('a'), mk('b'), mk('c') ]);
+    const context = new MessageInterceptorContextImpl(MessageHookPoints.SEND);
+    composited.doBefore(context, []);
+    composited.doAfter(MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.OK), []);
+    assert.deepStrictEqual(calls, [
+      'before-a', 'before-b', 'before-c', 'after-c', 'after-b', 'after-a',
+    ]);
+  });
+
+  it('should not break the pipeline when an interceptor throws', () => {
+    const calls: string[] = [];
+    const composited = new CompositedMessageInterceptor([
+      { doBefore: () => { calls.push('before-throwing'); }, doAfter: () => { calls.push('after-throwing'); } },
+      { doBefore: () => { throw new Error('boom'); }, doAfter: () => { throw new Error('boom'); } },
+      { doBefore: () => { calls.push('before-ok'); }, doAfter: () => { calls.push('after-ok'); } },
+    ]);
+    const context = new MessageInterceptorContextImpl(MessageHookPoints.CONSUME);
+    composited.doBefore(context, []);
+    composited.doAfter(MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.ERROR), []);
+    assert.deepStrictEqual(calls, [ 'before-throwing', 'before-ok', 'after-ok', 'after-throwing' ]);
+  });
+
+  it('should carry attributes between doBefore and doAfter', () => {
+    const key = AttributeKey.create<string>('k');
+    let seen: string | undefined;
+    const composited = new CompositedMessageInterceptor([
+      {
+        doBefore: context => { context.putAttribute(key, Attribute.create('v')); },
+        doAfter: context => { seen = context.getAttribute(key)?.get(); },
+      },
+    ]);
+    const context = new MessageInterceptorContextImpl(MessageHookPoints.RECEIVE);
+    composited.doBefore(context, []);
+    composited.doAfter(MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.OK), []);
+    assert.strictEqual(seen, 'v');
+  });
+
+  it('should count inflight receive requests via InflightRequestCountInterceptor', () => {
+    const interceptor = new InflightRequestCountInterceptor();
+    const composited = new CompositedMessageInterceptor([ interceptor ]);
+    const context = new MessageInterceptorContextImpl(MessageHookPoints.RECEIVE);
+    composited.doBefore(context, []);
+    composited.doBefore(context, []);
+    assert.strictEqual(interceptor.getInflightReceiveRequestCount(), 2);
+    composited.doAfter(MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.OK), []);
+    assert.strictEqual(interceptor.getInflightReceiveRequestCount(), 1);
   });
 });

--- a/nodejs/test/defect-fixes.test.ts
+++ b/nodejs/test/defect-fixes.test.ts
@@ -183,18 +183,18 @@ describe('StatusChecker mappings vs Java', () => {
   });
 });
 
-describe('Endpoints.getGrpcTarget with resolver scheme (B-1)', () => {
-  it('should prefix ipv4: scheme for IPv4 addresses', () => {
-    assert.strictEqual(new Endpoints('127.0.0.1:10911').getGrpcTarget(), 'ipv4:127.0.0.1:10911');
+describe('Endpoints.getGrpcTarget with resolver scheme (custom ip resolver)', () => {
+  it('should prefix ip: scheme for IPv4 addresses', () => {
+    assert.strictEqual(new Endpoints('127.0.0.1:10911').getGrpcTarget(), 'ip:127.0.0.1:10911');
   });
 
-  it('should prefix ipv4: scheme for multiple IPv4 addresses', () => {
+  it('should prefix ip: scheme for multiple IPv4 addresses', () => {
     const target = new Endpoints('127.0.0.1:8081;127.0.0.2:8082').getGrpcTarget();
-    assert.strictEqual(target, 'ipv4:127.0.0.1:8081,127.0.0.2:8082');
+    assert.strictEqual(target, 'ip:127.0.0.1:8081,127.0.0.2:8082');
   });
 
-  it('should prefix ipv6: scheme with brackets for IPv6 addresses', () => {
-    assert.strictEqual(new Endpoints('[::1]:10911').getGrpcTarget(), 'ipv6:[::1]:10911');
+  it('should prefix ip: scheme with brackets for IPv6 addresses', () => {
+    assert.strictEqual(new Endpoints('[::1]:10911').getGrpcTarget(), 'ip:[::1]:10911');
   });
 
   it('should prefix dns: scheme for domain names', () => {

--- a/nodejs/test/fixes-vs-java.test.ts
+++ b/nodejs/test/fixes-vs-java.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression tests for defect fixes aligned with the Java client:
+ *  - Retry backoff unit contract (milliseconds, sub-second precision kept)
+ *  - CustomizedBackoffRetryPolicy implementation
+ *  - Endpoints string parsing (IPv6 / http(s) prefix)
+ *  - StatusChecker mappings (ILLEGAL_LITE_TOPIC / MESSAGE_BODY_EMPTY /
+ *    LITE_SUBSCRIPTION_QUOTA_EXCEEDED)
+ */
+
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert';
+import { Duration } from 'google-protobuf/google/protobuf/duration_pb';
+import {
+  ExponentialBackoffRetryPolicy,
+  CustomizedBackoffRetryPolicy,
+} from '../src/retry';
+import { Endpoints } from '../src/route';
+import {
+  StatusChecker,
+  BadRequestException,
+  PayloadEmptyException,
+  LiteSubscriptionQuotaExceededException,
+} from '../src/exception';
+import { Code, RetryPolicy as RetryPolicyPB, ExponentialBackoff, CustomizedBackoff } from '../proto/apache/rocketmq/v2/definition_pb';
+import { Status } from '../proto/apache/rocketmq/v2/definition_pb';
+
+function statusOf(code: Code): Status.AsObject {
+  return { code, message: 'mock message', requestId: '' } as unknown as Status.AsObject;
+}
+
+describe('ExponentialBackoffRetryPolicy (ms contract)', () => {
+  it('should return delays in milliseconds', () => {
+    const policy = new ExponentialBackoffRetryPolicy(3, 1000, 10000, 2);
+    assert.strictEqual(policy.getNextAttemptDelay(1), 1000);
+    assert.strictEqual(policy.getNextAttemptDelay(2), 2000);
+    assert.strictEqual(policy.getNextAttemptDelay(3), 4000);
+    assert.strictEqual(policy.getNextAttemptDelay(4), 8000);
+    // capped by maxBackoff
+    assert.strictEqual(policy.getNextAttemptDelay(5), 10000);
+  });
+
+  it('should keep sub-second precision when inheriting backoff', () => {
+    const retryPolicy = new RetryPolicyPB().setExponentialBackoff(
+      new ExponentialBackoff()
+        .setInitial(new Duration().setSeconds(0).setNanos(500000000)) // 0.5s
+        .setMax(new Duration().setSeconds(3).setNanos(250000000)) // 3.25s
+        .setMultiplier(2));
+    const policy = new ExponentialBackoffRetryPolicy(3).inheritBackoff(retryPolicy) as ExponentialBackoffRetryPolicy;
+    assert.strictEqual(policy.getNextAttemptDelay(1), 500);
+    assert.strictEqual(policy.getNextAttemptDelay(2), 1000);
+    assert.strictEqual(policy.getNextAttemptDelay(3), 2000);
+    // capped by max backoff (3.25s, sub-second precision kept)
+    assert.strictEqual(policy.getNextAttemptDelay(4), 3250);
+  });
+
+  it('should serialize back to protobuf without losing precision', () => {
+    const policy = new ExponentialBackoffRetryPolicy(3, 500, 3250, 2);
+    const pb = policy.toProtobuf();
+    const exponential = pb.getExponentialBackoff()!;
+    assert.strictEqual(exponential.getInitial()!.getSeconds(), 0);
+    assert.strictEqual(exponential.getInitial()!.getNanos(), 500000000);
+    assert.strictEqual(exponential.getMax()!.getSeconds(), 3);
+    assert.strictEqual(exponential.getMax()!.getNanos(), 250000000);
+  });
+});
+
+describe('CustomizedBackoffRetryPolicy', () => {
+  it('should return the Nth duration and clamp to the last one', () => {
+    const policy = new CustomizedBackoffRetryPolicy([1000, 5000, 10000], 5);
+    assert.strictEqual(policy.getNextAttemptDelay(1), 1000);
+    assert.strictEqual(policy.getNextAttemptDelay(2), 5000);
+    assert.strictEqual(policy.getNextAttemptDelay(3), 10000);
+    assert.strictEqual(policy.getNextAttemptDelay(4), 10000);
+    assert.strictEqual(policy.getMaxAttempts(), 5);
+  });
+
+  it('should inherit customized backoff from protobuf', () => {
+    const customizedBackoff = new CustomizedBackoff();
+    customizedBackoff.addNext(new Duration().setSeconds(1));
+    customizedBackoff.addNext(new Duration().setNanos(500000000));
+    const retryPolicy = new RetryPolicyPB()
+      .setMaxAttempts(4)
+      .setCustomizedBackoff(customizedBackoff);
+    const policy = new CustomizedBackoffRetryPolicy([100], 3).inheritBackoff(retryPolicy);
+    assert.strictEqual(policy.getMaxAttempts(), 3);
+    assert.strictEqual(policy.getNextAttemptDelay(1), 1000);
+    assert.strictEqual(policy.getNextAttemptDelay(2), 500);
+  });
+});
+
+describe('Endpoints parsing', () => {
+  it('should parse IPv4 endpoints with port', () => {
+    const endpoints = new Endpoints('127.0.0.1:10911');
+    assert.deepStrictEqual(endpoints.addressesList, [{ host: '127.0.0.1', port: 10911 }]);
+    assert.strictEqual(endpoints.scheme, 1); // IPV4
+  });
+
+  it('should parse domain endpoints', () => {
+    const endpoints = new Endpoints('example.com:443');
+    assert.deepStrictEqual(endpoints.addressesList, [{ host: 'example.com', port: 443 }]);
+    assert.strictEqual(endpoints.scheme, 3); // DOMAIN_NAME
+  });
+
+  it('should parse bracketed IPv6 endpoints with port', () => {
+    const endpoints = new Endpoints('[::1]:10911');
+    assert.deepStrictEqual(endpoints.addressesList, [{ host: '::1', port: 10911 }]);
+    assert.strictEqual(endpoints.scheme, 2); // IPV6
+  });
+
+  it('should parse bare IPv6 endpoints without port', () => {
+    const endpoints = new Endpoints('1050:0000:0000:0000:0005:0600:300c:326b');
+    assert.strictEqual(endpoints.addressesList[0].host, '1050:0000:0000:0000:0005:0600:300c:326b');
+    assert.strictEqual(endpoints.addressesList[0].port, 80);
+    assert.strictEqual(endpoints.scheme, 2); // IPV6
+  });
+
+  it('should strip http(s) prefixes and parse multiple endpoints', () => {
+    const endpoints = new Endpoints('http://127.0.0.1:10911;https://example.com:8080');
+    assert.strictEqual(endpoints.addressesList.length, 2);
+    assert.deepStrictEqual(endpoints.addressesList[0], { host: '127.0.0.1', port: 10911 });
+    assert.deepStrictEqual(endpoints.addressesList[1], { host: 'example.com', port: 8080 });
+  });
+});
+
+describe('StatusChecker mappings vs Java', () => {
+  it('should map ILLEGAL_LITE_TOPIC to BadRequestException', () => {
+    assert.throws(() => StatusChecker.check(statusOf(Code.ILLEGAL_LITE_TOPIC)), BadRequestException);
+  });
+
+  it('should map MESSAGE_BODY_EMPTY to PayloadEmptyException', () => {
+    assert.throws(() => StatusChecker.check(statusOf(Code.MESSAGE_BODY_EMPTY)), PayloadEmptyException);
+  });
+
+  it('should map LITE_SUBSCRIPTION_QUOTA_EXCEEDED to LiteSubscriptionQuotaExceededException', () => {
+    assert.throws(
+      () => StatusChecker.check(statusOf(Code.LITE_SUBSCRIPTION_QUOTA_EXCEEDED)),
+      LiteSubscriptionQuotaExceededException);
+  });
+});

--- a/nodejs/test/metrics.test.ts
+++ b/nodejs/test/metrics.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression tests for the metrics export pipeline, aligned with the Java
+ * client's org.apache.rocketmq.client.java.metrics package:
+ *  - Metric switch parsing (on flag + endpoints)
+ *  - Histogram bucket definitions / OTel view construction
+ *  - ClientMeter / ClientMeterManager enable-disable lifecycle
+ *  - MessageMeterInterceptor recording at the SEND/RECEIVE/CONSUME hook points
+ *  - PushConsumerGaugeObserver aggregation of cached message count/bytes
+ */
+
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert';
+import { Metadata } from '@grpc/grpc-js';
+import { Attributes } from '@opentelemetry/api';
+import { InstrumentType } from '@opentelemetry/sdk-metrics';
+import {
+  Endpoints as EndpointsPB,
+  AddressScheme,
+  Metric as MetricPB,
+} from '../proto/apache/rocketmq/v2/definition_pb';
+import { Producer } from '../src/producer';
+import { ProcessQueue } from '../src/consumer/ProcessQueue';
+import { PushConsumerGaugeObserver } from '../src/consumer/PushConsumerGaugeObserver';
+import { Metric } from '../src/metrics/Metric';
+import { ClientMeter } from '../src/metrics/ClientMeter';
+import { ClientMeterManager } from '../src/metrics/ClientMeterManager';
+import { EmptyGaugeObserver } from '../src/metrics/EmptyGaugeObserver';
+import { GaugeEnum } from '../src/metrics/GaugeEnum';
+import {
+  HistogramEnum,
+  HISTOGRAM_BUCKETS,
+  buildHistogramView,
+} from '../src/metrics/HistogramEnum';
+import { InvocationStatus } from '../src/metrics/InvocationStatus';
+import { MetricLabels } from '../src/metrics/MetricLabels';
+import {
+  MessageHookPoints,
+  MessageHookPointsStatus,
+  MessageInterceptorContextImpl,
+  MessageMeterInterceptor,
+} from '../src/hook';
+
+const silentLogger = {
+  info() { /* noop */ },
+  warn() { /* noop */ },
+  error() { /* noop */ },
+  debug() { /* noop */ },
+};
+
+function buildMetricPb(on: boolean, host = '127.0.0.1', port = 10811): MetricPB {
+  const endpointsPb = new EndpointsPB();
+  endpointsPb.setScheme(AddressScheme.IPV4);
+  endpointsPb.addAddresses().setHost(host).setPort(port);
+  return new MetricPB().setOn(on).setEndpoints(endpointsPb);
+}
+
+/**
+ * Captures every histogram record instead of exporting it, so the interceptor
+ * can be exercised without standing up the OTLP pipeline.
+ */
+class RecordingMeterManager {
+  readonly records: Array<{ histogramEnum: HistogramEnum; attributes: Attributes; value: number }> = [];
+  enabled = true;
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  record(histogramEnum: HistogramEnum, attributes: Attributes, value: number): void {
+    this.records.push({ histogramEnum, attributes, value });
+  }
+
+  setGaugeObserver(): void {
+    // not exercised by the interceptor
+  }
+
+  async shutdown(): Promise<void> {
+    // noop
+  }
+}
+
+function asManager(recorder: RecordingMeterManager): ClientMeterManager {
+  return recorder as unknown as ClientMeterManager;
+}
+
+describe('Metric switch parsing (vs Java metrics.Metric)', () => {
+  it('should be enabled when on=true and endpoints are present', () => {
+    const metric = new Metric(buildMetricPb(true, '127.0.0.1', 10811));
+    assert.strictEqual(metric.on, true);
+    assert.ok(metric.endpoints, 'expected endpoints to be parsed');
+    assert.deepStrictEqual(metric.endpoints!.addressesList, [{ host: '127.0.0.1', port: 10811 }]);
+  });
+
+  it('should be disabled when the on flag is false', () => {
+    const metric = new Metric(buildMetricPb(false));
+    assert.strictEqual(metric.on, false);
+    assert.strictEqual(metric.endpoints, null);
+  });
+
+  it('should be disabled when the metric is absent', () => {
+    const metric = new Metric(undefined);
+    assert.strictEqual(metric.on, false);
+    assert.strictEqual(metric.endpoints, null);
+  });
+});
+
+describe('Histogram buckets and views', () => {
+  it('should define explicit buckets for all four histograms', () => {
+    const histograms = Object.values(HistogramEnum);
+    assert.strictEqual(histograms.length, 4);
+    for (const histogram of histograms) {
+      assert.ok(HISTOGRAM_BUCKETS[histogram].length > 0,
+        `expected buckets for ${histogram}`);
+    }
+  });
+
+  it('should build a view targeting the histogram instrument', () => {
+    const view = buildHistogramView(HistogramEnum.SEND_COST_TIME);
+    assert.strictEqual(view.instrumentName, HistogramEnum.SEND_COST_TIME);
+    assert.strictEqual(view.instrumentType, InstrumentType.HISTOGRAM);
+    assert.ok(view.aggregation, 'expected an explicit bucket aggregation');
+  });
+});
+
+describe('ClientMeter lifecycle', () => {
+  it('should be a no-op when disabled', () => {
+    const meter = ClientMeter.disabledInstance();
+    assert.strictEqual(meter.enabled, false);
+    // must not throw even though no underlying meter exists
+    meter.record(HistogramEnum.SEND_COST_TIME, {}, 1);
+  });
+
+  it('should only be satisfied by a matching switch', () => {
+    const meter = ClientMeter.disabledInstance();
+    assert.strictEqual(meter.satisfy(new Metric(undefined)), true);
+    assert.strictEqual(meter.satisfy(new Metric(buildMetricPb(true))), false);
+  });
+});
+
+describe('ClientMeterManager reset', () => {
+  it('should keep metrics disabled while the switch is off', async () => {
+    const manager = new ClientMeterManager('client-1', () => new Metadata(), silentLogger);
+    assert.strictEqual(manager.isEnabled(), false);
+    await manager.reset(new Metric(buildMetricPb(false)));
+    assert.strictEqual(manager.isEnabled(), false);
+    // idempotent: a second reset must not throw
+    await manager.reset(new Metric(undefined));
+    assert.strictEqual(manager.isEnabled(), false);
+    await manager.shutdown();
+  });
+
+  it('should build the OTLP pipeline when the switch is on', async () => {
+    const manager = new ClientMeterManager('client-2', () => new Metadata(), silentLogger);
+    try {
+      // 127.0.0.1:65535 is a closed port: the pipeline is built eagerly, while
+      // the periodic export (60s) never fires during the test.
+      await manager.reset(new Metric(buildMetricPb(true, '127.0.0.1', 65535)));
+      assert.strictEqual(manager.isEnabled(), true, 'expected the meter to be enabled');
+    } finally {
+      await manager.shutdown();
+    }
+  });
+});
+
+describe('MessageMeterInterceptor (SEND/RECEIVE/CONSUME)', () => {
+  it('should record send cost time on the SEND hook point', () => {
+    const recorder = new RecordingMeterManager();
+    const interceptor = new MessageMeterInterceptor(asManager(recorder), 'client-1', () => undefined);
+    const context = new MessageInterceptorContextImpl(MessageHookPoints.SEND);
+    const message = { topic: 'TopicSend' } as any;
+    interceptor.doBefore(context, [ message ]);
+    interceptor.doAfter(
+      MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.OK), [ message ]);
+
+    assert.strictEqual(recorder.records.length, 1);
+    const record = recorder.records[0];
+    assert.strictEqual(record.histogramEnum, HistogramEnum.SEND_COST_TIME);
+    assert.strictEqual(record.attributes[MetricLabels.TOPIC], 'TopicSend');
+    assert.strictEqual(record.attributes[MetricLabels.CLIENT_ID], 'client-1');
+    assert.strictEqual(record.attributes[MetricLabels.INVOCATION_STATUS], InvocationStatus.SUCCESS.name);
+    assert.ok(record.value >= 0, 'expected a non-negative cost');
+  });
+
+  it('should mark the send as failed when the hook status is ERROR', () => {
+    const recorder = new RecordingMeterManager();
+    const interceptor = new MessageMeterInterceptor(asManager(recorder), 'client-1', () => undefined);
+    const context = new MessageInterceptorContextImpl(MessageHookPoints.SEND);
+    const message = { topic: 'TopicSend' } as any;
+    interceptor.doBefore(context, [ message ]);
+    interceptor.doAfter(
+      MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.ERROR), [ message ]);
+
+    assert.strictEqual(recorder.records.length, 1);
+    assert.strictEqual(recorder.records[0].attributes[MetricLabels.INVOCATION_STATUS],
+      InvocationStatus.FAILURE.name);
+  });
+
+  it('should record delivery latency on the RECEIVE hook point', () => {
+    const recorder = new RecordingMeterManager();
+    const interceptor = new MessageMeterInterceptor(asManager(recorder), 'client-1', () => 'group-1');
+    const context = new MessageInterceptorContextImpl(MessageHookPoints.RECEIVE);
+    const message = { topic: 'TopicRecv', transportDeliveryTimestamp: new Date(Date.now() - 120) } as any;
+    interceptor.doBefore(context, [ message ]);
+    interceptor.doAfter(
+      MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.OK), [ message ]);
+
+    assert.strictEqual(recorder.records.length, 1);
+    const record = recorder.records[0];
+    assert.strictEqual(record.histogramEnum, HistogramEnum.DELIVERY_LATENCY);
+    assert.strictEqual(record.attributes[MetricLabels.TOPIC], 'TopicRecv');
+    assert.strictEqual(record.attributes[MetricLabels.CONSUMER_GROUP], 'group-1');
+    // 120ms elapsed between the delivery timestamp and now
+    assert.ok(record.value >= 100 && record.value < 5000, `unexpected latency ${record.value}`);
+  });
+
+  it('should skip delivery latency when the timestamp is in the future', () => {
+    const recorder = new RecordingMeterManager();
+    const interceptor = new MessageMeterInterceptor(asManager(recorder), 'client-1', () => 'group-1');
+    const context = new MessageInterceptorContextImpl(MessageHookPoints.RECEIVE);
+    const message = { topic: 'TopicRecv', transportDeliveryTimestamp: new Date(Date.now() + 60_000) } as any;
+    interceptor.doBefore(context, [ message ]);
+    interceptor.doAfter(
+      MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.OK), [ message ]);
+
+    assert.strictEqual(recorder.records.length, 0, 'negative latency must not be recorded');
+  });
+
+  it('should record await time and process time on the CONSUME hook point', () => {
+    const recorder = new RecordingMeterManager();
+    const interceptor = new MessageMeterInterceptor(asManager(recorder), 'client-1', () => 'group-1');
+    const context = new MessageInterceptorContextImpl(MessageHookPoints.CONSUME);
+    const message = { topic: 'TopicConsume', decodeTimestamp: new Date(Date.now() - 200) } as any;
+    interceptor.doBefore(context, [ message ]);
+    interceptor.doAfter(
+      MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.OK), [ message ]);
+
+    assert.strictEqual(recorder.records.length, 2);
+    assert.strictEqual(recorder.records[0].histogramEnum, HistogramEnum.AWAIT_TIME);
+    assert.ok(recorder.records[0].value >= 200, `unexpected await time ${recorder.records[0].value}`);
+    assert.strictEqual(recorder.records[1].histogramEnum, HistogramEnum.PROCESS_TIME);
+    assert.strictEqual(recorder.records[1].attributes[MetricLabels.CONSUMER_GROUP], 'group-1');
+    assert.strictEqual(recorder.records[1].attributes[MetricLabels.INVOCATION_STATUS],
+      InvocationStatus.SUCCESS.name);
+  });
+
+  it('should record nothing when metrics are disabled', () => {
+    const recorder = new RecordingMeterManager();
+    recorder.enabled = false;
+    const interceptor = new MessageMeterInterceptor(asManager(recorder), 'client-1', () => 'group-1');
+    const context = new MessageInterceptorContextImpl(MessageHookPoints.SEND);
+    const message = { topic: 'TopicSend' } as any;
+    interceptor.doBefore(context, [ message ]);
+    interceptor.doAfter(
+      MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.OK), [ message ]);
+    assert.strictEqual(recorder.records.length, 0);
+  });
+
+  it('should record nothing on CONSUME when the client has no consumer group', () => {
+    const recorder = new RecordingMeterManager();
+    const interceptor = new MessageMeterInterceptor(asManager(recorder), 'client-1', () => undefined);
+    const context = new MessageInterceptorContextImpl(MessageHookPoints.CONSUME);
+    const message = { topic: 'TopicConsume', decodeTimestamp: new Date(Date.now() - 50) } as any;
+    interceptor.doBefore(context, [ message ]);
+    interceptor.doAfter(
+      MessageInterceptorContextImpl.withStatus(context, MessageHookPointsStatus.OK), [ message ]);
+    assert.strictEqual(recorder.records.length, 0);
+  });
+});
+
+describe('Consumer gauge observers', () => {
+  function fakeProcessQueue(topic: string, count: number, bytes: number): ProcessQueue {
+    return {
+      topic,
+      cachedMessagesCount: () => count,
+      cachedMessageBytes: () => bytes,
+    } as unknown as ProcessQueue;
+  }
+
+  function toEntries(values: Map<Attributes, number>) {
+    return Array.from(values.entries())
+      .map(([ attributes, value ]) => ({
+        topic: attributes[MetricLabels.TOPIC],
+        group: attributes[MetricLabels.CONSUMER_GROUP],
+        clientId: attributes[MetricLabels.CLIENT_ID],
+        value,
+      }))
+      .sort((a, b) => String(a.topic).localeCompare(String(b.topic)));
+  }
+
+  it('should aggregate cached messages and bytes per topic', () => {
+    const observer = new PushConsumerGaugeObserver(
+      () => [
+        fakeProcessQueue('TopicA', 3, 300),
+        fakeProcessQueue('TopicA', 2, 200),
+        fakeProcessQueue('TopicB', 5, 500),
+      ],
+      'client-1', 'group-1');
+
+    assert.deepStrictEqual(observer.getGauges(),
+      [ GaugeEnum.CONSUMER_CACHED_MESSAGES, GaugeEnum.CONSUMER_CACHED_BYTES ]);
+
+    assert.deepStrictEqual(toEntries(observer.getValues(GaugeEnum.CONSUMER_CACHED_MESSAGES)), [
+      { topic: 'TopicA', group: 'group-1', clientId: 'client-1', value: 5 },
+      { topic: 'TopicB', group: 'group-1', clientId: 'client-1', value: 5 },
+    ]);
+    assert.deepStrictEqual(toEntries(observer.getValues(GaugeEnum.CONSUMER_CACHED_BYTES)), [
+      { topic: 'TopicA', group: 'group-1', clientId: 'client-1', value: 500 },
+      { topic: 'TopicB', group: 'group-1', clientId: 'client-1', value: 500 },
+    ]);
+  });
+
+  it('should return an empty map when no process queue is assigned', () => {
+    const observer = new PushConsumerGaugeObserver(() => [], 'client-1', 'group-1');
+    assert.strictEqual(observer.getValues(GaugeEnum.CONSUMER_CACHED_MESSAGES).size, 0);
+    assert.strictEqual(observer.getValues(GaugeEnum.CONSUMER_CACHED_BYTES).size, 0);
+  });
+
+  it('should expose no gauges through the empty observer', () => {
+    assert.deepStrictEqual(EmptyGaugeObserver.EMPTY.getGauges(), []);
+    assert.strictEqual(EmptyGaugeObserver.EMPTY.getValues().size, 0);
+  });
+});
+
+describe('BaseClient metrics wiring', () => {
+  it('should create the meter manager during construction', () => {
+    const producer = new Producer({
+      endpoints: '127.0.0.1:8081',
+      namespace: '',
+      topics: [ 'TopicTest' ],
+    });
+    const manager = (producer as any).clientMeterManager;
+    assert.ok(manager instanceof ClientMeterManager, 'expected a ClientMeterManager to be created');
+    assert.strictEqual(manager.isEnabled(), false, 'metrics start disabled until the settings command');
+  });
+});

--- a/nodejs/test/route/IpNameResolver.test.ts
+++ b/nodejs/test/route/IpNameResolver.test.ts
@@ -73,7 +73,7 @@ describe('IpNameResolver (custom ip scheme, mirrors Java IpNameResolverFactory)'
     assert.strictEqual(eps[0].addresses[0].port, 80);
   });
 
-  it('reports an error for an unparseable address', async () => {
+  it('reports an error for an unparsable address', async () => {
     await assert.rejects(() => resolve('localhost:notaport'));
   });
 

--- a/nodejs/test/route/IpNameResolver.test.ts
+++ b/nodejs/test/route/IpNameResolver.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert';
+import { Endpoints } from '../../src/route';
+import { IpResolver } from '../../src/route/IpNameResolver';
+
+type Endpoint = { addresses: { host: string; port: number }[] };
+
+function makeTarget(path: string) {
+  return { scheme: 'ip', authority: '', path } as any;
+}
+
+/**
+ * Drive the resolver with a capturing listener and return the resolved endpoints.
+ * The listener is invoked on nextTick, so we await it.
+ */
+function resolve(path: string): Promise<Endpoint[]> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const listener = (endpointList: any, _attrs: any, _cfg: any, _note: string) => {
+      if (endpointList.ok) {
+        resolvePromise(endpointList.value as Endpoint[]);
+      } else {
+        rejectPromise(new Error(endpointList.error.details));
+      }
+    };
+    const resolver = new IpResolver(makeTarget(path), listener as any, {} as any);
+    resolver.updateResolution();
+  });
+}
+
+function toKeySet(eps: Endpoint[]): Set<string> {
+  return new Set(eps.map(e => `${e.addresses[0].host}:${e.addresses[0].port}`));
+}
+
+describe('IpNameResolver (custom ip scheme, mirrors Java IpNameResolverFactory)', () => {
+  it('parses comma-separated host:port and resolves every address', async () => {
+    const eps = await resolve('127.0.0.1:10911,127.0.0.2:10912');
+    assert.strictEqual(eps.length, 2);
+    const keys = toKeySet(eps);
+    assert.ok(keys.has('127.0.0.1:10911'));
+    assert.ok(keys.has('127.0.0.2:10912'));
+    for (const ep of eps) {
+      assert.strictEqual(ep.addresses.length, 1, 'each address becomes its own EquivalentAddressGroup');
+    }
+  });
+
+  it('handles bracketed IPv6 addresses', async () => {
+    const eps = await resolve('[::1]:10911,[fe80::1]:10912');
+    const keys = toKeySet(eps);
+    assert.ok(keys.has('::1:10911'));
+    assert.ok(keys.has('fe80::1:10912'));
+  });
+
+  it('applies default port 80 when omitted', async () => {
+    const eps = await resolve('127.0.0.1');
+    assert.strictEqual(eps.length, 1);
+    assert.strictEqual(eps[0].addresses[0].port, 80);
+  });
+
+  it('reports an error for an unparseable address', async () => {
+    await assert.rejects(() => resolve('localhost:notaport'));
+  });
+
+  it('shuffles the address order (Fisher-Yates)', async () => {
+    const original = Math.random;
+    // Force a deterministic Fisher-Yates permutation. With random=0:
+    //   input [a,b,c] -> i=2: swap(2,0)=[c,b,a] -> i=1: swap(1,0)=[b,c,a]
+    Math.random = () => 0;
+    try {
+      const eps = await resolve('10.0.0.1:80,10.0.0.2:80,10.0.0.3:80');
+      const order = eps.map(e => e.addresses[0].host);
+      assert.deepStrictEqual(order, ['10.0.0.2', '10.0.0.3', '10.0.0.1']);
+    } finally {
+      Math.random = original;
+    }
+  });
+
+  it('returns a permutation (all original addresses, no duplicates) across runs', async () => {
+    const input = '10.0.0.1:80,10.0.0.2:80,10.0.0.3:80,10.0.0.4:80';
+    const expected = new Set(['10.0.0.1:80', '10.0.0.2:80', '10.0.0.3:80', '10.0.0.4:80']);
+    for (let i = 0; i < 20; i++) {
+      const eps = await resolve(input);
+      assert.strictEqual(eps.length, 4);
+      const keys = toKeySet(eps);
+      assert.deepStrictEqual(keys, expected);
+    }
+  });
+});
+
+describe('Endpoints.getGrpcTarget uses the custom ip scheme', () => {
+  it('emits ip: scheme for IPv4/IPv6 endpoints', () => {
+    assert.ok(new Endpoints('127.0.0.1:10911;127.0.0.2:10912').getGrpcTarget().startsWith('ip:'));
+    assert.ok(new Endpoints('[::1]:10911;[fe80::1]:10912').getGrpcTarget().startsWith('ip:'));
+  });
+
+  it('keeps dns: scheme for domain names', () => {
+    assert.ok(new Endpoints('example.com:8080;example.org:8081').getGrpcTarget().startsWith('dns:'));
+  });
+});

--- a/nodejs/test/util/Semaphore.test.ts
+++ b/nodejs/test/util/Semaphore.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert';
+import { Semaphore } from '../../src/util/Semaphore';
+
+describe('Semaphore (consumption permit primitive)', () => {
+  it('starts with the configured number of permits', () => {
+    const s = new Semaphore(3);
+    assert.strictEqual(s.availablePermits, 3);
+  });
+
+  it('tryAcquire consumes a permit and returns false when exhausted', () => {
+    const s = new Semaphore(1);
+    assert.strictEqual(s.tryAcquire(), true);
+    assert.strictEqual(s.availablePermits, 0);
+    assert.strictEqual(s.tryAcquire(), false);
+    assert.strictEqual(s.availablePermits, 0);
+  });
+
+  it('rejects non-negative integer construction', () => {
+    assert.throws(() => new Semaphore(-1), RangeError);
+    assert.throws(() => new Semaphore(1.5), RangeError);
+  });
+
+  it('acquire resolves immediately when a permit is available', async () => {
+    const s = new Semaphore(1);
+    await s.acquire();
+    assert.strictEqual(s.availablePermits, 0);
+  });
+
+  it('acquire blocks until a permit is released, then resumes', async () => {
+    const s = new Semaphore(0);
+    let resumed = false;
+    const p = s.acquire().then(() => { resumed = true; });
+    // Permit not yet available.
+    await new Promise(r => setTimeout(r, 10));
+    assert.strictEqual(resumed, false);
+    s.release();
+    await p;
+    assert.strictEqual(resumed, true);
+  });
+
+  it('serves multiple waiters in FIFO order on successive releases', async () => {
+    const s = new Semaphore(0);
+    const order: number[] = [];
+    const a = s.acquire().then(() => order.push(1));
+    const b = s.acquire().then(() => order.push(2));
+    const c = s.acquire().then(() => order.push(3));
+    s.release();
+    s.release();
+    s.release();
+    await Promise.all([a, b, c]);
+    assert.deepStrictEqual(order, [1, 2, 3]);
+    assert.strictEqual(s.availablePermits, 0);
+  });
+
+  it('release hands the permit to a waiter without incrementing the pool', () => {
+    const s = new Semaphore(0);
+    const p = s.acquire();
+    s.release(); // should go straight to the waiter, not the pool
+    assert.strictEqual(s.availablePermits, 0);
+    return p;
+  });
+});

--- a/nodejs/tsconfig.test.json
+++ b/nodejs/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist",
+    "noEmit": false
+  },
+  "include": [ "src", "test" ],
+  "exclude": [ "node_modules", "dist" ]
+}


### PR DESCRIPTION
# fix(nodejs): defect fixes and feature enhancements for the Node.js client

## Summary

This PR fixes a set of defects and adds missing capabilities to the Node.js client of RocketMQ 5.x
(gRPC protocol). It lands **8 commits** touching **61 files (+3,578 / −103)**.

**New capabilities**

- Message interceptor (hook) framework with all 8 hook points.
- Metrics export pipeline over OpenTelemetry / OTLP gRPC.
- Custom `ip:` gRPC name resolver for endpoints targets.
- Consumer-side rate limiting (semaphore backpressure).
- `NOTIFY_UNSUBSCRIBE_LITE_COMMAND` handling.
- `CustomizedBackoffRetryPolicy`.

**Fixed defects**

- Retry backoff units, sub-second precision, `Endpoints` parsing, `StatusChecker` mappings.
- Telemetry-session timer leak, fail-fast on startup route fetch.
- gRPC target/resolver scheme, RPC client keying and channel options, heartbeat-driven rejoin and
  transport self-healing, verify-message reply, process diagnostics, FIFO routing, shutdown drain,
  `SimpleConsumer` state guards, lite subscription multi-endpoint sync.
- Logger-close shutdown race.
- Non-deterministic consumer group in the integration test.

---

## New capabilities

### 1. Message interceptor / hook framework

New `src/hook/` package providing a full interceptor chain:

- `MessageHookPoints` with all eight points: `SEND`, `RECEIVE`, `CONSUME`, `ACK`,
  `CHANGE_INVISIBLE_DURATION`, `COMMIT_TRANSACTION`, `ROLLBACK_TRANSACTION`, `FORWARD_TO_DLQ`.
- `MessageHookPointsStatus`, `Attribute` / `AttributeKey`, `MessageInterceptor` +
  `MessageInterceptorContext(Impl)`.
- `CompositedMessageInterceptor` — runs `doBefore` in registration order and `doAfter` in reverse,
  isolating each interceptor so one failure cannot break the chain.
- `InflightRequestCountInterceptor` — built-in interceptor tracking in-flight receive requests
  (registered automatically by push consumers).

**Wiring:** `SEND` in `Producer#send`; `RECEIVE` / `ACK` / `CHANGE_INVISIBLE_DURATION` in `Consumer`;
`CONSUME` in `ConsumeTask` (the context carries the message view, consumer group and consume error);
`COMMIT_TRANSACTION` / `ROLLBACK_TRANSACTION` around the `EndTransaction` RPC in
`Producer#endTransaction`; `FORWARD_TO_DLQ` around every DLQ RPC attempt.

**Configuration:** `BaseClientOptions#messageInterceptor` accepts a single interceptor or an array;
`addMessageInterceptor` is only accepted before the client is running.

### 2. Metrics export pipeline (OpenTelemetry / OTLP gRPC)

New `src/metrics/`: `Metric`, `ClientMeter`, `ClientMeterManager`, `HistogramEnum`, `GaugeEnum`,
`GaugeObserver`, `EmptyGaugeObserver`, `MetricLabels`, `InvocationStatus`.

- `ClientMeterManager#reset(metric)` rebuilds an OpenTelemetry `SdkMeterProvider` on every settings
  command and exports:
  - histograms `rocketmq_send_cost_time`, `rocketmq_delivery_latency`, `rocketmq_await_time`,
    `rocketmq_process_time` (with explicit bucket boundaries);
  - consumer gauges for cached messages and cached bytes.
- Every export is signed per request through the client's `MQv2-HMAC-SHA1` metadata provider.
- `MessageMeterInterceptor` records the histograms at the `SEND` / `RECEIVE` / `CONSUME` hook points.
- `PushConsumerGaugeObserver` aggregates cached messages/bytes per topic.
- `BaseClient` creates the manager, resets it from `onSettingsCommand`, and shuts it down on client
  shutdown.

### 3. Custom `ip:` gRPC name resolver

`src/route/IpNameResolver.ts` registers an `ip` scheme resolver so that multi-address proxy endpoints
are resolved as a static address group instead of relying on the default DNS resolution.

### 4. Consumer-side rate limiting

`src/util/Semaphore.ts`, applied to `ProcessQueue`, bounds in-flight consumption by
`consumeConcurrentlyMax` and provides backpressure: the receive loop is paused until the pending
messages are settled and permits are released.

### 5. `NOTIFY_UNSUBSCRIBE_LITE_COMMAND`

`TelemetrySession` now dispatches `NOTIFY_UNSUBSCRIBE_LITE_COMMAND` (proto oneof field 9) to
`BaseClient#onNotifyUnsubscribeLiteCommand` instead of falling through to the unknown-command branch.
`LitePushConsumerImpl` overrides it and forwards to `LiteSubscriptionManager`.

### 6. `CustomizedBackoffRetryPolicy`

New discrete-backoff retry policy wired into `PushSubscriptionSettings`; out-of-range steps clamp to
the last duration.

---

## Bug fixes

### Retry, parsing & status

- Retry delays are **milliseconds** (the protobuf contract's unit was misimplemented); inherited
  backoff preserves sub-second precision from the server `Duration` (`seconds * 1000 + nanos / 1e6`).
- `Endpoints` string parsing rewritten: strips an `http(s)://` prefix, parses bracketed **and** bare
  IPv6, and splits the port via `lastIndexOf(':')`.
- `StatusChecker` new mappings: `ILLEGAL_LITE_TOPIC` → `BadRequestException`,
  `MESSAGE_BODY_EMPTY` → `PayloadEmptyException`,
  `LITE_SUBSCRIPTION_QUOTA_EXCEEDED` → `LiteSubscriptionQuotaExceededException`.
- Startup route fetch fails fast on `NotFoundException`.

### Telemetry session

- No longer leaks reconnect timers: `release()` clears the timer and guards reconnection; error/end
  events dedupe through a single reconnect schedule.
- Removed the commented-out reply in `onRecoverOrphanedTransactionCommand` (dead code).

### Transport & heartbeat

| Area | Fix |
|------|-----|
| `Endpoints.getGrpcTarget()` | Prefix the gRPC target with the resolver scheme — `ipv4:` / `ipv6:` (bracketed IPv6 hosts) / `dns:` — so grpc-js resolves multi-address and bare-IPv6 targets correctly |
| `RpcClientManager` | Key rpc clients by the `endpoints.facade` **string** instead of object identity (endpoints are recreated on every route fetch, leaking duplicate channels); add `evict()` |
| `RpcClient` | Add channel options: keepalive 5 min / 30 s + `keepalive_permit_without_calls`, max send/receive message length `2^31-1` |
| `BaseClient` heartbeat | Rejoin isolated endpoints after a successful heartbeat |
| `BaseClient` heartbeat | After ≥2 consecutive heartbeat failures, rebuild the transport layer: evict the stale `RpcClient` + rebuild the telemetry session, throttled by a 30 s per-endpoints cooldown |
| Verify-message command | Reply with `VerifyMessageResult` carrying the nonce instead of echoing the command |
| Stack-trace command | Return real process diagnostics (pid, node version, uptime, `memoryUsage`, active handles) instead of `'mock stack'` |
| `LiteSubscriptionManager` | Sync lite subscriptions to **all** route endpoints (not only the client's configured endpoints); adds a public `LitePushConsumerImpl#getTotalRouteEndpoints()` |

### Routing & consumption

- `PublishingLoadBalancer` interprets SipHash-2-4 as **signed** int64 and applies `floorMod`, so FIFO
  message-group routing is consistent (the previous unsigned modulo routed "negative" hashes to
  different queues).
- `PushConsumer` shutdown bounds the cached-message drain wait by
  `requestTimeout + longPollingTimeout`, so shutdown cannot hang forever on a stuck consumption chain.
- `SimpleConsumer` guards `receive()` / `ack()` / `changeInvisibleDuration()` with `isRunning()` checks.

### Shutdown logging race

`Producer#shutdown` / `PushConsumer#shutdown` logged one line **after** `super.shutdown()`, but
`BaseClient#shutdown` closed the logger at the end, so every shutdown threw
`log stream had been closed`. `logger.close()` is now deferred to the next macrotask
(`setImmediate`). Reproduced on the parent commit (Producer integration 5/6 → 6/6 after the fix).

---

## Test plan

Verified locally against a live **RocketMQ 5.5.1** cluster (NameServer `:9876`, Broker `:10911`,
embedded proxy gRPC `:8081`, clean store).

- **Type-check:** `tsc --noEmit` against both `tsconfig.prod.json` and `tsconfig.test.json` — **0 errors**.
- **Lint:** `eslint` on the changed files — **0 errors** (only pre-existing JSDoc warnings).
- **Full suite:** **157/157 pass, 0 fail, 0 skipped** (61 suites), run serially
  (`node --test --test-concurrency=1 --test-force-exit --test-reporter=spec`).

| Group | Files | Cases | Result |
|-------|-------|------:|--------|
| Offline (no broker) — `defect-fixes`, `metrics`, `IpNameResolver`, `Semaphore`, `ProcessQueue` | 5 | 66 | ✅ |
| Integration (live proxy) — `index`, `Producer`, `SimpleConsumer`, `ProducerRecall` | 4 | 12 | ✅ |
| Remaining unit — `consumer/*`, `message/*`, `exception/*`, `util/index` | 12 | 79 | ✅ |
| **Total** | **21** | **157** | **pass 157 / fail 0 / skipped 0** |

New coverage added by this PR:

- gRPC-target scheme prefixes; signed-hash `floorMod` routing (negative-hash probe).
- Telemetry `NOTIFY_UNSUBSCRIBE_LITE_COMMAND` dispatch.
- Interceptor chain: ordering, error isolation, attribute propagation, inflight counting, and the
  `COMMIT_TRANSACTION` / `ROLLBACK_TRANSACTION` / `FORWARD_TO_DLQ` hook points.
- Metrics pipeline: switch parsing, histogram buckets/views, meter lifecycle, a real OTLP pipeline
  build, gauge aggregation, `BaseClient` wiring.
- `IpNameResolver`, `Semaphore`, and `ProcessQueue` backpressure.

Key end-to-end case: `SimpleConsumer#should receive success` publishes 1 + 102 messages, drains in
batches of 20, acks each message, and matches every `messageId`.

> Note: `node --test` must be run with `--test-force-exit`. `new Producer(...)` / `new Consumer(...)`
> keep 3 `setInterval`s + 2 sockets alive (the RpcClientManager / BaseClient timers are not shut down
> in the integration tests). This is pre-existing behaviour, not introduced here.

---

## Commits

- `d7a6a3a2` fix(nodejs): align retry units, endpoints parsing and status mapping
- `f5fbde3b` fix(nodejs): fail fast on NotFoundException during startup route fetch
- `0a84b7eb` fix(nodejs): align client behaviors (round 2)
- `7797490f` feat(nodejs): support NOTIFY_UNSUBSCRIBE_LITE_COMMAND and message interceptor hooks
- `444961e2` feat(nodejs): wire COMMIT_TRANSACTION / ROLLBACK_TRANSACTION / FORWARD_TO_DLQ hook points
- `4a99496b` feat(nodejs): add metrics export pipeline, custom IpNameResolver and consumption rate limiting
- `55d40b3f` fix(nodejs): defer logger close so subclass shutdown logs do not throw
- `49bcc2d3` test(nodejs): use a fixed consumer group in the simple consumer integration test
